### PR TITLE
feat: Remove LINQ from hot path.

### DIFF
--- a/src/SkiaSharp.QrCode/QRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/QRCodeGenerator.cs
@@ -539,9 +539,12 @@ public class QRCodeGenerator : IDisposable
     /// </summary>
     private List<int> BinaryStringListToDecList(List<string> binaryStringList)
     {
-        return binaryStringList
-            .Select(binaryString => BinToDec(binaryString))
-            .ToList();
+        var result = new List<int>(binaryStringList.Count);
+        foreach (var item in binaryStringList)
+        {
+            result.Add(BinToDec(item));
+        }
+        return result;
     }
 
     /// <summary>

--- a/src/SkiaSharp.QrCode/QRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/QRCodeGenerator.cs
@@ -524,11 +524,13 @@ public class QRCodeGenerator : IDisposable
     /// </summary>
     private List<string> BinaryStringToBitBlockList(string bitString)
     {
-        return new List<char>(bitString.ToCharArray())
-            .Select((x, i) => new { Index = i, Value = x })
-            .GroupBy(x => x.Index / 8)
-            .Select(x => string.Join("", x.Select(v => v.Value.ToString()).ToArray()))
-            .ToList();
+        var byteCount = bitString.Length / 8;
+        var result = new List<string>(byteCount);
+        for (var i = 0; i < byteCount; i++)
+        {
+            result.Add(bitString.Substring(i * 8, 8));
+        }
+        return result;
     }
 
     /// <summary>

--- a/src/SkiaSharp.QrCode/QRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/QRCodeGenerator.cs
@@ -524,6 +524,15 @@ public class QRCodeGenerator : IDisposable
     /// </summary>
     private List<string> BinaryStringToBitBlockList(string bitString)
     {
+        if (bitString.Length % 8 != 0)
+        {
+            var remainder = bitString.Length % 8;
+            throw new ArgumentException($"Binary string length must be a multiple of 8. "
+                + $"Length: {bitString.Length}, Remainder: {remainder} bits. "
+                + $"Data may be corrupted or improperly padded.",
+                nameof(bitString));
+        }
+
         var byteCount = bitString.Length / 8;
         var result = new List<string>(byteCount);
         for (var i = 0; i < byteCount; i++)


### PR DESCRIPTION
## summary

Remove LINQ from hot path.

baseline

<img width="990" height="229" alt="image" src="https://github.com/user-attachments/assets/485ade23-98e7-4f10-9936-6c7c70a555d1" />

feat: remove Linq for BinaryStringToBitBlockList

<img width="986" height="217" alt="image" src="https://github.com/user-attachments/assets/0b9b45fe-bd86-4aeb-9884-891e0d9a4cee" />

feat: remove Linq for BinaryStringListToDecList

<img width="979" height="219" alt="image" src="https://github.com/user-attachments/assets/182ce64f-1fd3-47ac-b82d-ac65c378a1d7" />
