### PR TITLE
feat: use stackalloc if QRCodeData is small enough. This reduce allocation on small dataset.

### DIFF
--- a/src/SkiaSharp.QrCode/QRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/QRCodeGenerator.cs
@@ -84,10 +84,9 @@ public static class QRCodeGenerator
             var newSize = oldSize + quietZoneSize * 2;
             var newDataLength = newSize * newSize;
 
-            //Span<byte> newBuffer = newDataLength <= 2048
-            //    ? stackalloc byte[newDataLength]
-            //    : new byte[newDataLength];
-            Span<byte> newBuffer = new byte[newDataLength];
+            Span<byte> newBuffer = newDataLength <= 2048
+                ? stackalloc byte[newDataLength]
+                : new byte[newDataLength];
 
             // Copy old data into new buffer with quiet zone
             var oldBuffer = qrCodeData.GetData();
@@ -166,10 +165,9 @@ public static class QRCodeGenerator
             var newSize = oldSize + quietZoneSize * 2;
             var newDataLength = newSize * newSize;
 
-            //Span<byte> newBuffer = newDataLength <= 2048
-            //    ? stackalloc byte[newDataLength]
-            //    : new byte[newDataLength];
-            Span<byte> newBuffer = new byte[newDataLength];
+            Span<byte> newBuffer = newDataLength <= 2048
+                ? stackalloc byte[newDataLength]
+                : new byte[newDataLength];
 
             // Copy old data into new buffer with quiet zone
             var oldBuffer = qrCodeData.GetData();


### PR DESCRIPTION
## Summary

AddQuietZone require new QRCodeData, therefore heap allocation was happen. This PR eliminate this allocation if dataset is small enough and can be fit inside stackalloc.

baseline

<img width="1126" height="723" alt="Image" src="https://github.com/user-attachments/assets/04897e56-20f2-42e0-8b72-0178ad14e6cf" />


pr

<img width="1118" height="724" alt="Image" src="https://github.com/user-attachments/assets/77b44746-bf03-4728-85ad-eeaa54df954d" />