### PR TITLE
feat: use ArrayPool if data is larger than 256 letters or 1KB

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/QRBinaryEncoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/QRBinaryEncoder.cs
@@ -159,22 +159,23 @@ internal ref struct QRBinaryEncoder
                 buffer[i] = (byte)textSpan[i]; // direct cast since ASCII, avoids Span.ToString() allocation
             }
             WriteNumericData(buffer);
-            return;
         }
-
-        var rented = ArrayPool<byte>.Shared.Rent(textSpan.Length);
-        try
+        else
         {
-            var buffer = rented.AsSpan(0, textSpan.Length);
-            for (int i = 0; i < textSpan.Length; i++)
+            var rented = ArrayPool<byte>.Shared.Rent(textSpan.Length);
+            try
             {
-                buffer[i] = (byte)textSpan[i];
+                var buffer = rented.AsSpan(0, textSpan.Length);
+                for (int i = 0; i < textSpan.Length; i++)
+                {
+                    buffer[i] = (byte)textSpan[i];
+                }
+                WriteNumericData(buffer);
             }
-            WriteNumericData(buffer);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
         }
 #endif
     }
@@ -217,22 +218,23 @@ internal ref struct QRBinaryEncoder
                 buffer[i] = (byte)textSpan[i]; // direct cast since ASCII, avoids Span.ToString() allocation
             }
             WriteAlphanumericData(buffer);
-            return;
         }
-
-        var rented = ArrayPool<byte>.Shared.Rent(textSpan.Length);
-        try
+        else
         {
-            var buffer = rented.AsSpan(0, textSpan.Length);
-            for (int i = 0; i < textSpan.Length; i++)
+            var rented = ArrayPool<byte>.Shared.Rent(textSpan.Length);
+            try
             {
-                buffer[i] = (byte)textSpan[i];
+                var buffer = rented.AsSpan(0, textSpan.Length);
+                for (int i = 0; i < textSpan.Length; i++)
+                {
+                    buffer[i] = (byte)textSpan[i];
+                }
+                WriteAlphanumericData(buffer);
             }
-            WriteAlphanumericData(buffer);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rented);
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
         }
 #endif
     }
@@ -248,7 +250,7 @@ internal ref struct QRBinaryEncoder
 
         if (maxByteCount <= StackAllocThreshold)
         {
-            Span<byte> buffer = stackalloc byte[textSpan.Length * 4];
+            Span<byte> buffer = stackalloc byte[maxByteCount];
             var length = GetByteData(textSpan, eci, utf8Bom, buffer);
             WriteByteData(buffer.Slice(0, length));
         }


### PR DESCRIPTION
## Summary

- Previously QRBinaryEncoder fully using stackalloc whatever data length is. This PR introduce using ArrayPool if data is longer than 256 letter, or 1KB on byte mode.
- Avoid Span.ToString on .NETStnadard2.0. Manual loop instead.


baseline

<img width="1106" height="718" alt="image" src="https://github.com/user-attachments/assets/fd9d6058-c8e5-4ca9-95eb-3af76e3e5382" />

pr

<img width="1118" height="729" alt="Image" src="https://github.com/user-attachments/assets/26d8e04d-e716-40a0-83a0-8f154e438a51" />