### PR TITLE
fix: FinderPattern background was fixed to White

### DIFF
--- a/samples/Dotfiles/Finderpattern.cs
+++ b/samples/Dotfiles/Finderpattern.cs
@@ -5,13 +5,15 @@ using SkiaSharp;
 using SkiaSharp.QrCode;
 using SkiaSharp.QrCode.Image;
 
+// fix confirmation for: https://github.com/guitarrapc/SkiaSharp.QrCode/issues/299
+
 var backgroundColor = new SKColor(0xEA, 0xFB, 0x00, 0xFF);
 var codeColor = SKColors.Green;
 var qr = QRCodeGenerator.CreateQrCode("finder-shape-background-test", ECCLevel.M);
 
 var imageSize = qr.Size * 10;
 var area = SKRect.Create(0, 0, imageSize, imageSize);
-var outputDirectory = Path.Combine(Environment.CurrentDirectory, "samples", "Dotfiles", "finder-shapes");
+var outputDirectory = Path.Combine(Environment.CurrentDirectory, "samples", "Dotfiles", "output", "finder-shapes");
 Directory.CreateDirectory(outputDirectory);
 
 var finderPatternShapes = new FinderPatternShape[]

--- a/samples/Dotfiles/Finderpattern.cs
+++ b/samples/Dotfiles/Finderpattern.cs
@@ -1,0 +1,50 @@
+#:sdk Microsoft.NET.Sdk
+#:property TargetFramework=net10.0
+#:project ../../src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
+using SkiaSharp;
+using SkiaSharp.QrCode;
+using SkiaSharp.QrCode.Image;
+
+var backgroundColor = new SKColor(0xEA, 0xFB, 0x00, 0xFF);
+var codeColor = SKColors.Green;
+var qr = QRCodeGenerator.CreateQrCode("finder-shape-background-test", ECCLevel.M);
+
+var imageSize = qr.Size * 10;
+var area = SKRect.Create(0, 0, imageSize, imageSize);
+var outputDirectory = Path.Combine(Environment.CurrentDirectory, "samples", "Dotfiles", "finder-shapes");
+Directory.CreateDirectory(outputDirectory);
+
+var finderPatternShapes = new FinderPatternShape[]
+{
+    RectangleFinderPatternShape.Default,
+    CircleFinderPatternShape.Default,
+    RoundedRectangleFinderPatternShape.Default,
+    RoundedRectangleCircleFinderPatternShape.Default,
+};
+
+foreach (var finderPatternShape in finderPatternShapes)
+{
+    using var bitmap = new SKBitmap(imageSize, imageSize);
+    using var canvas = new SKCanvas(bitmap);
+
+    QRCodeRenderer.Render(canvas, area, qr, codeColor, backgroundColor, finderPatternShape: finderPatternShape);
+
+    var finderRect = QRCodeRenderer.GetFinderPatternRect(qr, 0, area);
+    var moduleSize = finderRect.Width / 7f;
+    var ringSampleX = (int)MathF.Round(finderRect.Left + moduleSize * 1.5f);
+    var ringSampleY = (int)MathF.Round(finderRect.Top + moduleSize * 3.5f);
+    var centerSampleX = (int)MathF.Round(finderRect.Left + moduleSize * 3.5f);
+    var centerSampleY = (int)MathF.Round(finderRect.Top + moduleSize * 3.5f);
+
+    var ringPixel = bitmap.GetPixel(ringSampleX, ringSampleY);
+    var centerPixel = bitmap.GetPixel(centerSampleX, centerSampleY);
+
+    var outputPath = Path.Combine(outputDirectory, $"{finderPatternShape.GetType().Name}.png");
+    using var image = SKImage.FromBitmap(bitmap);
+    using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+    using var stream = File.Open(outputPath, FileMode.Create, FileAccess.Write, FileShare.None);
+    data.SaveTo(stream);
+
+    Console.WriteLine($"{finderPatternShape.GetType().Name}: ring={ringPixel}, center={centerPixel}");
+    Console.WriteLine($"saved: {outputPath}");
+}

--- a/samples/Dotfiles/Sample.cs
+++ b/samples/Dotfiles/Sample.cs
@@ -1,0 +1,6 @@
+#:sdk Microsoft.NET.Sdk
+#:property TargetFramework=net10.0
+#:project ../../src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
+using SkiaSharp;
+using SkiaSharp.QrCode;
+using SkiaSharp.QrCode.Image;

--- a/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs
+++ b/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs
@@ -53,14 +53,14 @@ public sealed class RectangleFinderPatternShape : FinderPatternShape
         // Draw outer ring (7×7)
         canvas.DrawRect(rect, paint);
 
-        // Draw white ring (5×5)
-        using var whitePaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
+        // Draw ring (5×5)
+        using var ringPaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
         var innerRect = SKRect.Create(
             rect.Left + moduleSize,
             rect.Top + moduleSize,
             moduleSize * 5,
             moduleSize * 5);
-        canvas.DrawRect(innerRect, whitePaint);
+        canvas.DrawRect(innerRect, ringPaint);
 
         // Draw black center (3×3)
         var centerRect = SKRect.Create(
@@ -100,9 +100,9 @@ public sealed class CircleFinderPatternShape : FinderPatternShape
         // Draw outer ring (7x7)
         canvas.DrawCircle(center, radius, paint);
 
-        // Draw white ring (5x5)
-        using var whitePaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
-        canvas.DrawCircle(center, radius * (5f / 7f), whitePaint);
+        // Draw ring (5x5)
+        using var ringPaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
+        canvas.DrawCircle(center, radius * (5f / 7f), ringPaint);
 
         // Draw black center (3x3)
         canvas.DrawCircle(center, radius * (3f / 7f), paint);
@@ -149,14 +149,14 @@ public sealed class RoundedRectangleFinderPatternShape : FinderPatternShape
         // Draw outer rounded rectangle (7×7)
         canvas.DrawRoundRect(rect, radius, radius, paint);
 
-        // Draw white ring (5×5)
-        using var whitePaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
+        // Draw ring (5×5)
+        using var ringPaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
         var innerRect = SKRect.Create(
             rect.Left + moduleSize,
             rect.Top + moduleSize,
             moduleSize * 5,
             moduleSize * 5);
-        canvas.DrawRoundRect(innerRect, radius * 0.8f, radius * 0.8f, whitePaint);
+        canvas.DrawRoundRect(innerRect, radius * 0.8f, radius * 0.8f, ringPaint);
 
         // Draw black center (3×3)
         var centerRect = SKRect.Create(
@@ -214,14 +214,14 @@ public sealed class RoundedRectangleCircleFinderPatternShape : FinderPatternShap
         // Draw outer rounded rectangle (7×7)
         canvas.DrawRoundRect(rect, cornerRadius, cornerRadius, paint);
 
-        // Draw white ring (5×5)
-        using var whitePaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
+        // Draw ring (5×5)
+        using var ringPaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
         var innerRect = SKRect.Create(
             rect.Left + moduleSize,
             rect.Top + moduleSize,
             moduleSize * 5,
             moduleSize * 5);
-        canvas.DrawRoundRect(innerRect, cornerRadius * 0.7f, cornerRadius * 0.7f, whitePaint);
+        canvas.DrawRoundRect(innerRect, cornerRadius * 0.7f, cornerRadius * 0.7f, ringPaint);
 
         // Draw black center (3×3) - 3/7 of the base radius
         canvas.DrawCircle(center, baseRadius * (3f / 7f), paint);

--- a/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs
+++ b/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs
@@ -12,6 +12,18 @@ public abstract class FinderPatternShape
     /// <param name="rect">The rectangular area for the finder pattern (7x7 modules).</param>
     /// <param name="paint">The paint to use for drawing.</param>
     public abstract void Draw(SKCanvas canvas, SKRect rect, SKPaint paint);
+
+    /// <summary>
+    /// Draw a finder pattern at the specified location with background color support.
+    /// </summary>
+    /// <param name="canvas">The canvas to render on.</param>
+    /// <param name="rect">The rectangular area for the finder pattern (7x7 modules).</param>
+    /// <param name="paint">The paint to use for drawing dark modules.</param>
+    /// <param name="backgroundColor">The color used for light modules in the finder pattern.</param>
+    public virtual void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor)
+    {
+        Draw(canvas, rect, paint);
+    }
 }
 
 /// <summary>
@@ -30,13 +42,19 @@ public sealed class RectangleFinderPatternShape : FinderPatternShape
     /// <inheritdoc/>
     public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint)
     {
+        Draw(canvas, rect, paint, SKColors.White);
+    }
+
+    /// <inheritdoc/>
+    public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor)
+    {
         var moduleSize = rect.Width / 7f;
 
         // Draw outer ring (7×7)
         canvas.DrawRect(rect, paint);
 
         // Draw white ring (5×5)
-        using var whitePaint = new SKPaint { Color = SKColors.White, Style = SKPaintStyle.Fill };
+        using var whitePaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
         var innerRect = SKRect.Create(
             rect.Left + moduleSize,
             rect.Top + moduleSize,
@@ -70,6 +88,12 @@ public sealed class CircleFinderPatternShape : FinderPatternShape
     /// <inheritdoc/>
     public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint)
     {
+        Draw(canvas, rect, paint, SKColors.White);
+    }
+
+    /// <inheritdoc/>
+    public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor)
+    {
         var center = new SKPoint(rect.MidX, rect.MidY);
         var radius = Math.Min(rect.Width, rect.Height) / 2f;
 
@@ -77,7 +101,7 @@ public sealed class CircleFinderPatternShape : FinderPatternShape
         canvas.DrawCircle(center, radius, paint);
 
         // Draw white ring (5x5)
-        using var whitePaint = new SKPaint() { Color = SKColors.White, Style = SKPaintStyle.Fill };
+        using var whitePaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
         canvas.DrawCircle(center, radius * (5f / 7f), whitePaint);
 
         // Draw black center (3x3)
@@ -113,6 +137,12 @@ public sealed class RoundedRectangleFinderPatternShape : FinderPatternShape
     /// <inheritdoc/>
     public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint)
     {
+        Draw(canvas, rect, paint, SKColors.White);
+    }
+
+    /// <inheritdoc/>
+    public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor)
+    {
         var moduleSize = rect.Width / 7f;
         var radius = Math.Min(rect.Width, rect.Height) * _cornerRadiusPercent;
 
@@ -120,7 +150,7 @@ public sealed class RoundedRectangleFinderPatternShape : FinderPatternShape
         canvas.DrawRoundRect(rect, radius, radius, paint);
 
         // Draw white ring (5×5)
-        using var whitePaint = new SKPaint { Color = SKColors.White, Style = SKPaintStyle.Fill };
+        using var whitePaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
         var innerRect = SKRect.Create(
             rect.Left + moduleSize,
             rect.Top + moduleSize,
@@ -166,6 +196,12 @@ public sealed class RoundedRectangleCircleFinderPatternShape : FinderPatternShap
     /// <inheritdoc/>
     public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint)
     {
+        Draw(canvas, rect, paint, SKColors.White);
+    }
+
+    /// <inheritdoc/>
+    public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint, SKColor backgroundColor)
+    {
         var center = new SKPoint(rect.MidX, rect.MidY);
         var moduleSize = rect.Width / 7f;
 
@@ -179,7 +215,7 @@ public sealed class RoundedRectangleCircleFinderPatternShape : FinderPatternShap
         canvas.DrawRoundRect(rect, cornerRadius, cornerRadius, paint);
 
         // Draw white ring (5×5)
-        using var whitePaint = new SKPaint { Color = SKColors.White, Style = SKPaintStyle.Fill };
+        using var whitePaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill };
         var innerRect = SKRect.Create(
             rect.Left + moduleSize,
             rect.Top + moduleSize,

--- a/src/SkiaSharp.QrCode/QRCodeRenderer.cs
+++ b/src/SkiaSharp.QrCode/QRCodeRenderer.cs
@@ -112,7 +112,7 @@ public static class QRCodeRenderer
             for (var i = 0; i < 3; i++)
             {
                 var finderRect = GetFinderPatternRect(data, i, area);
-                finderPatternShape.Draw(canvas, finderRect, darkPaint);
+                finderPatternShape.Draw(canvas, finderRect, darkPaint, bgColor);
             }
         }
 

--- a/tests/SkiaSharp.QrCode.Tests/FinderPatternShapeColorTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/FinderPatternShapeColorTest.cs
@@ -1,0 +1,50 @@
+using SkiaSharp.QrCode.Image;
+using Xunit;
+
+namespace SkiaSharp.QrCode.Tests;
+
+public class FinderPatternShapeColorTest
+{
+    [Theory]
+    [MemberData(nameof(GetFinderPatternShapes))]
+    public void CustomFinderPatternShape_UsesBackgroundColorForInnerRing(FinderPatternShape finderPatternShape)
+    {
+        var backgroundColor = new SKColor(0xEA, 0xFB, 0x00, 0xFF);
+        var codeColor = SKColors.Green;
+        var qr = QRCodeGenerator.CreateQrCode("finder-shape-background-test", ECCLevel.M);
+
+        var imageSize = qr.Size * 10;
+        var area = SKRect.Create(0, 0, imageSize, imageSize);
+        using var bitmap = new SKBitmap(imageSize, imageSize);
+        using var canvas = new SKCanvas(bitmap);
+
+        QRCodeRenderer.Render(
+            canvas,
+            area,
+            qr,
+            codeColor,
+            backgroundColor,
+            finderPatternShape: finderPatternShape);
+
+        var finderRect = QRCodeRenderer.GetFinderPatternRect(qr, 0, area);
+        var moduleSize = finderRect.Width / 7f;
+        var ringSampleX = (int)MathF.Round(finderRect.Left + moduleSize * 1.5f);
+        var ringSampleY = (int)MathF.Round(finderRect.Top + moduleSize * 3.5f);
+        var centerSampleX = (int)MathF.Round(finderRect.Left + moduleSize * 3.5f);
+        var centerSampleY = (int)MathF.Round(finderRect.Top + moduleSize * 3.5f);
+
+        var ringPixel = bitmap.GetPixel(ringSampleX, ringSampleY);
+        var centerPixel = bitmap.GetPixel(centerSampleX, centerSampleY);
+
+        Assert.Equal(backgroundColor, ringPixel);
+        Assert.Equal(codeColor, centerPixel);
+    }
+
+    public static IEnumerable<object[]> GetFinderPatternShapes()
+    {
+        yield return [RectangleFinderPatternShape.Default];
+        yield return [CircleFinderPatternShape.Default];
+        yield return [RoundedRectangleFinderPatternShape.Default];
+        yield return [RoundedRectangleCircleFinderPatternShape.Default];
+    }
+}

--- a/tests/SkiaSharp.QrCode.Tests/FinderPatternShapeColorTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/FinderPatternShapeColorTest.cs
@@ -1,4 +1,3 @@
-using SkiaSharp;
 using SkiaSharp.QrCode.Image;
 using Xunit;
 

--- a/tests/SkiaSharp.QrCode.Tests/FinderPatternShapeColorTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/FinderPatternShapeColorTest.cs
@@ -1,3 +1,4 @@
+using SkiaSharp;
 using SkiaSharp.QrCode.Image;
 using Xunit;
 


### PR DESCRIPTION
fixed: #299

## Summary
Because there was no overload to pass the background color to finder patterns, the finder-pattern background was always white even when a custom background color was set.

This PR fixes that issue by matching the finder-pattern background to the configured background color.

## Fixed

<img width="370" height="370" alt="CircleFinderPatternShape" src="https://github.com/user-attachments/assets/ed567cf9-a971-4502-9493-290491b4eb4a" />
<img width="370" height="370" alt="RectangleFinderPatternShape" src="https://github.com/user-attachments/assets/37d45728-63f7-48f8-8fd3-e50a8afee628" />
<img width="370" height="370" alt="RoundedRectangleCircleFinderPatternShape" src="https://github.com/user-attachments/assets/30dda975-3159-436a-b4c4-dccbc62a3dd7" />
<img width="370" height="370" alt="RoundedRectangleFinderPatternShape" src="https://github.com/user-attachments/assets/5f1338c9-7968-4e38-8630-8cc1fa28c130" />
