### PR TITLE
feat: add net8.0, handle NET5 or greater

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/QRBinaryEncoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/QRBinaryEncoder.cs
@@ -123,7 +123,7 @@ internal ref struct QRBinaryEncoder
     private void EncodeNumeric(ReadOnlySpan<char> textSpan)
     {
         // Convert string to ASCII bytes (numeric chars are ASCII compatible)
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         Span<byte> asciiBytes = stackalloc byte[textSpan.Length];
         var bytesWritten = Encoding.ASCII.GetBytes(textSpan, asciiBytes);
 
@@ -143,7 +143,7 @@ internal ref struct QRBinaryEncoder
     private void EncodeAlphanumeric(ReadOnlySpan<char> textSpan)
     {
         // Convert string to ASCII bytes (numeric chars are ASCII compatible)
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         Span<byte> asciiBytes = stackalloc byte[textSpan.Length];
         var bytesWritten = Encoding.ASCII.GetBytes(textSpan, asciiBytes);
 
@@ -273,7 +273,7 @@ internal ref struct QRBinaryEncoder
 
         static int EncodeISO88591(ReadOnlySpan<char> textSpan, Span<byte> buffer)
         {
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
             return Encoding.GetEncoding("ISO-8859-1").GetBytes(textSpan, buffer);
 #else
             var input = textSpan.ToString();
@@ -286,7 +286,7 @@ internal ref struct QRBinaryEncoder
         static int EncodeUtf8(ReadOnlySpan<char> textSpan, bool utf8BOM, Span<byte> buffer)
         {
             var offset = 0;
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
             if (utf8BOM)
             {
                 var preamble = Encoding.UTF8.GetPreamble();

--- a/src/SkiaSharp.QrCode/QRCodeData.cs
+++ b/src/SkiaSharp.QrCode/QRCodeData.cs
@@ -1,6 +1,6 @@
 using System.IO.Compression;
 using System.Runtime.CompilerServices;
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 using System.Runtime.InteropServices;
 #endif
 
@@ -138,7 +138,7 @@ public class QRCodeData
     {
         var size = source.Size;
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
         var srcSpan = MemoryMarshal.CreateSpan(ref source._moduleMatrix[0, 0], size * size);
         var destSpan = MemoryMarshal.CreateSpan(ref _moduleMatrix[0, 0], size * size);
         srcSpan.CopyTo(destSpan);

--- a/src/SkiaSharp.QrCode/QRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/QRCodeGenerator.cs
@@ -734,7 +734,7 @@ public static class QRCodeGenerator
 
         static int CalculateByteCount(ReadOnlySpan<char> textSpan, EciMode eciMode)
         {
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
             ReadOnlySpan<char> input = textSpan;
 #else
             string input = textSpan.ToString();

--- a/src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
+++ b/src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
 
     <!-- NuGet -->
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
## Summary

Add .NET 8 and 5 or greater handling for some Span<byte> API's.

baseline

<img width="1106" height="718" alt="image" src="https://github.com/user-attachments/assets/fd9d6058-c8e5-4ca9-95eb-3af76e3e5382" />

pr

<img width="1120" height="726" alt="image" src="https://github.com/user-attachments/assets/f8298c11-ffbd-4200-afe5-52b475f39ee5" />
