### PR TITLE
feat: remove temp collection by collection expression.

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
@@ -274,7 +274,7 @@ internal static class ModulePlacer
     /// Reserves separator areas (white borders) around finder patterns.
     /// 1-module wide white border separates finder patterns from data area.
     /// </summary>
-    public static void ReserveSeperatorAreas(int size, ref List<Rectangle> blockedModules)
+    public static void ReserveSeparatorAreas(int size, ref List<Rectangle> blockedModules)
     {
         blockedModules.Add(new Rectangle(7, 0, 1, 8));
         blockedModules.Add(new Rectangle(0, 7, 7, 1));

--- a/src/SkiaSharp.QrCode/QRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/QRCodeGenerator.cs
@@ -313,7 +313,7 @@ public class QRCodeGenerator : IDisposable
         var alignmentPatternLocations = GetAlignmentPatternPositions(version);
 
         ModulePlacer.PlaceFinderPatterns(ref qrCodeData, ref blockedModules);
-        ModulePlacer.ReserveSeperatorAreas(qrCodeData.Size, ref blockedModules);
+        ModulePlacer.ReserveSeparatorAreas(qrCodeData.Size, ref blockedModules);
         ModulePlacer.PlaceAlignmentPatterns(ref qrCodeData, alignmentPatternLocations, ref blockedModules);
         ModulePlacer.PlaceTimingPatterns(ref qrCodeData, ref blockedModules);
         ModulePlacer.PlaceDarkModule(ref qrCodeData, version, ref blockedModules);


### PR DESCRIPTION
## tl;dr;

Previously using `[new Rect, new Rect, new Rect...]` to use `List.AddRange`. Change this to simple `List.Add` to remove temp collection.

baseline

<img width="1074" height="550" alt="image" src="https://github.com/user-attachments/assets/8a35f636-28db-482b-a41d-774477240442" />

pr

<img width="1069" height="553" alt="Image" src="https://github.com/user-attachments/assets/a1fd77ac-5cf4-465c-9f09-57c13230e6dc" />