### PR TITLE
feat: add AddVersion to QRCodeImageBuilder

### DIFF
--- a/samples/Dotfiles/SpecifyVersion.cs
+++ b/samples/Dotfiles/SpecifyVersion.cs
@@ -1,0 +1,62 @@
+#:sdk Microsoft.NET.Sdk
+#:property TargetFramework=net10.0
+#:project ../../src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj
+using SkiaSharp;
+using SkiaSharp.QrCode;
+using SkiaSharp.QrCode.Image;
+
+// fix confirmation for: https://github.com/guitarrapc/SkiaSharp.QrCode/issues/296 & https://github.com/guitarrapc/SkiaSharp.QrCode/issues/292
+
+var content = "abc";
+var iconPath = "samples/ConsoleApp/samples/insta.png";
+var outputDirectory = Path.Combine(Environment.CurrentDirectory, "samples", "Dotfiles", "output", "specify-version");
+var autoOutputPath = Path.Combine(outputDirectory, "auto-version.png");
+var fixedOutputPath = Path.Combine(outputDirectory, "version-10.png");
+Directory.CreateDirectory(outputDirectory);
+
+// For this example, we'll use the test icon
+using var logo = SKBitmap.Decode(File.ReadAllBytes(iconPath));
+var icon = IconData.FromImage(logo, iconSizePercent: 14, iconBorderWidth: 1);
+
+var autoVersionBuilder = new QRCodeImageBuilder(content)
+    .WithSize(1024, 1024)
+    .WithErrorCorrection(ECCLevel.H)
+    .WithQuietZone(4)
+    .WithColors(
+        codeColor: SKColor.Parse("ff6000"),
+        backgroundColor: SKColors.White,
+        clearColor: SKColors.White
+    )
+    .WithModuleShape(CircleModuleShape.Default, sizePercent: 1.0f)
+    .WithFinderPatternShape(RoundedRectangleCircleFinderPatternShape.Default)
+    .WithIcon(icon);
+
+var fixedVersionBuilder = new QRCodeImageBuilder(content)
+    .WithSize(1024, 1024)
+    .WithErrorCorrection(ECCLevel.H)
+    .WithVersion(10)
+    .WithQuietZone(4)
+    .WithColors(
+        codeColor: SKColor.Parse("ff6000"),
+        backgroundColor: SKColors.White,
+        clearColor: SKColors.White
+    )
+    .WithModuleShape(CircleModuleShape.Default, sizePercent: 1.0f)
+    .WithFinderPatternShape(RoundedRectangleCircleFinderPatternShape.Default)
+    .WithIcon(icon);
+
+var autoPngBytes = autoVersionBuilder.ToByteArray();
+var fixedPngBytes = fixedVersionBuilder.ToByteArray();
+
+File.WriteAllBytes(autoOutputPath, autoPngBytes);
+File.WriteAllBytes(fixedOutputPath, fixedPngBytes);
+
+var autoData = QRCodeGenerator.CreateQrCode(content, ECCLevel.H);
+var version10Data = QRCodeGenerator.CreateQrCode(content, ECCLevel.H, requestedVersion: 10);
+var autoCoreModules = autoData.Size - 8; // quiet zone = 4 on each side
+var version10CoreModules = version10Data.Size - 8; // quiet zone = 4 on each side
+
+Console.WriteLine($"  ✓ Auto version: v{autoData.Version} ({autoCoreModules}x{autoCoreModules} modules)");
+Console.WriteLine($"  ✓ Fixed version: v{version10Data.Version} ({version10CoreModules}x{version10CoreModules} modules)");
+Console.WriteLine($"  ✓ Saved to: {autoOutputPath}");
+Console.WriteLine($"  ✓ Saved to: {fixedOutputPath}");

--- a/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
@@ -32,6 +32,7 @@ public class QRCodeImageBuilder
     private int _quality = 100;
     private ECCLevel _eccLevel = ECCLevel.M;
     private EciMode _eciMode = EciMode.Default;
+    private int _requestedVersion = -1;
     private int _quietZoneSize = 4;
 
     // rendering
@@ -264,6 +265,24 @@ public class QRCodeImageBuilder
     }
 
     /// <summary>
+    /// Configure the QR code version to generate.
+    /// </summary>
+    /// <param name="version">Version to use (1-40), or -1 for automatic selection based on content length.</param>
+    /// <returns>This builder instance for method chaining.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    public QRCodeImageBuilder WithVersion(int version)
+    {
+        if (version is not -1 and (< 1 or > 40))
+            throw new ArgumentOutOfRangeException(nameof(version), "Version must be between 1 and 40, or -1 for automatic selection.");
+        if (_qrCodeData is not null)
+            throw new InvalidOperationException("WithVersion cannot be used when QRCodeData is provided directly.");
+
+        _requestedVersion = version;
+        return this;
+    }
+
+    /// <summary>
     /// Configure the quiet zone size (white border) around the QR code.
     /// </summary>
     /// <param name="size">Quiet zone size in modules (0-10). Recommended is 4.</param>
@@ -422,7 +441,7 @@ public class QRCodeImageBuilder
     private SKImage GenerateImage()
     {
         // Generate QR Data
-        var qrCodeData = _qrCodeData ?? QRCodeGenerator.CreateQrCode(_content.AsSpan(), _eccLevel, eciMode: _eciMode, quietZoneSize: _quietZoneSize);
+        var qrCodeData = _qrCodeData ?? QRCodeGenerator.CreateQrCode(_content.AsSpan(), _eccLevel, eciMode: _eciMode, requestedVersion: _requestedVersion, quietZoneSize: _quietZoneSize);
 
         // Create surface and render
         var info = new SKImageInfo(_size.X, _size.Y);

--- a/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
@@ -7,7 +7,7 @@ namespace SkiaSharp.QrCode.Image;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This builder provides both simple static methods for quick QR code generation 
+/// This builder provides both simple static methods for quick QR code generation
 /// and a fluent API for advanced customization.
 /// </para>
 /// <para>
@@ -16,8 +16,8 @@ namespace SkiaSharp.QrCode.Image;
 /// </para>
 /// <para>
 /// <b>Advanced Configuration (Fluent API):</b><br/>
-/// Chain methods like <see cref="WithSize(int, int)"/>, <see cref="WithColors(SKColor?, SKColor?, SKColor?)"/>, 
-/// <see cref="WithModuleShape(ModuleShape?, float)"/>, <see cref="WithGradient(GradientOptions?)"/>, 
+/// Chain methods like <see cref="WithSize(int, int)"/>, <see cref="WithColors(SKColor?, SKColor?, SKColor?)"/>,
+/// <see cref="WithModuleShape(ModuleShape?, float)"/>, <see cref="WithGradient(GradientOptions?)"/>,
 /// and <see cref="WithIcon(IconData?)"/> to customize QR code appearance.
 /// </para>
 /// </remarks>
@@ -273,10 +273,10 @@ public class QRCodeImageBuilder
     /// <exception cref="InvalidOperationException"></exception>
     public QRCodeImageBuilder WithVersion(int version)
     {
-        if (version is not -1 and (< 1 or > 40))
-            throw new ArgumentOutOfRangeException(nameof(version), "Version must be between 1 and 40, or -1 for automatic selection.");
         if (_qrCodeData is not null)
             throw new InvalidOperationException("WithVersion cannot be used when QRCodeData is provided directly.");
+        if (version is not -1 and (< 1 or > 40))
+            throw new ArgumentOutOfRangeException(nameof(version), "Version must be between 1 and 40, or -1 for automatic selection.");
 
         _requestedVersion = version;
         return this;

--- a/tests/SkiaSharp.QrCode.Tests/QRCodeImagebuilderUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRCodeImagebuilderUnitTest.cs
@@ -244,6 +244,60 @@ public class QRCodeImageBuilderTest
 
     #endregion
 
+    #region Fluent API Tests - WithVersion
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(40)]
+    public void WithVersion_ValidVersions_ReturnsBuilder(int version)
+    {
+        var builder = new QRCodeImageBuilder(TestContent);
+        var result = builder.WithVersion(version);
+
+        Assert.Same(builder, result);
+    }
+
+    [Theory]
+    [InlineData(-2)]
+    [InlineData(0)]
+    [InlineData(41)]
+    public void WithVersion_InvalidVersion_ThrowsArgumentOutOfRangeException(int version)
+    {
+        var builder = new QRCodeImageBuilder(TestContent);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => builder.WithVersion(version));
+    }
+
+    [Fact]
+    public void WithVersion_QRCodeDataBuilder_ThrowsInvalidOperationException()
+    {
+        var qrCodeData = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.H);
+        var builder = new QRCodeImageBuilder(qrCodeData);
+
+        Assert.Throws<InvalidOperationException>(() => builder.WithVersion(10));
+    }
+
+    [Fact]
+    public void WithVersion_FixedVersion_MatchesQRCodeDataRendering()
+    {
+        const int fixedVersion = 10;
+        using var expectedBitmap = new QRCodeImageBuilder(QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.H, requestedVersion: fixedVersion))
+            .WithSize(256, 256)
+            .ToBitmap();
+
+        using var actualBitmap = new QRCodeImageBuilder(TestContent)
+            .WithErrorCorrection(ECCLevel.H)
+            .WithVersion(fixedVersion)
+            .WithSize(256, 256)
+            .ToBitmap();
+
+        Assert.True(BitmapsAreEqual(expectedBitmap, actualBitmap));
+    }
+
+    #endregion
+
     #region Fluent API Tests - WithQuietZone
 
     [Theory]
@@ -489,4 +543,21 @@ public class QRCodeImageBuilderTest
     }
 
     #endregion
+
+    private static bool BitmapsAreEqual(SKBitmap left, SKBitmap right)
+    {
+        if (left.Width != right.Width || left.Height != right.Height)
+            return false;
+
+        for (var y = 0; y < left.Height; y++)
+        {
+            for (var x = 0; x < left.Width; x++)
+            {
+                if (left.GetPixel(x, y) != right.GetPixel(x, y))
+                    return false;
+            }
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
fixes:  #292, #296

## Summary

`QRCodeGenerator` already supports `requestedVersion` to force a larger QR version even for short content, but `QRCodeImageBuilder` had no public API to expose that option.

This PR adds `QRCodeImageBuilder.WithVersion(int)`, passing `requestedVersion` through to generation so callers can control module count (QR size) when needed.