### PR TITLE
feat: remove IsValidISO88591 inside QRBinaryEncoder. Encoding is already decided

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/QRBinaryEncoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/QRBinaryEncoder.cs
@@ -364,9 +364,7 @@ internal ref struct QRBinaryEncoder
     {
         return eciMode switch
         {
-            EciMode.Default => QRCodeConstants.IsValidISO88591(textSpan)
-                ? EncodeISO88591(textSpan, buffer)
-                : EncodeUtf8(textSpan, utf8BOM, buffer),
+            EciMode.Default => EncodeISO88591(textSpan, buffer), // already validated as ISO-8859-1
             EciMode.Iso8859_1 => EncodeISO88591(textSpan, buffer),
             EciMode.Utf8 => EncodeUtf8(textSpan, utf8BOM, buffer),
             _ => throw new ArgumentOutOfRangeException(nameof(eciMode), "Unsupported ECI mode for Byte encoding"),

--- a/tests/SkiaSharp.QrCode.Tests/QRBinaryEncoderUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRBinaryEncoderUnitTest.cs
@@ -173,8 +173,11 @@ public class QRBinaryEncoderUnitTest
         var utf8Bytes = Encoding.UTF8.GetBytes(input);
         var expected = string.Concat(utf8Bytes.Select(b => Convert.ToString(b, 2).PadLeft(8, '0')));
 
+        // to simulate automatic encoding mode detection, which sets EciMode
+        var (detectedEncoding, detectedEci, _) = TextAnalyzer.Analyze(input, eci);
+        // need detected as EncodingMode.Byte + EciMode.Utf8 beforehand.
         var encoder = new QRBinaryEncoder(buffer);
-        encoder.WriteData(input, EncodingMode.Byte, eci, false);
+        encoder.WriteData(input, EncodingMode.Byte, detectedEci, false);
 
         var actual = ToBinaryString(encoder.GetEncodedData(), encoder.BitPosition);
         Assert.Equal(expected, actual);


### PR DESCRIPTION
## Summary

Previously encoding is not decided before QRBinaryEncoder, TextAnalyzer provide pre-decision. We can remove IsValidISO88591.

baseline

<img width="1117" height="716" alt="image" src="https://github.com/user-attachments/assets/4aa8851e-e003-46e6-9945-ae3e5a792b10" />

pr

<img width="1118" height="730" alt="image" src="https://github.com/user-attachments/assets/3351b21f-f30d-4056-b261-1c70c04692ba" />
