### PR TITLE
feat: Write multiple bits at once

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BitWriter.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BitWriter.cs
@@ -9,12 +9,14 @@ namespace SkiaSharp.QrCode.Internals.BinaryEncoders;
 internal ref struct BitWriter
 {
     private Span<byte> _buffer;
-    private int _bitPosition;
+    private int _bytePosition;
+    private byte _accumulator;
+    private int _accumulatorBits;
 
     /// <summary>
     /// Current bit position in the buffer.
     /// </summary>
-    public int BitPosition => _bitPosition;
+    public int BitPosition => _bytePosition * 8 + _accumulatorBits;
 
     /// <summary>
     /// Number of bytes written (rounded up to nearest byte)
@@ -22,12 +24,14 @@ internal ref struct BitWriter
     /// <remarks>
     /// If written 9 bits, this will be 2
     /// </remarks>
-    public int ByteCount => (_bitPosition + 7) / 8;
+    public int ByteCount => _bytePosition + (_accumulatorBits > 0 ? 1 : 0);
 
     public BitWriter(Span<byte> buffer)
     {
         _buffer = buffer;
-        _bitPosition = 0;
+        _bytePosition = 0;
+        _accumulator = 0;
+        _accumulatorBits = 0;
         buffer.Clear(); // 0 initialization
     }
 
@@ -48,21 +52,71 @@ internal ref struct BitWriter
         // Result: _buffer[0] = 0b10100000
         // --------------------------------------------
 
-        if (_bitPosition + bitCount > _buffer.Length * 8)
-            throw new InvalidOperationException($"Buffer overflow: trying to write {bitCount} bits at position {_bitPosition}, buffer size: {_buffer.Length * 8} bits");
+        if (bitCount < 1 || bitCount > 32)
+            throw new ArgumentOutOfRangeException(nameof(bitCount), "bitCount must be between 1 and 32");
 
-        // Because QR requires writing MSB first, we need to start from the highest bit
-        for (var i = bitCount - 1; i >= 0; i--)
+        if (BitPosition + bitCount > _buffer.Length * 8)
+            throw new InvalidOperationException($"Buffer overflow: trying to write {bitCount} bits at position {BitPosition}, buffer size: {_buffer.Length * 8} bits");
+
+        // 16 bits over, split into two writes
+        if (bitCount > 16)
         {
-            var bit = value >> i & 1;
-            var byteIndex = _bitPosition / 8;
-            var bitIndex = 7 - _bitPosition % 8; // 7 - (...) because we read MSB first
-            if (bit == 1)
-            {
-                _buffer[byteIndex] |= (byte)(1 << bitIndex);
-            }
+            var highBits = bitCount - 16;
+            Write(value >> 16, highBits);
+            Write(value & 0xFFFF, 16);
+            return;
+        }
 
-            _bitPosition++;
+        // 8 bits over and accumulator is empty, split into two writes
+        if (bitCount > 8 && _accumulatorBits == 0)
+        {
+            var highBits = bitCount - 8;
+            WriteInternal(value >> 8, highBits);
+            WriteInternal(value & 0xFF, 8);
+        }
+        else
+        {
+            WriteInternal(value, bitCount);
+        }
+
+        // if there are remaining bits in the accumulator, flush them to the buffer
+        if (_accumulatorBits > 0)
+        {
+            _buffer[_bytePosition] = _accumulator;
+        }
+    }
+
+    /// <summary>
+    /// Internal write logic that assumes bitCount <= 16 and fits in the buffer
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="bitCount"></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void WriteInternal(int value, int bitCount)
+    {
+        var remainingBits = bitCount;
+        while (remainingBits > 0)
+        {
+            // decide how many bits to write in this iteration
+            var bitsToWrite = Math.Min(remainingBits, 8 - _accumulatorBits);
+
+            // extract the bits to write (from MSB)
+            var shift = remainingBits - bitsToWrite;
+            var mask = (1 << bitsToWrite) - 1;
+            var bits = (value >> shift) & mask;
+
+            // add to accumulator
+            _accumulator |= (byte)(bits << (8 - _accumulatorBits - bitsToWrite));
+            _accumulatorBits += bitsToWrite;
+            remainingBits -= bitsToWrite;
+
+            // if accumulator is full, write to buffer
+            if (_accumulatorBits == 8)
+            {
+                _buffer[_bytePosition++] = _accumulator;
+                _accumulator = 0;
+                _accumulatorBits = 0;
+            }
         }
     }
 
@@ -70,5 +124,5 @@ internal ref struct BitWriter
     /// Gets the written data as a read-only span
     /// </summary>
     /// <returns></returns>
-    public ReadOnlySpan<byte> GetData() => _buffer.Slice(0, ByteCount);
+    public ReadOnlySpan<byte> GetData() => _buffer[..ByteCount];
 }


### PR DESCRIPTION
## Summary

Change BitWriter from `write each iteration` to `keep in accumulator and writeat once`. This reduce memory access timing.

baseline

<img width="1118" height="722" alt="Image" src="https://github.com/user-attachments/assets/10e836e2-f250-4470-8e3a-8718b3bdf6b5" />

pr

<img width="1106" height="718" alt="image" src="https://github.com/user-attachments/assets/fd9d6058-c8e5-4ca9-95eb-3af76e3e5382" />

