### PR TITLE
chore: Add Color Selection on BlazorWasm Sample

### DIFF
--- a/samples/BlazorWasm/BlazorWasm.csproj
+++ b/samples/BlazorWasm/BlazorWasm.csproj
@@ -10,8 +10,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="1.4.0" />
-    <PackageReference Include="SkiaSharp.QrCode" Version="0.5.0" />
+    <!--<PackageReference Include="SkiaSharp.QrCode" Version="0.5.0" />-->
     <PackageReference Include="SkiaSharp.Views.Blazor" Version="2.88.0-preview.256" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SkiaSharp.QrCode\SkiaSharp.QrCode.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/BlazorWasm/Pages/CustomInputSelect.cs
+++ b/samples/BlazorWasm/Pages/CustomInputSelect.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Components.Forms;
+using SkiaSharp;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace BlazorWasm.Pages
+{
+    public class CustomInputSelect<TValue> : InputSelect<TValue>
+    {
+        protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out TValue result, [NotNullWhen(false)] out string? validationErrorMessage)
+        {
+            if (!string.IsNullOrEmpty(value) && typeof(TValue) == typeof(SKColor))
+            {
+                if (SKColor.TryParse(value, out var color))
+                {
+                    result = (TValue)(object)color;
+                    validationErrorMessage = null;
+                    return true;
+                }
+                else
+                {
+                    result = default;
+                    validationErrorMessage = $"The selected value {value} is not a valid SKColor.";
+                    return false;
+                }
+            }
+            else
+            {
+                return base.TryParseValueFromString(value, out result, out validationErrorMessage);
+            }
+        }
+    }
+}

--- a/samples/BlazorWasm/Pages/QR.razor
+++ b/samples/BlazorWasm/Pages/QR.razor
@@ -34,6 +34,42 @@
 
         <p>
             <label>
+                ClearColor:
+                <CustomInputSelect @bind-Value="@Model.ClearColor">
+                    @foreach (var color in typeof(SKColors).GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static).Select(x => (x.Name, Value: x.GetValue(Model.ClearColor))).ToArray())
+                    {
+                        <option value="@color.Value">@color.Name</option>
+                    }
+                </CustomInputSelect>
+            </label>
+        </p>
+
+        <p>
+            <label>
+                CodeColor:
+                <CustomInputSelect @bind-Value="@Model.CodeColor">
+                    @foreach (var color in typeof(SKColors).GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static).Select(x => (x.Name, Value: x.GetValue(Model.CodeColor))).ToArray())
+                    {
+                        <option value="@color.Value">@color.Name</option>
+                    }
+                </CustomInputSelect>
+            </label>
+        </p>
+
+        <p>
+            <label>
+                BackgroundColor:
+                <CustomInputSelect @bind-Value="@Model.BackgroundColor">
+                    @foreach (var color in typeof(SKColors).GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static).Select(x => (x.Name, Value: x.GetValue(Model.BackgroundColor))).ToArray())
+                    {
+                        <option value="@color.Value">@color.Name</option>
+                    }
+                </CustomInputSelect>
+            </label>
+        </p>
+
+        <p>
+            <label>
                 Content:
                 <InputText @bind-Value="@Model.Content" />
             </label>
@@ -74,7 +110,7 @@
         // Render to canvas
         var info = new SKImageInfo(512, 512); // Make sure match with SKCanvasView width & height.
         using var surface = SKSurface.Create(info);
-        canvas.Render(qr, info.Width, info.Height);
+        canvas.Render(qr, info.Width, info.Height, Model.ClearColor, Model.CodeColor, Model.BackgroundColor);
     }
 
     public class QrGenerateModel
@@ -84,6 +120,9 @@
         [Range(0, 10)]
         public int QuietZoneSize { get; set; } = 4;
         public ECCLevel EccLevel { get; set; } = ECCLevel.L;
+        public SKColor ClearColor { get; set; } = SKColors.Transparent;
+        public SKColor CodeColor { get; set; } = SKColors.Black;
+        public SKColor BackgroundColor { get; set; } = SKColors.White;
     }
 }
 


### PR DESCRIPTION
## tl;dr;

Add ClearColor, CodeColor, BackgroundColor selection on BlazorWasm sample.

## Samples

Black Code, White Background

![image](https://user-images.githubusercontent.com/3856350/166525963-f7499702-6dab-4228-9029-1b8d36751305.png)

White Code, Black Background

![image](https://user-images.githubusercontent.com/3856350/166525995-b0270cf5-fba1-4d5e-b022-7e5cb6cabd8b.png)

DarkBlue Code, LightGray Background

![image](https://user-images.githubusercontent.com/3856350/166527087-b45f0df3-ade6-4ac6-9b7d-fc87400cf174.png)
