### PR TITLE
chore: replace GetRawData List<byte> to byte[] direct access

### DIFF
--- a/src/SkiaSharp.QrCode/QRCodeData.cs
+++ b/src/SkiaSharp.QrCode/QRCodeData.cs
@@ -108,7 +108,7 @@ public class QRCodeData : IDisposable
         var paddingBits = GetPaddingBits(totalBits);
         var totalBitsWithPadding = totalBits + paddingBits;
         var dataBytes = totalBitsWithPadding / 8;
-        var headerSize = 4; // 3 bytes signature + 1 byte size
+        var headerSize = _headerSignature.Length + 1; // signature length + 1 byte for size
         var totalSize = headerSize + dataBytes;
 
         var bytes = new byte[totalSize];


### PR DESCRIPTION
## Summary

replace GetRawData `List<T>` operation to `byte[]` direct access. As is not required to use List.

baseline

<img width="982" height="213" alt="Image" src="https://github.com/user-attachments/assets/2b6c4b9d-d796-4afc-849d-49ed82240c4c" />

pr

<img width="974" height="211" alt="Image" src="https://github.com/user-attachments/assets/a91671b3-e159-42c3-ad47-3dabb031ba05" />
