### PR TITLE
chore: remove LICENSE.md from nuget package and show MIT instead.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,6 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>skia, skiasharp, qrcode</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 </Project>

--- a/src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
+++ b/src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
@@ -13,11 +13,4 @@
     <PackageReference Include="SkiaSharp" Version="2.80.2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\LICENSE.md">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## tl;dr;

This project is MIT licensed and there are no strong reason to include LICENSE.md inside nuget package.

Let's remove LICENSE.md from nupkg and use `PackageLicenseExpression` MIT instead.