### PR TITLE
chore: remove LINQ

### DIFF
--- a/src/SkiaSharp.QrCode/QRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/QRCodeGenerator.cs
@@ -367,7 +367,7 @@ public class QRCodeGenerator : IDisposable
         // QR codes are always padded to full capacity with 0xEC/0x11 bytes
         // So the final bit string length = data capacity in bits
         // ECCInfo contains the actual byte capacity (TotalDataCodewords)
-        var eccInfo = CapacityECCTable.Single(x => x.Version == version && x.ErrorCorrectionLevel == eccLevel);
+        var eccInfo = GetEccInfo(version, eccLevel);
         return eccInfo.TotalDataCodewords * 8; // Convert bytes to bits
     }
 
@@ -492,7 +492,7 @@ public class QRCodeGenerator : IDisposable
 
             // Get actual capacity for this version and ECC level
             // Use CapacityTable (which has VersionInfo structure)
-            var eccInfo = CapacityECCTable.Single(x => x.Version == version && x.ErrorCorrectionLevel == eccLevel);
+            var eccInfo = GetEccInfo(version, eccLevel);
             var capacityBits = eccInfo.TotalDataCodewords * 8; // convert bytes to bits
 
             if (capacityBits >= totalRequiredBits)


### PR DESCRIPTION
## Summary

Remove LINQ and use existing GetVersion.

baseline

<img width="974" height="224" alt="image" src="https://github.com/user-attachments/assets/ae26a2d0-e899-4baf-bca1-0136ca70fb63" />

pr

<img width="966" height="224" alt="Image" src="https://github.com/user-attachments/assets/dbd016a7-5d55-4149-ad00-d00c74765ac0" />
