### PR TITLE
feat: little optmization for QRCodeData deep copy

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
@@ -109,15 +109,8 @@ internal static class ModulePlacer
         // Test all 8 patterns
         for (var patternIndex = 0; patternIndex < 8; patternIndex++)
         {
-            // Create temporary QR code matrix
-            var qrTemp = new QRCodeData(version);
-            for (var row = 0; row < size; row++)
-            {
-                for (var col = 0; col < size; col++)
-                {
-                    qrTemp[row, col] = qrCode[row, col];
-                }
-            }
+            // Create temporary QR code with deep copy
+            var qrTemp = new QRCodeData(qrCode);
 
             // Apply format and version information
             var formatStr = GetFormatString(eccLevel, patternIndex);
@@ -353,6 +346,7 @@ internal static class ModulePlacer
         if (text.Length == 0) return string.Empty;
 
         // We are .NET Standard 2.0 compatible, so we can't use this method.
+        // Leave this comment for future optimization if we move to .NET Standard 2.1+ or .NET 5+
         //return string.Create(text.Length, text, (span, source) =>
         //{
         //    for (int i = 0; i < source.Length; i++)

--- a/src/SkiaSharp.QrCode/QRCodeData.cs
+++ b/src/SkiaSharp.QrCode/QRCodeData.cs
@@ -41,6 +41,29 @@ public class QRCodeData : IDisposable
         internal set => _moduleMatrix[row, col] = value;
     }
 
+    /// <summary>
+    /// Creates a deep copy of an existing <see cref="QRCodeData"/> instance
+    /// All module states are copied to ensure independence from the source.
+    /// </summary>
+    /// <param name="source">Source QR code data to copy</param>
+    /// <remarks>
+    /// This constructor is useful for creating temporary QR codes during mask pattern selection.
+    /// The copied instance is completely independent and modifications do not affect the source.
+    /// </remarks>
+    public QRCodeData(QRCodeData source)
+    {
+        Version = source.Version;
+        var size = source.Size;
+        _moduleMatrix = new bool[size, size];
+
+        // Copy matrix data
+        Array.Copy(source._moduleMatrix, _moduleMatrix, source._moduleMatrix.Length);
+    }
+
+    /// <summary>
+    /// Initializes with the specified version.
+    /// </summary>
+    /// <param name="version"></param>
     public QRCodeData(int version)
     {
         Version = version;
@@ -48,6 +71,21 @@ public class QRCodeData : IDisposable
         _moduleMatrix = new bool[size, size];
     }
 
+    /// <summary>
+    /// Initializes using the specified raw data and compression
+    /// mode.
+    /// </summary>
+    /// <remarks>
+    /// This constructor processes the provided raw data to initialize the QR code's module matrix
+    /// and determine its version. The raw data is expected to follow the QR code format, including a valid header and
+    /// size information.
+    /// </remarks>
+    /// <param name="rawData">The raw byte array representing the QR code data. This data may be compressed based on the specified <paramref
+    /// name="compressMode"/>.</param>
+    /// <param name="compressMode">The compression mode used to encode the <paramref name="rawData"/>. Determines how the data will be
+    /// decompressed.</param>
+    /// <exception cref="InvalidDataException">Thrown if the decompressed data is invalid.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the decompressed data does not contain enough bits to fully populate the QR code matrix.</exception>
     public QRCodeData(byte[] rawData, Compression compressMode)
     {
         // Decompress

--- a/src/SkiaSharp.QrCode/QRCodeData.cs
+++ b/src/SkiaSharp.QrCode/QRCodeData.cs
@@ -63,7 +63,7 @@ public class QRCodeData : IDisposable
     /// <summary>
     /// Initializes with the specified version.
     /// </summary>
-    /// <param name="version"></param>
+    /// <param name="version">QR Code version number (1-40) used to determine matrix size</param>
     public QRCodeData(int version)
     {
         Version = version;
@@ -80,10 +80,8 @@ public class QRCodeData : IDisposable
     /// and determine its version. The raw data is expected to follow the QR code format, including a valid header and
     /// size information.
     /// </remarks>
-    /// <param name="rawData">The raw byte array representing the QR code data. This data may be compressed based on the specified <paramref
-    /// name="compressMode"/>.</param>
-    /// <param name="compressMode">The compression mode used to encode the <paramref name="rawData"/>. Determines how the data will be
-    /// decompressed.</param>
+    /// <param name="rawData">The raw byte array representing the QR code data. This data may be compressed based on the specified <paramref name="compressMode"/>.</param>
+    /// <param name="compressMode">The compression mode used to encode the <paramref name="rawData"/>. Determines how the data will be decompressed.</param>
     /// <exception cref="InvalidDataException">Thrown if the decompressed data is invalid.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the decompressed data does not contain enough bits to fully populate the QR code matrix.</exception>
     public QRCodeData(byte[] rawData, Compression compressMode)


### PR DESCRIPTION
## Summary

Introduce `QRCodeData(QRCodeData source)` constructor to offer deep copy source to destination.

baseline

<img width="985" height="228" alt="image" src="https://github.com/user-attachments/assets/af4df84a-7cc4-4936-acf7-0f4d26a379c1" />

pr

<img width="978" height="234" alt="Image" src="https://github.com/user-attachments/assets/da77ce6e-bacb-4a66-af84-c26399d47dc7" />

