### PR TITLE
refactor: Use span instead of static field header signature

### DIFF
--- a/src/SkiaSharp.QrCode/QRCodeData.cs
+++ b/src/SkiaSharp.QrCode/QRCodeData.cs
@@ -15,8 +15,6 @@ namespace SkiaSharp.QrCode;
 /// </remarks>
 public class QRCodeData : IDisposable
 {
-    private static readonly byte[] _headerSignature = [0x51, 0x52, 0x52]; // "QRR"
-
     /// <summary>
     /// Get the QR code version (1-40)
     /// </summary>
@@ -138,6 +136,9 @@ public class QRCodeData : IDisposable
     /// <param name="compressMode"></param>
     internal byte[] GetRawData(Compression compressMode)
     {
+        // "QRR"
+        ReadOnlySpan<byte> _headerSignature = [0x51, 0x52, 0x52];
+
         // size calculations
         var size = Size;
         var totalBits = size * size;


### PR DESCRIPTION
## Summary

- Remove header signature Static field and use Span instead

baseline

<img width="965" height="219" alt="image" src="https://github.com/user-attachments/assets/20aab5af-30fe-4c39-8b6c-87fa722d51af" />

pr

<img width="964" height="226" alt="image" src="https://github.com/user-attachments/assets/9ae732ad-9cf0-4f5d-a4b2-72830330f43b" />
