### PR TITLE
feat: change byte[,] to stackalloc

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
@@ -210,7 +210,7 @@ internal static class ModulePlacer
     {
         var size = qrCode.Size;
 
-        // Stack allocation for coordinate pairs (15 bits × 2 copies × 2 coords = 60 bytes)
+        // Stack allocation: 15 tuples × 4 ints × 4 bytes = 240 bytes
         Span<(int x1, int y1, int x2, int y2)> positions = stackalloc (int, int, int, int)[15]
         {
             ( 8, 0, size - 1, 8 ),


### PR DESCRIPTION
## Summary

Replace `new [,]` with `stackalloc (int, int, int, int)` to remove memory alloc.

baseline

<img width="1063" height="553" alt="image" src="https://github.com/user-attachments/assets/9e59e28e-abb2-4671-b2a9-ffe7f5e61ab6" />

pr

<img width="1058" height="558" alt="image" src="https://github.com/user-attachments/assets/fa2b5095-47bd-494b-b11e-84ed28046c0f" />
