### PR TITLE
feat: Optimize Calculate score penalty loop to use single pass if possible

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
@@ -648,7 +648,7 @@ internal static class ModulePlacer
         var score2 = 0;
         var blackModules = 0; // dark modules count for Penalty 4
 
-        // Scan Panalty 1, 2, 4 in single pass
+        // Scan Penalty 1, 2, 4 in single pass
         for (var y = 0; y < size; y++)
         {
             var modInRow = 0;
@@ -680,7 +680,7 @@ internal static class ModulePlacer
                     lastValRow = current;
                 }
 
-                // Penalty 2: 2x2 block patterns (check only row direction)
+                // Penalty 2: 2x2 block patterns
                 if (x < size - 1 && y < size - 1)
                 {
                     var right = qrCode[y, x + 1];


### PR DESCRIPTION
## Summary

Previously every penalty score calculate loop `x, y`. This means looping qr data 4 time. This PR introduce single pass score calculation.

baseline

<img width="1118" height="730" alt="image" src="https://github.com/user-attachments/assets/3351b21f-f30d-4056-b261-1c70c04692ba" />

pr

<img width="1131" height="720" alt="image" src="https://github.com/user-attachments/assets/065ce536-0d33-45db-8ebc-30b7d0b08141" />
