### PR TITLE
feat: BitWriter remove divide (`/`) and mod (`%`) for bit operation

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BitWriter.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BitWriter.cs
@@ -22,7 +22,7 @@ internal ref struct BitWriter
     /// <remarks>
     /// If written 9 bits, this will be 2
     /// </remarks>
-    public int ByteCount => (_bitPosition + 7) / 8;
+    public int ByteCount => (_bitPosition + 7) >> 3; // Optimize `(_bitPosition + 7) / 8;`
 
     public BitWriter(Span<byte> buffer)
     {
@@ -55,8 +55,9 @@ internal ref struct BitWriter
         for (var i = bitCount - 1; i >= 0; i--)
         {
             var bit = value >> i & 1;
-            var byteIndex = _bitPosition / 8;
-            var bitIndex = 7 - _bitPosition % 8; // 7 - (...) because we read MSB first
+            var byteIndex = _bitPosition >> 3; // Optimize `_bitPosition / 8;`
+            // 7 - (...) because we read MSB first
+            var bitIndex = 7 - (_bitPosition & 7); // Optimize `7 - _bitPosition % 8;`
             if (bit == 1)
             {
                 _buffer[byteIndex] |= (byte)(1 << bitIndex);


### PR DESCRIPTION
## Summary

`/` and `%` takes 10-20 cycle. Change them to bit shift 1 cycle operation.

baseline

<img width="1084" height="558" alt="image" src="https://github.com/user-attachments/assets/5610c52c-1837-4504-bd15-f3be646b6e6a" />

pr

<img width="1079" height="551" alt="Image" src="https://github.com/user-attachments/assets/a239f8d7-26c5-4ed5-8672-c97d630e0cdf" />