### PR TITLE
feat: minor update, remove non need modulo for Galois multiply

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/GaloisField.cs
+++ b/src/SkiaSharp.QrCode/Internals/GaloisField.cs
@@ -110,7 +110,7 @@ internal static class GaloisField
         var expSpan = expTable.AsSpan();
         var logSpan = logTable.AsSpan();
 
-        // Seems `expSpan[(logSpan[a] + logSpan[b]) % 255];` is correct, but we already extended expTable to 512 elements to avoid modulo operation.
+        // While `expSpan[(logSpan[a] + logSpan[b]) % 255];` is mathematically correct, we already extended expTable to 512 elements to avoid the modulo operation.
         return expSpan[(logSpan[a] + logSpan[b])];
     }
 


### PR DESCRIPTION
## Summary

remove non need modulo `% 255`. We already expanded expTable to 512.


baseline

<img width="1108" height="716" alt="image" src="https://github.com/user-attachments/assets/cd5d6e4e-1667-4271-a061-1131878c8c17" />


pr

<img width="1099" height="710" alt="image" src="https://github.com/user-attachments/assets/0a60af1e-228b-4b0d-96b7-c5293f24e4da" />
