### PR TITLE
fix: Penalty3 calculation should do for row and col separately

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
@@ -710,7 +710,7 @@ internal static class ModulePlacer
             {
                 var current = buffer[y * size + x] != 0;
 
-                // Panalty 1
+                // Penalty 1
                 if (current == lastValColumn)
                 {
                     modInColumn++;


### PR DESCRIPTION
## Summary

Previously Penalty3's col count was always reset to 0, but it should keep.

baseline

<img width="1114" height="725" alt="Image" src="https://github.com/user-attachments/assets/9029f752-ebd3-4562-94ee-ee8c25f82afb" />

pr

<img width="1112" height="722" alt="image" src="https://github.com/user-attachments/assets/71bc3c17-74cb-4310-bcf8-cfcc12827f91" />
