### PR TITLE
ci: Adds SLSA provenance attestation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,9 @@ on:
 jobs:
   build-dotnet:
     permissions:
+      attestations: write
       contents: read
+      id-token: write
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -29,6 +31,11 @@ jobs:
       - run: dotnet pack -c Release -p:Version="${GIT_TAG}" -o ./publish
         env:
           GIT_TAG: ${{ github.ref_name }}
+      # attestations
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: "./publish/*.nupkg"
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: nuget


### PR DESCRIPTION
## Summary

Adds a step to generate and attach a SLSA provenance attestation to the build artifacts.

This enhances the security and trustworthiness of the produced packages.

> [!NOTE]
> NuGet re-signs nupkg files with their own signature, which means the nupkg SHA will differ from the originally uploaded file.