### PR TITLE
feat: Specify QR Size by WithSize when using WithModuleSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,10 +811,28 @@ new QRCodeImageBuilder("https://example.com")
 ```csharp
 using SkiaSharp.QrCode.Image;
 
+// Content size = (QR matrix size in modules) * 10
 var qrCode = new QRCodeImageBuilder("https://example.com")
-    .WithModulePixelSize(10) // image side = (QR matrix size in modules) * 10
+    .WithModulePixelSize(10)
     .WithErrorCorrection(ECCLevel.H)
     .WithQuietZone(4);
+
+var pngBytes = qrCode.ToByteArray();
+```
+
+#### Module Pixel Size with Canvas Padding
+
+```csharp
+using SkiaSharp;
+using SkiaSharp.QrCode.Image;
+
+// Module size defines QR content; WithSize defines a larger canvas.
+// Content is centered and padded with clearColor. Canvas must be >= content size.
+var qrCode = new QRCodeImageBuilder("https://example.com")
+    .WithModulePixelSize(10)
+    .WithSize(512, 512)
+    .WithColors(clearColor: SKColors.Transparent)
+    .WithErrorCorrection(ECCLevel.H);
 
 var pngBytes = qrCode.ToByteArray();
 ```

--- a/README.md
+++ b/README.md
@@ -806,32 +806,49 @@ new QRCodeImageBuilder("https://example.com")
     .SaveTo(stream);
 ```
 
-#### Fixed Module Pixel Size
+#### Choosing Image Size
+
+| Goal | API | Notes |
+|---|---|---|
+| Keep module edges sharp / logo aligned | `WithModulePixelSize(n)` | Output side = `QR matrix size * n`. Best default when using logos. |
+| Also fit a fixed UI frame | `WithModulePixelSize(n)` + `WithSize(w, h)` | Canvas must be `>=` content size. Extra space is centered padding (`clearColor`). Too-small canvas throws. |
+| Only need a fixed pixel box | `WithSize(w, h)` | Simple, but module size may become fractional when QR version changes. |
+
+**Recommended (module-aligned):**
 
 ```csharp
 using SkiaSharp.QrCode.Image;
 
-// Content size = (QR matrix size in modules) * 10
 var qrCode = new QRCodeImageBuilder("https://example.com")
-    .WithModulePixelSize(10)
+    .WithModulePixelSize(10) // content = (QR matrix size in modules) * 10
     .WithErrorCorrection(ECCLevel.H)
     .WithQuietZone(4);
 
 var pngBytes = qrCode.ToByteArray();
 ```
 
-#### Module Pixel Size with Canvas Padding
+**Recommended (module-aligned + fixed canvas):**
 
 ```csharp
 using SkiaSharp;
 using SkiaSharp.QrCode.Image;
 
-// Module size defines QR content; WithSize defines a larger canvas.
-// Content is centered and padded with clearColor. Canvas must be >= content size.
 var qrCode = new QRCodeImageBuilder("https://example.com")
     .WithModulePixelSize(10)
-    .WithSize(512, 512)
+    .WithSize(512, 512) // must be >= content size
     .WithColors(clearColor: SKColors.Transparent)
+    .WithErrorCorrection(ECCLevel.H);
+
+var pngBytes = qrCode.ToByteArray();
+```
+
+**Fixed box only (may use fractional module pixels):**
+
+```csharp
+using SkiaSharp.QrCode.Image;
+
+var qrCode = new QRCodeImageBuilder("https://example.com")
+    .WithSize(512, 512)
     .WithErrorCorrection(ECCLevel.H);
 
 var pngBytes = qrCode.ToByteArray();
@@ -890,6 +907,8 @@ var pngBytes = qrCode.ToByteArray();
 
 #### QR code with Logo (icon only)
 
+Prefer module-based sizing so the logo sits on the QR grid. See [Choosing Image Size](#choosing-image-size).
+
 ```csharp
 using SkiaSharp;
 using SkiaSharp.QrCode.Image;
@@ -904,6 +923,7 @@ var iconByModules = IconData.FromImageByModules(logo, iconSizeModules: 7, iconBo
 
 var qrCode = new QRCodeImageBuilder("https://example.com")
     .WithModulePixelSize(12)
+    // .WithSize(512, 512) // optional: larger canvas with centered padding
     .WithErrorCorrection(ECCLevel.H) // High ECC recommended for icons
     .WithIcon(iconByModules);
 

--- a/samples/Dotfiles/ModulePixelSize.cs
+++ b/samples/Dotfiles/ModulePixelSize.cs
@@ -5,14 +5,16 @@ using SkiaSharp;
 using SkiaSharp.QrCode;
 using SkiaSharp.QrCode.Image;
 
-// Verification sample for WithModulePixelSize + FromImageByModules:
+// Verification sample for WithModulePixelSize (+ optional WithSize canvas pad):
 // - Fixed image size can produce fractional module pixels.
 // - Fixed module pixel size keeps each module aligned to exact pixels across versions.
+// - Module + larger WithSize centers content and pads with clearColor.
 // - Module-based icon sizing keeps logo body/border aligned to the same grid.
 
 const string content = "HELLO-294";
 const int fixedImageSize = 512;
 const int modulePixelSize = 12;
+const int paddedCanvasSize = 512;
 var outputDirectory = Path.Combine(Environment.CurrentDirectory, "samples", "Dotfiles", "output", "module-pixel-size");
 Directory.CreateDirectory(outputDirectory);
 using var logo = SKBitmap.Decode(File.ReadAllBytes("samples/ConsoleApp/samples/instarich-logo.png"));
@@ -28,6 +30,7 @@ var scenarios = new (int Version, int QuietZone)[]
 foreach (var (version, quietZone) in scenarios)
 {
     var qrData = QRCodeGenerator.CreateQrCode(content, ECCLevel.H, requestedVersion: version, quietZoneSize: quietZone);
+    var contentSide = qrData.Size * modulePixelSize;
 
     using var fixedSizeBitmap = new QRCodeImageBuilder(qrData)
         .WithSize(fixedImageSize, fixedImageSize)
@@ -48,13 +51,30 @@ foreach (var (version, quietZone) in scenarios)
     SaveBitmap(fixedSizeBitmap, Path.Combine(outputDirectory, $"v{version}_fixed-size_{fixedImageSize}.png"));
     SaveBitmap(modulePixelBitmap, Path.Combine(outputDirectory, $"v{version}_module-pixel-{modulePixelSize}.png"));
 
-    var fixedSizeModulePx = (float)fixedImageSize / qrData.Size;
-    var modulePixelImageSide = qrData.Size * modulePixelSize;
-    var iconTotalModules = (icon.IconSizeModules ?? 0) + ((icon.IconBorderModules ?? 1) * 2);
-
     Console.WriteLine($"Version v{version} (matrix size: {qrData.Size} modules)");
-    Console.WriteLine($"  fixed-size         : {fixedImageSize}x{fixedImageSize}, effective module px = {fixedSizeModulePx:F4}");
-    Console.WriteLine($"  with-module-pixel  : {modulePixelImageSide}x{modulePixelImageSide}, module px = {modulePixelSize}");
+    Console.WriteLine($"  fixed-size         : {fixedImageSize}x{fixedImageSize}, effective module px = {(float)fixedImageSize / qrData.Size:F4}");
+    Console.WriteLine($"  with-module-pixel  : {contentSide}x{contentSide}, module px = {modulePixelSize}");
+
+    if (paddedCanvasSize >= contentSide)
+    {
+        using var paddedBitmap = new QRCodeImageBuilder(qrData)
+            .WithModulePixelSize(modulePixelSize)
+            .WithSize(paddedCanvasSize, paddedCanvasSize)
+            .WithColors(SKColors.Black, SKColors.White, SKColors.Transparent)
+            .WithModuleShape(CircleModuleShape.Default, 0.92f)
+            .WithFinderPatternShape(RoundedRectangleCircleFinderPatternShape.Default)
+            .WithIcon(icon)
+            .ToBitmap();
+
+        SaveBitmap(paddedBitmap, Path.Combine(outputDirectory, $"v{version}_module-pixel-{modulePixelSize}_pad-{paddedCanvasSize}.png"));
+        Console.WriteLine($"  module+canvas-pad  : {paddedCanvasSize}x{paddedCanvasSize}, content = {contentSide}x{contentSide}");
+    }
+    else
+    {
+        Console.WriteLine($"  module+canvas-pad  : skipped ({paddedCanvasSize} < content {contentSide})");
+    }
+
+    var iconTotalModules = (icon.IconSizeModules ?? 0) + ((icon.IconBorderModules ?? 1) * 2);
     Console.WriteLine($"  icon               : body={icon.IconSizeModules} modules, border={icon.IconBorderModules} modules, total={iconTotalModules} modules");
     Console.WriteLine();
 }

--- a/src/SkiaSharp.QrCode/Image/IconData.cs
+++ b/src/SkiaSharp.QrCode/Image/IconData.cs
@@ -60,7 +60,7 @@ public class IconData
     /// <remarks>
     /// <para>
     /// Prefer combining this with <c>WithModulePixelSize</c> so each module maps to an integer pixel size.
-    /// Using <c>WithSize</c> is allowed, but module boundaries may become fractional.
+    /// Optional <c>WithSize</c> can then set a larger canvas; content is centered and padded.
     /// </para>
     /// <para>
     /// Validation against QR size/core occupancy happens at render time.

--- a/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
@@ -523,8 +523,9 @@ public class QRCodeImageBuilder
                 $"(QR matrix size {qrCodeData.Size} * module pixel size {_modulePixelSize.Value}).");
         }
 
-        var left = (canvasWidth - contentSide) / 2f;
-        var top = (canvasHeight - contentSide) / 2f;
+        // Use integer offsets so content stays on whole pixels (odd padding may be 1px asymmetric).
+        var left = (canvasWidth - contentSide) / 2;
+        var top = (canvasHeight - contentSide) / 2;
         return (
             new SKImageInfo(canvasWidth, canvasHeight),
             SKRect.Create(left, top, contentSide, contentSide));

--- a/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
@@ -27,7 +27,7 @@ public class QRCodeImageBuilder
 {
     private readonly string? _content;
     private readonly QRCodeData? _qrCodeData;
-    private Vector2Slim _size = new(512, 512);
+    private Vector2Slim? _explicitSize;
     private SKEncodedImageFormat _format = SKEncodedImageFormat.Png;
     private int _quality = 100;
     private ECCLevel _eccLevel = ECCLevel.M;
@@ -213,13 +213,14 @@ public class QRCodeImageBuilder
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Use this when the final image dimensions are fixed (for example UI layout constraints).
-    /// Module pixel size then becomes <c>imageSize / QRCodeData.Size</c>, which may be fractional
-    /// and can change when QR version changes.
+    /// Used alone, this sets an exact canvas size. Module pixel size then becomes
+    /// <c>imageSize / QRCodeData.Size</c>, which may be fractional and can change when QR version changes.
     /// </para>
     /// <para>
-    /// Mutually exclusive with <see cref="WithModulePixelSize(int)"/>. If both are called,
-    /// the last call wins.
+    /// Used with <see cref="WithModulePixelSize(int)"/>, this sets the canvas size while module pixels
+    /// define the QR content size (<c>QRCodeData.Size * modulePixelSize</c>).
+    /// The canvas must be at least as large as the content on both sides; extra space is padded and
+    /// the QR content is centered. Padding uses <c>clearColor</c> from <see cref="WithColors"/>.
     /// </para>
     /// </remarks>
     /// <param name="width">Width in pixels (must be positive).</param>
@@ -233,23 +234,22 @@ public class QRCodeImageBuilder
         if (height <= 0)
             throw new ArgumentOutOfRangeException(nameof(height), "Height must be positive");
 
-        _size = new Vector2Slim(width, height);
-        _modulePixelSize = null;
+        _explicitSize = new Vector2Slim(width, height);
         return this;
     }
 
     /// <summary>
-    /// Configure the output image size from pixels-per-module.
+    /// Configure QR content size from pixels-per-module.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Use this when module alignment matters (for example logos/icons that should sit cleanly on module boundaries).
-    /// The final image size is <c>QRCodeData.Size * modulePixelSize</c> for both width and height,
-    /// so each module stays an exact integer pixel size even when QR version changes.
+    /// Sets each QR module to an exact integer pixel size. Content side length is
+    /// <c>QRCodeData.Size * modulePixelSize</c>.
     /// </para>
     /// <para>
-    /// Mutually exclusive with <see cref="WithSize(int, int)"/>. If both are called,
-    /// the last call wins.
+    /// Used alone, the output image matches the content size.
+    /// Used with <see cref="WithSize(int, int)"/>, the content is centered on the larger canvas
+    /// and padded with <c>clearColor</c>. If the canvas is smaller than the content, rendering throws.
     /// </para>
     /// </remarks>
     /// <param name="modulePixelSize">Pixel size per QR module (must be positive).</param>
@@ -482,30 +482,51 @@ public class QRCodeImageBuilder
         // Generate QR Data
         var qrCodeData = _qrCodeData ?? QRCodeGenerator.CreateQrCode(_content.AsSpan(), _eccLevel, eciMode: _eciMode, requestedVersion: _requestedVersion, quietZoneSize: _quietZoneSize);
 
-        // Create surface and render
-        var info = CreateImageInfo(qrCodeData);
+        var (info, contentRect) = CreateLayout(qrCodeData);
         using var surface = SKSurface.Create(info);
         var canvas = surface.Canvas;
 
-        canvas.Render(qrCodeData, info.Width, info.Height, _clearColor, _codeColor, _backgroundColor, _iconData, _moduleShape, _moduleSizePercent, _gradientOptions, _finderPatternShape);
+        // Extension clears the full canvas with clearColor, then draws QR into contentRect.
+        // Extra canvas area (pad) therefore keeps clearColor.
+        canvas.Render(qrCodeData, contentRect, _clearColor, _codeColor, _backgroundColor, _iconData, _moduleShape, _moduleSizePercent, _gradientOptions, _finderPatternShape);
 
-        // Encode and save
         return surface.Snapshot();
     }
 
-    private SKImageInfo CreateImageInfo(QRCodeData qrCodeData)
+    private (SKImageInfo info, SKRect contentRect) CreateLayout(QRCodeData qrCodeData)
     {
         if (_modulePixelSize is null)
-            return new SKImageInfo(_size.X, _size.Y);
+        {
+            var size = _explicitSize ?? new Vector2Slim(512, 512);
+            return (new SKImageInfo(size.X, size.Y), SKRect.Create(0, 0, size.X, size.Y));
+        }
 
+        int contentSide;
         try
         {
-            var imageSide = checked(qrCodeData.Size * _modulePixelSize.Value);
-            return new SKImageInfo(imageSide, imageSide);
+            contentSide = checked(qrCodeData.Size * _modulePixelSize.Value);
         }
         catch (OverflowException ex)
         {
             throw new InvalidOperationException("Calculated image size overflowed. Reduce module pixel size or QR version.", ex);
         }
+
+        if (_explicitSize is null)
+            return (new SKImageInfo(contentSide, contentSide), SKRect.Create(0, 0, contentSide, contentSide));
+
+        var canvasWidth = _explicitSize.Value.X;
+        var canvasHeight = _explicitSize.Value.Y;
+        if (canvasWidth < contentSide || canvasHeight < contentSide)
+        {
+            throw new InvalidOperationException(
+                $"Canvas size {canvasWidth}x{canvasHeight} is smaller than QR content size {contentSide}x{contentSide} " +
+                $"(QR matrix size {qrCodeData.Size} * module pixel size {_modulePixelSize.Value}).");
+        }
+
+        var left = (canvasWidth - contentSide) / 2f;
+        var top = (canvasHeight - contentSide) / 2f;
+        return (
+            new SKImageInfo(canvasWidth, canvasHeight),
+            SKRect.Create(left, top, contentSide, contentSide));
     }
 }

--- a/tests/SkiaSharp.QrCode.Tests/QRCodeImagebuilderUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRCodeImagebuilderUnitTest.cs
@@ -303,6 +303,32 @@ public class QRCodeImageBuilderTest
         Assert.Equal(contentSide, bitmap.Height);
     }
 
+    [Fact]
+    public void WithModulePixelSize_AndOddPadding_UsesIntegerOrigin()
+    {
+        const int modulePixelSize = 6;
+        var qrCodeData = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+        var contentSide = qrCodeData.Size * modulePixelSize;
+        var canvasSide = contentSide + 1; // odd padding: 0 left/top, 1 right/bottom with integer division
+
+        using var bitmap = new QRCodeImageBuilder(TestContent)
+            .WithModulePixelSize(modulePixelSize)
+            .WithSize(canvasSide, canvasSide)
+            .WithColors(codeColor: SKColors.Black, backgroundColor: SKColors.White, clearColor: SKColors.Transparent)
+            .ToBitmap();
+
+        var expectedLeft = (canvasSide - contentSide) / 2;
+        var expectedTop = (canvasSide - contentSide) / 2;
+        Assert.Equal(0, expectedLeft);
+        Assert.Equal(0, expectedTop);
+
+        // Content starts on an integer pixel and keeps QR background in quiet zone.
+        Assert.Equal(SKColors.White, bitmap.GetPixel(expectedLeft, expectedTop));
+        // The extra 1px pad is on the far edges.
+        Assert.Equal(0, bitmap.GetPixel(canvasSide - 1, 0).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(0, canvasSide - 1).Alpha);
+    }
+
     #endregion
 
     #region Fluent API Tests - WithFormat

--- a/tests/SkiaSharp.QrCode.Tests/QRCodeImagebuilderUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRCodeImagebuilderUnitTest.cs
@@ -240,31 +240,67 @@ public class QRCodeImageBuilderTest
     }
 
     [Fact]
-    public void WithModulePixelSize_AfterWithSize_ModulePixelSizeTakesPrecedence()
+    public void WithModulePixelSize_AndLargerCanvas_PadsAndCentersContent()
     {
         const int modulePixelSize = 6;
         var qrCodeData = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
-        var expectedSide = qrCodeData.Size * modulePixelSize;
+        var contentSide = qrCodeData.Size * modulePixelSize;
+        const int canvasWidth = 400;
+        const int canvasHeight = 500;
+        Assert.True(canvasWidth >= contentSide);
+        Assert.True(canvasHeight >= contentSide);
 
         using var bitmap = new QRCodeImageBuilder(TestContent)
-            .WithSize(123, 456)
             .WithModulePixelSize(modulePixelSize)
+            .WithSize(canvasWidth, canvasHeight)
+            .WithColors(codeColor: SKColors.Black, backgroundColor: SKColors.White, clearColor: SKColors.Transparent)
             .ToBitmap();
 
-        Assert.Equal(expectedSide, bitmap.Width);
-        Assert.Equal(expectedSide, bitmap.Height);
+        Assert.Equal(canvasWidth, bitmap.Width);
+        Assert.Equal(canvasHeight, bitmap.Height);
+
+        var expectedLeft = (canvasWidth - contentSide) / 2;
+        var expectedTop = (canvasHeight - contentSide) / 2;
+
+        // Padding outside content should keep clearColor (transparent).
+        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(canvasWidth - 1, canvasHeight - 1).Alpha);
+
+        // Content area corners should be QR background (quiet zone).
+        Assert.Equal(SKColors.White, bitmap.GetPixel(expectedLeft, expectedTop));
+        Assert.Equal(SKColors.White, bitmap.GetPixel(expectedLeft + contentSide - 1, expectedTop + contentSide - 1));
     }
 
     [Fact]
-    public void WithSize_AfterWithModulePixelSize_ExplicitSizeTakesPrecedence()
+    public void WithModulePixelSize_AndTooSmallCanvas_ThrowsInvalidOperationException()
     {
+        const int modulePixelSize = 10;
+        var qrCodeData = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+        var contentSide = qrCodeData.Size * modulePixelSize;
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new QRCodeImageBuilder(TestContent)
+                .WithModulePixelSize(modulePixelSize)
+                .WithSize(contentSide - 1, contentSide)
+                .ToBitmap());
+
+        Assert.Contains("smaller than QR content size", ex.Message);
+    }
+
+    [Fact]
+    public void WithModulePixelSize_AndExactCanvas_MatchesContentSize()
+    {
+        const int modulePixelSize = 8;
+        var qrCodeData = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+        var contentSide = qrCodeData.Size * modulePixelSize;
+
         using var bitmap = new QRCodeImageBuilder(TestContent)
-            .WithModulePixelSize(9)
-            .WithSize(321, 654)
+            .WithModulePixelSize(modulePixelSize)
+            .WithSize(contentSide, contentSide)
             .ToBitmap();
 
-        Assert.Equal(321, bitmap.Width);
-        Assert.Equal(654, bitmap.Height);
+        Assert.Equal(contentSide, bitmap.Width);
+        Assert.Equal(contentSide, bitmap.Height);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

#312 added `WithModulePixelSize`. However there are no API to specify QR Size.

`WithModulePixelSize` and `WithSize` are now complementary instead of mutually exclusive.
- `WithModulePixelSize(n)` defines QR content size (`matrixSize * n`) with exact integer module pixels.
- Optional `WithSize(w, h)` sets a larger canvas. Content is centered and padded with `clearColor`.
- If the canvas is smaller than the content, rendering throws.
This matches the natural flow: pick module sharpness first, then optionally fit a UI frame without stretching modules.
## Usage
```csharp
// Module-aligned content only
new QRCodeImageBuilder(url)
    .WithModulePixelSize(10)
    .WithIcon(IconData.FromImageByModules(logo, iconSizeModules: 7));
// Module-aligned content + fixed canvas (pad if larger)
new QRCodeImageBuilder(url)
    .WithModulePixelSize(10)
    .WithSize(512, 512) // must be >= content size
    .WithColors(clearColor: SKColors.Transparent)
    .WithIcon(IconData.FromImageByModules(logo, iconSizeModules: 7));
```