### PR TITLE
feat: Improve EccBinaryEncoder applying for scalar, SSSE3 and GFNI

### DIFF
--- a/src/SkiaSharp.Benchmark/QrCodeEndToEnd.cs
+++ b/src/SkiaSharp.Benchmark/QrCodeEndToEnd.cs
@@ -1,0 +1,54 @@
+using SkiaSharp.QrCode;
+using System.Text;
+
+/// <summary>
+/// End-to-end QR generation through the public API (QRCodeGenerator.CreateQrCode).
+/// Used to measure the user-visible impact of internal kernel changes such as the
+/// Reed-Solomon ECC encoder optimization.
+///
+/// Scenarios cover the version/ECC spread:
+///   Short_M : tiny payload, version ~1-2 (per-call overhead dominated)
+///   Url_M   : typical URL payload, version ~4-5
+///   Long_L  : ~2900 chars -> version 40, ECC level L (largest data blocks)
+///   Long_H  : ~1200 chars -> version 40, ECC level H (81 blocks x 30 ecc, max ECC share)
+/// </summary>
+public class QrCodeEndToEnd
+{
+    private string _short = default!;
+    private string _url = default!;
+    private string _longL = default!;
+    private string _longH = default!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _short = "HELLO WORLD 2026";
+        _url = "https://github.com/guitarrapc/SkiaSharp.QrCode/blob/main/README.md?foo=sample&bar=dummy";
+        _longL = BuildDeterministicText(2900); // fits version 40-L byte mode (max 2953)
+        _longH = BuildDeterministicText(1200); // fits version 40-H byte mode (max 1273)
+    }
+
+    [Benchmark]
+    public QRCodeData Short_M() => QRCodeGenerator.CreateQrCode(_short, ECCLevel.M);
+
+    [Benchmark]
+    public QRCodeData Url_M() => QRCodeGenerator.CreateQrCode(_url, ECCLevel.M);
+
+    [Benchmark]
+    public QRCodeData Long_L() => QRCodeGenerator.CreateQrCode(_longL, ECCLevel.L);
+
+    [Benchmark]
+    public QRCodeData Long_H() => QRCodeGenerator.CreateQrCode(_longH, ECCLevel.H);
+
+    private static string BuildDeterministicText(int length)
+    {
+        var sb = new StringBuilder(length);
+        var rng = new Random(42);
+        const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 .,:/?&=-_";
+        for (var i = 0; i < length; i++)
+        {
+            sb.Append(alphabet[rng.Next(alphabet.Length)]);
+        }
+        return sb.ToString();
+    }
+}

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.Simd.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.Simd.cs
@@ -463,8 +463,11 @@ internal static partial class EccBinaryEncoder
 #endif
 
     // ---------------------------------------------------------------------------
-    // Table construction (all lazy, per eccCount; benign races — identical results,
-    // atomic reference assignment)
+    // Table construction (all lazy, per eccCount). Benign races: concurrent builders
+    // produce identical arrays and the losing build is garbage. Publication uses
+    // Volatile.Write so readers on weakly-ordered hardware can never observe a
+    // partially initialized array; plain reads suffice because the element loads are
+    // address-dependent on the reference load.
     // ---------------------------------------------------------------------------
 
     // Normal-domain generator coefficients (generator[1..eccCount], leading 1
@@ -483,7 +486,7 @@ internal static partial class EccBinaryEncoder
         var padded = new byte[32];
         generator.Slice(1, eccCount).CopyTo(padded);
 
-        s_paddedGenCache[eccCount] = padded;
+        Volatile.Write(ref s_paddedGenCache[eccCount], padded);
         return padded;
     }
 
@@ -549,7 +552,7 @@ internal static partial class EccBinaryEncoder
             }
         }
 
-        s_nibbleCache[eccCount] = t;
+        Volatile.Write(ref s_nibbleCache[eccCount], t);
         return t;
     }
 
@@ -589,7 +592,7 @@ internal static partial class EccBinaryEncoder
             }
         }
 
-        s_quadFactorCache[eccCount] = t;
+        Volatile.Write(ref s_quadFactorCache[eccCount], t);
         return t;
     }
 
@@ -617,7 +620,7 @@ internal static partial class EccBinaryEncoder
             }
         }
 
-        s_quadUpdateCache[eccCount] = t;
+        Volatile.Write(ref s_quadUpdateCache[eccCount], t);
         return t;
     }
 
@@ -647,7 +650,7 @@ internal static partial class EccBinaryEncoder
             }
         }
 
-        s_composedTUCache[eccCount] = t;
+        Volatile.Write(ref s_composedTUCache[eccCount], t);
         return t;
     }
 
@@ -671,7 +674,7 @@ internal static partial class EccBinaryEncoder
         MemoryMarshal.AsBytes(GetComposedTUTables(eccCount).AsSpan()).CopyTo(blob.AsSpan((int)BlobTu, 4096));
         GetPaddedGenerator(eccCount).CopyTo(blob.AsSpan((int)BlobGen, 32)); // last 8 bytes stay 0
 
-        s_blobCache[eccCount] = blob;
+        Volatile.Write(ref s_blobCache[eccCount], blob);
         return blob;
     }
 

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.Simd.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.Simd.cs
@@ -1,0 +1,705 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace SkiaSharp.QrCode.Internals.BinaryEncoders;
+
+/// <summary>
+/// Vectorized Reed-Solomon kernels for x86/x64. Selected at runtime by
+/// <see cref="EccBinaryEncoder.CalculateECC"/>; every kernel produces byte-identical
+/// output to <see cref="EccBinaryEncoder.CalculateEccScalar"/>.
+/// </summary>
+/// <remarks>
+/// Shared architecture of both kernels (result of a measured 13-round optimization
+/// loop; the discarded alternatives and reasoning live in the private MicroBenchmarks
+/// repository):
+///
+/// - The ≤32-byte remainder register lives in one (eccCount ≤ 16) or two vector
+///   registers for the whole block — no message buffer, no store/load round-trips.
+/// - Four data bytes are consumed per iteration. Their division factors are a
+///   GF(2)-linear function of the four input bytes, so they come from four parallel
+///   256-entry uint table lookups (T) instead of a serial per-byte recurrence.
+/// - Iterations are software-pipelined: the next quad's factors are derived from the
+///   PRE-update register using composed T∘U tables, which keeps the whole vector
+///   update off the critical dependency chain (same idea as multi-bit CRC tables).
+/// - The register update multiplies the (shifted) generator vector by each factor:
+///   GFNI does this in one gf2p8affineqb per factor; the SSSE3 kernel uses the
+///   classic PSHUFB nibble-split multiply (2 shuffles per factor) instead.
+///
+/// Table cost: ~8 KB static (SSSE3 nibble-split table) + 2 KB static (GFNI matrices),
+/// plus ~8-18 KB per distinct eccCount actually used (QR uses at most 13 values;
+/// a typical app touches one or two). All tables build lazily on first use.
+/// </remarks>
+internal static partial class EccBinaryEncoder
+{
+    /// <summary>
+    /// Entry point for vectorized kernels. Caller guarantees Ssse3.IsSupported and
+    /// eccCount ≤ 32 (QR maximum is 30).
+    /// </summary>
+    internal static void CalculateEccSimd(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+#if NET10_0_OR_GREATER
+        if (Gfni.IsSupported)
+        {
+            CalculateEccGfni(data, ecc, eccCount);
+            return;
+        }
+#endif
+        // Covers all pre-GFNI x86 (AVX2-only CPUs included; wider vectors measured
+        // slower than dual 128-bit registers for this kernel).
+        CalculateEccSsse3(data, ecc, eccCount);
+    }
+
+    // ---------------------------------------------------------------------------
+    // SSSE3 kernel (PSHUFB nibble-split GF multiply)
+    // ---------------------------------------------------------------------------
+
+    internal static void CalculateEccSsse3(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        if (eccCount <= 16)
+        {
+            Ssse3Core128(data, ecc, eccCount);
+        }
+        else
+        {
+            Ssse3CoreDual128(data, ecc, eccCount);
+        }
+    }
+
+    private static void Ssse3Core128(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        var nib = GetNibbleTables(eccCount);
+        ref var nibRef = ref MemoryMarshal.GetArrayDataReference(nib);
+        ref var mulBase = ref MemoryMarshal.GetArrayDataReference(s_nibbleMulTable);
+        ref var qf = ref MemoryMarshal.GetArrayDataReference(GetQuadFactorTables(eccCount));
+        ref var tu = ref MemoryMarshal.GetArrayDataReference(GetComposedTUTables(eccCount));
+        ref var dataRef = ref MemoryMarshal.GetReference(data);
+
+        var genLo = Vector128.LoadUnsafe(ref nibRef, NibGenLoA);
+        var genHi = Vector128.LoadUnsafe(ref nibRef, NibGenHiA);
+        var genS1Lo = Vector128.LoadUnsafe(ref nibRef, NibGenS1LoA);
+        var genS1Hi = Vector128.LoadUnsafe(ref nibRef, NibGenS1HiA);
+        var genS2Lo = Vector128.LoadUnsafe(ref nibRef, NibGenS2LoA);
+        var genS2Hi = Vector128.LoadUnsafe(ref nibRef, NibGenS2HiA);
+        var genS3Lo = Vector128.LoadUnsafe(ref nibRef, NibGenS3LoA);
+        var genS3Hi = Vector128.LoadUnsafe(ref nibRef, NibGenS3HiA);
+
+        var reg = Vector128<byte>.Zero; // remainder register, ecc[0] = byte 0
+
+        var i = 0;
+        if (data.Length >= 4)
+        {
+            // First quad's factors come straight from the data (register is zero).
+            var d0 = Unsafe.ReadUnaligned<uint>(ref dataRef);
+            var f = QuadLookup(ref qf, d0);
+
+            for (i = 4; i + 3 < data.Length; i += 4)
+            {
+                // Next quad's input from the PRE-update register (software pipelining):
+                // x_next = d_next ^ reg[4..7] ^ U(f), and by GF(2)-linearity
+                // T(x_next) = T(d_next ^ reg[4..7]) ^ (T∘U)(f).
+                var z = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref dataRef, i)) ^ reg.AsUInt32().GetElement(1);
+                var y = QuadLookup(ref qf, z);
+
+                ref var t0 = ref Unsafe.Add(ref mulBase, (nint)((f & 0xFF) * 32));
+                ref var t1 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 8) & 0xFF) * 32));
+                ref var t2 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 16) & 0xFF) * 32));
+                ref var t3 = ref Unsafe.Add(ref mulBase, (nint)((f >> 24) * 32));
+
+                // reg = (reg >> 4 bytes) ^ (gen>>3)·f0 ^ (gen>>2)·f1 ^ (gen>>1)·f2 ^ gen·f3
+                reg = Sse2.ShiftRightLogical128BitLane(reg, 4)
+                    ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t0), genS3Lo) ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t0, 16), genS3Hi)
+                    ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t1), genS2Lo) ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t1, 16), genS2Hi)
+                    ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t2), genS1Lo) ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t2, 16), genS1Hi)
+                    ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t3), genLo) ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t3, 16), genHi);
+
+                f = QuadLookup(ref tu, f) ^ y;
+            }
+
+            // Final full quad (its factors were prepared by the last loop iteration).
+            {
+                ref var t0 = ref Unsafe.Add(ref mulBase, (nint)((f & 0xFF) * 32));
+                ref var t1 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 8) & 0xFF) * 32));
+                ref var t2 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 16) & 0xFF) * 32));
+                ref var t3 = ref Unsafe.Add(ref mulBase, (nint)((f >> 24) * 32));
+
+                reg = Sse2.ShiftRightLogical128BitLane(reg, 4)
+                    ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t0), genS3Lo) ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t0, 16), genS3Hi)
+                    ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t1), genS2Lo) ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t1, 16), genS2Hi)
+                    ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t2), genS1Lo) ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t2, 16), genS1Hi)
+                    ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t3), genLo) ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t3, 16), genHi);
+            }
+        }
+
+        // 0..3 trailing bytes, single-step
+        for (; i < data.Length; i++)
+        {
+            var f = (uint)(Unsafe.Add(ref dataRef, i) ^ reg.ToScalar());
+            ref var t = ref Unsafe.Add(ref mulBase, (nint)(f * 32));
+            reg = Sse2.ShiftRightLogical128BitLane(reg, 1)
+                ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t), genLo)
+                ^ Ssse3.Shuffle(Vector128.LoadUnsafe(ref t, 16), genHi);
+        }
+
+        Span<byte> tmp = stackalloc byte[16];
+        reg.StoreUnsafe(ref MemoryMarshal.GetReference(tmp));
+        tmp.Slice(0, eccCount).CopyTo(ecc);
+    }
+
+    private static void Ssse3CoreDual128(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        var nib = GetNibbleTables(eccCount);
+        ref var nibRef = ref MemoryMarshal.GetArrayDataReference(nib);
+        ref var mulBase = ref MemoryMarshal.GetArrayDataReference(s_nibbleMulTable);
+        ref var qf = ref MemoryMarshal.GetArrayDataReference(GetQuadFactorTables(eccCount));
+        ref var tu = ref MemoryMarshal.GetArrayDataReference(GetComposedTUTables(eccCount));
+        ref var dataRef = ref MemoryMarshal.GetReference(data);
+
+        var genLoA = Vector128.LoadUnsafe(ref nibRef, NibGenLoA);
+        var genHiA = Vector128.LoadUnsafe(ref nibRef, NibGenHiA);
+        var genLoB = Vector128.LoadUnsafe(ref nibRef, NibGenLoB);
+        var genHiB = Vector128.LoadUnsafe(ref nibRef, NibGenHiB);
+        var genS1LoA = Vector128.LoadUnsafe(ref nibRef, NibGenS1LoA);
+        var genS1HiA = Vector128.LoadUnsafe(ref nibRef, NibGenS1HiA);
+        var genS1LoB = Vector128.LoadUnsafe(ref nibRef, NibGenS1LoB);
+        var genS1HiB = Vector128.LoadUnsafe(ref nibRef, NibGenS1HiB);
+        var genS2LoA = Vector128.LoadUnsafe(ref nibRef, NibGenS2LoA);
+        var genS2HiA = Vector128.LoadUnsafe(ref nibRef, NibGenS2HiA);
+        var genS2LoB = Vector128.LoadUnsafe(ref nibRef, NibGenS2LoB);
+        var genS2HiB = Vector128.LoadUnsafe(ref nibRef, NibGenS2HiB);
+        var genS3LoA = Vector128.LoadUnsafe(ref nibRef, NibGenS3LoA);
+        var genS3HiA = Vector128.LoadUnsafe(ref nibRef, NibGenS3HiA);
+        var genS3LoB = Vector128.LoadUnsafe(ref nibRef, NibGenS3LoB);
+        var genS3HiB = Vector128.LoadUnsafe(ref nibRef, NibGenS3HiB);
+
+        // Remainder register as two 128-bit halves: lo = ecc[0..15], hi = ecc[16..31].
+        // Measured faster than one 256-bit register (no cross-lane shift, no table
+        // broadcast on the dependency chain).
+        var lo = Vector128<byte>.Zero;
+        var hi = Vector128<byte>.Zero;
+
+        var i = 0;
+        if (data.Length >= 4)
+        {
+            var d0 = Unsafe.ReadUnaligned<uint>(ref dataRef);
+            var f = QuadLookup(ref qf, d0);
+
+            for (i = 4; i + 3 < data.Length; i += 4)
+            {
+                var z = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref dataRef, i)) ^ lo.AsUInt32().GetElement(1);
+                var y = QuadLookup(ref qf, z);
+
+                ref var t0 = ref Unsafe.Add(ref mulBase, (nint)((f & 0xFF) * 32));
+                ref var t1 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 8) & 0xFF) * 32));
+                ref var t2 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 16) & 0xFF) * 32));
+                ref var t3 = ref Unsafe.Add(ref mulBase, (nint)((f >> 24) * 32));
+
+                var tblLo0 = Vector128.LoadUnsafe(ref t0);
+                var tblHi0 = Vector128.LoadUnsafe(ref t0, 16);
+                var tblLo1 = Vector128.LoadUnsafe(ref t1);
+                var tblHi1 = Vector128.LoadUnsafe(ref t1, 16);
+                var tblLo2 = Vector128.LoadUnsafe(ref t2);
+                var tblHi2 = Vector128.LoadUnsafe(ref t2, 16);
+                var tblLo3 = Vector128.LoadUnsafe(ref t3);
+                var tblHi3 = Vector128.LoadUnsafe(ref t3, 16);
+
+                // Shift the 32-byte register left by 4 array positions:
+                // newLo = lo[4..15] ++ hi[0..3], newHi = hi[4..15] ++ 0000.
+                var newLo = Ssse3.AlignRight(hi, lo, 4);
+                var newHi = Sse2.ShiftRightLogical128BitLane(hi, 4);
+
+                lo = newLo
+                    ^ Ssse3.Shuffle(tblLo0, genS3LoA) ^ Ssse3.Shuffle(tblHi0, genS3HiA)
+                    ^ Ssse3.Shuffle(tblLo1, genS2LoA) ^ Ssse3.Shuffle(tblHi1, genS2HiA)
+                    ^ Ssse3.Shuffle(tblLo2, genS1LoA) ^ Ssse3.Shuffle(tblHi2, genS1HiA)
+                    ^ Ssse3.Shuffle(tblLo3, genLoA) ^ Ssse3.Shuffle(tblHi3, genHiA);
+                hi = newHi
+                    ^ Ssse3.Shuffle(tblLo0, genS3LoB) ^ Ssse3.Shuffle(tblHi0, genS3HiB)
+                    ^ Ssse3.Shuffle(tblLo1, genS2LoB) ^ Ssse3.Shuffle(tblHi1, genS2HiB)
+                    ^ Ssse3.Shuffle(tblLo2, genS1LoB) ^ Ssse3.Shuffle(tblHi2, genS1HiB)
+                    ^ Ssse3.Shuffle(tblLo3, genLoB) ^ Ssse3.Shuffle(tblHi3, genHiB);
+
+                f = QuadLookup(ref tu, f) ^ y;
+            }
+
+            // Final full quad
+            {
+                ref var t0 = ref Unsafe.Add(ref mulBase, (nint)((f & 0xFF) * 32));
+                ref var t1 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 8) & 0xFF) * 32));
+                ref var t2 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 16) & 0xFF) * 32));
+                ref var t3 = ref Unsafe.Add(ref mulBase, (nint)((f >> 24) * 32));
+
+                var tblLo0 = Vector128.LoadUnsafe(ref t0);
+                var tblHi0 = Vector128.LoadUnsafe(ref t0, 16);
+                var tblLo1 = Vector128.LoadUnsafe(ref t1);
+                var tblHi1 = Vector128.LoadUnsafe(ref t1, 16);
+                var tblLo2 = Vector128.LoadUnsafe(ref t2);
+                var tblHi2 = Vector128.LoadUnsafe(ref t2, 16);
+                var tblLo3 = Vector128.LoadUnsafe(ref t3);
+                var tblHi3 = Vector128.LoadUnsafe(ref t3, 16);
+
+                var newLo = Ssse3.AlignRight(hi, lo, 4);
+                var newHi = Sse2.ShiftRightLogical128BitLane(hi, 4);
+
+                lo = newLo
+                    ^ Ssse3.Shuffle(tblLo0, genS3LoA) ^ Ssse3.Shuffle(tblHi0, genS3HiA)
+                    ^ Ssse3.Shuffle(tblLo1, genS2LoA) ^ Ssse3.Shuffle(tblHi1, genS2HiA)
+                    ^ Ssse3.Shuffle(tblLo2, genS1LoA) ^ Ssse3.Shuffle(tblHi2, genS1HiA)
+                    ^ Ssse3.Shuffle(tblLo3, genLoA) ^ Ssse3.Shuffle(tblHi3, genHiA);
+                hi = newHi
+                    ^ Ssse3.Shuffle(tblLo0, genS3LoB) ^ Ssse3.Shuffle(tblHi0, genS3HiB)
+                    ^ Ssse3.Shuffle(tblLo1, genS2LoB) ^ Ssse3.Shuffle(tblHi1, genS2HiB)
+                    ^ Ssse3.Shuffle(tblLo2, genS1LoB) ^ Ssse3.Shuffle(tblHi2, genS1HiB)
+                    ^ Ssse3.Shuffle(tblLo3, genLoB) ^ Ssse3.Shuffle(tblHi3, genHiB);
+            }
+        }
+
+        for (; i < data.Length; i++)
+        {
+            var f = (uint)(Unsafe.Add(ref dataRef, i) ^ lo.ToScalar());
+            ref var t = ref Unsafe.Add(ref mulBase, (nint)(f * 32));
+            var tblLo = Vector128.LoadUnsafe(ref t);
+            var tblHi = Vector128.LoadUnsafe(ref t, 16);
+            var newLo = Ssse3.AlignRight(hi, lo, 1);
+            var newHi = Sse2.ShiftRightLogical128BitLane(hi, 1);
+            lo = newLo ^ Ssse3.Shuffle(tblLo, genLoA) ^ Ssse3.Shuffle(tblHi, genHiA);
+            hi = newHi ^ Ssse3.Shuffle(tblLo, genLoB) ^ Ssse3.Shuffle(tblHi, genHiB);
+        }
+
+        Span<byte> tmp = stackalloc byte[32];
+        lo.StoreUnsafe(ref MemoryMarshal.GetReference(tmp));
+        hi.StoreUnsafe(ref MemoryMarshal.GetReference(tmp), 16);
+        tmp.Slice(0, eccCount).CopyTo(ecc);
+    }
+
+#if NET10_0_OR_GREATER
+    // ---------------------------------------------------------------------------
+    // GFNI kernel (gf2p8affineqb: whole-vector GF multiply in one instruction)
+    // ---------------------------------------------------------------------------
+
+    internal static void CalculateEccGfni(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        if (eccCount <= 16)
+        {
+            GfniCore128(data, ecc, eccCount);
+        }
+        else if (Gfni.V256.IsSupported && Avx2.IsSupported)
+        {
+            GfniCore256(data, ecc, eccCount);
+        }
+        else
+        {
+            Ssse3CoreDual128(data, ecc, eccCount);
+        }
+    }
+
+    private static void GfniCore128(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        ref var blob = ref MemoryMarshal.GetArrayDataReference(GetBlob(eccCount));
+        ref var gm = ref MemoryMarshal.GetArrayDataReference(s_gfniMatrix);
+        ref var dataRef = ref MemoryMarshal.GetReference(data);
+
+        // Raw shifted generator vectors: (gen >> s)[j] = gen[j + s]
+        var gen0v = Vector128.LoadUnsafe(ref blob, BlobGen);
+        var gen1v = Vector128.LoadUnsafe(ref blob, BlobGen + 1);
+        var gen2v = Vector128.LoadUnsafe(ref blob, BlobGen + 2);
+        var gen3v = Vector128.LoadUnsafe(ref blob, BlobGen + 3);
+
+        var reg = Vector128<byte>.Zero;
+
+        var i = 0;
+        if (data.Length >= 4)
+        {
+            var d0 = Unsafe.ReadUnaligned<uint>(ref dataRef);
+            var f = BlobQuadLookup(ref blob, BlobQf, d0);
+
+            for (i = 4; i + 3 < data.Length; i += 4)
+            {
+                var z = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref dataRef, i)) ^ reg.AsUInt32().GetElement(1);
+                var y = BlobQuadLookup(ref blob, BlobQf, z);
+
+                var m0 = Vector128.Create(ReadMatrix(ref gm, f & 0xFF)).AsByte();
+                var m1 = Vector128.Create(ReadMatrix(ref gm, (f >> 8) & 0xFF)).AsByte();
+                var m2 = Vector128.Create(ReadMatrix(ref gm, (f >> 16) & 0xFF)).AsByte();
+                var m3 = Vector128.Create(ReadMatrix(ref gm, f >> 24)).AsByte();
+
+                reg = Sse2.ShiftRightLogical128BitLane(reg, 4)
+                    ^ Gfni.GaloisFieldAffineTransform(gen3v, m0, 0)
+                    ^ Gfni.GaloisFieldAffineTransform(gen2v, m1, 0)
+                    ^ Gfni.GaloisFieldAffineTransform(gen1v, m2, 0)
+                    ^ Gfni.GaloisFieldAffineTransform(gen0v, m3, 0);
+
+                f = BlobQuadLookup(ref blob, BlobTu, f) ^ y;
+            }
+
+            // Final full quad
+            {
+                var m0 = Vector128.Create(ReadMatrix(ref gm, f & 0xFF)).AsByte();
+                var m1 = Vector128.Create(ReadMatrix(ref gm, (f >> 8) & 0xFF)).AsByte();
+                var m2 = Vector128.Create(ReadMatrix(ref gm, (f >> 16) & 0xFF)).AsByte();
+                var m3 = Vector128.Create(ReadMatrix(ref gm, f >> 24)).AsByte();
+
+                reg = Sse2.ShiftRightLogical128BitLane(reg, 4)
+                    ^ Gfni.GaloisFieldAffineTransform(gen3v, m0, 0)
+                    ^ Gfni.GaloisFieldAffineTransform(gen2v, m1, 0)
+                    ^ Gfni.GaloisFieldAffineTransform(gen1v, m2, 0)
+                    ^ Gfni.GaloisFieldAffineTransform(gen0v, m3, 0);
+            }
+        }
+
+        for (; i < data.Length; i++)
+        {
+            var f = (uint)(Unsafe.Add(ref dataRef, i) ^ reg.ToScalar());
+            var m = Vector128.Create(ReadMatrix(ref gm, f)).AsByte();
+            reg = Sse2.ShiftRightLogical128BitLane(reg, 1)
+                ^ Gfni.GaloisFieldAffineTransform(gen0v, m, 0);
+        }
+
+        Span<byte> tmp = stackalloc byte[16];
+        reg.StoreUnsafe(ref MemoryMarshal.GetReference(tmp));
+        tmp.Slice(0, eccCount).CopyTo(ecc);
+    }
+
+    private static void GfniCore256(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        ref var blob = ref MemoryMarshal.GetArrayDataReference(GetBlob(eccCount));
+        ref var gm = ref MemoryMarshal.GetArrayDataReference(s_gfniMatrix);
+        ref var dataRef = ref MemoryMarshal.GetReference(data);
+
+        var gen0v = Vector256.LoadUnsafe(ref blob, BlobGen);
+        var gen1v = Vector256.LoadUnsafe(ref blob, BlobGen + 1);
+        var gen2v = Vector256.LoadUnsafe(ref blob, BlobGen + 2);
+        var gen3v = Vector256.LoadUnsafe(ref blob, BlobGen + 3);
+
+        var reg = Vector256<byte>.Zero;
+
+        var i = 0;
+        if (data.Length >= 4)
+        {
+            var d0 = Unsafe.ReadUnaligned<uint>(ref dataRef);
+            var f = BlobQuadLookup(ref blob, BlobQf, d0);
+
+            for (i = 4; i + 3 < data.Length; i += 4)
+            {
+                var z = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref dataRef, i)) ^ reg.AsUInt32().GetElement(1);
+                var y = BlobQuadLookup(ref blob, BlobQf, z);
+
+                var m0 = Vector256.Create(ReadMatrix(ref gm, f & 0xFF)).AsByte();
+                var m1 = Vector256.Create(ReadMatrix(ref gm, (f >> 8) & 0xFF)).AsByte();
+                var m2 = Vector256.Create(ReadMatrix(ref gm, (f >> 16) & 0xFF)).AsByte();
+                var m3 = Vector256.Create(ReadMatrix(ref gm, f >> 24)).AsByte();
+
+                // 256-bit byte shift right by 4 across the lane boundary
+                var carry = Avx2.Permute2x128(reg, reg, 0x81);
+                reg = Avx2.AlignRight(carry, reg, 4)
+                    ^ Gfni.V256.GaloisFieldAffineTransform(gen3v, m0, 0)
+                    ^ Gfni.V256.GaloisFieldAffineTransform(gen2v, m1, 0)
+                    ^ Gfni.V256.GaloisFieldAffineTransform(gen1v, m2, 0)
+                    ^ Gfni.V256.GaloisFieldAffineTransform(gen0v, m3, 0);
+
+                f = BlobQuadLookup(ref blob, BlobTu, f) ^ y;
+            }
+
+            // Final full quad
+            {
+                var m0 = Vector256.Create(ReadMatrix(ref gm, f & 0xFF)).AsByte();
+                var m1 = Vector256.Create(ReadMatrix(ref gm, (f >> 8) & 0xFF)).AsByte();
+                var m2 = Vector256.Create(ReadMatrix(ref gm, (f >> 16) & 0xFF)).AsByte();
+                var m3 = Vector256.Create(ReadMatrix(ref gm, f >> 24)).AsByte();
+
+                var carry = Avx2.Permute2x128(reg, reg, 0x81);
+                reg = Avx2.AlignRight(carry, reg, 4)
+                    ^ Gfni.V256.GaloisFieldAffineTransform(gen3v, m0, 0)
+                    ^ Gfni.V256.GaloisFieldAffineTransform(gen2v, m1, 0)
+                    ^ Gfni.V256.GaloisFieldAffineTransform(gen1v, m2, 0)
+                    ^ Gfni.V256.GaloisFieldAffineTransform(gen0v, m3, 0);
+            }
+        }
+
+        for (; i < data.Length; i++)
+        {
+            var f = (uint)(Unsafe.Add(ref dataRef, i) ^ reg.ToScalar());
+            var m = Vector256.Create(ReadMatrix(ref gm, f)).AsByte();
+            var carry = Avx2.Permute2x128(reg, reg, 0x81);
+            reg = Avx2.AlignRight(carry, reg, 1)
+                ^ Gfni.V256.GaloisFieldAffineTransform(gen0v, m, 0);
+        }
+
+        Span<byte> tmp = stackalloc byte[32];
+        reg.StoreUnsafe(ref MemoryMarshal.GetReference(tmp));
+        tmp.Slice(0, eccCount).CopyTo(ecc);
+    }
+#endif // NET10_0_OR_GREATER
+
+    // ---------------------------------------------------------------------------
+    // Lookup helpers
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// XOR of the four per-byte-position table entries for the packed input
+    /// <paramref name="x"/>: T0[x0] ^ T1[x1] ^ T2[x2] ^ T3[x3].
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint QuadLookup(ref uint table, uint x)
+        => Unsafe.Add(ref table, (nint)(x & 0xFF))
+         ^ Unsafe.Add(ref table, 256 + (nint)((x >> 8) & 0xFF))
+         ^ Unsafe.Add(ref table, 512 + (nint)((x >> 16) & 0xFF))
+         ^ Unsafe.Add(ref table, 768 + (nint)(x >> 24));
+
+#if NET10_0_OR_GREATER
+    /// <summary>Same as <see cref="QuadLookup"/> against a byte-offset region of the fused blob.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint BlobQuadLookup(ref byte blob, nint regionOffset, uint x)
+        => Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref blob, regionOffset + (nint)((x & 0xFF) * 4)))
+         ^ Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref blob, regionOffset + 1024 + (nint)(((x >> 8) & 0xFF) * 4)))
+         ^ Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref blob, regionOffset + 2048 + (nint)(((x >> 16) & 0xFF) * 4)))
+         ^ Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref blob, regionOffset + 3072 + (nint)((x >> 24) * 4)));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ulong ReadMatrix(ref ulong matrices, uint factor)
+        => Unsafe.Add(ref matrices, (nint)factor);
+#endif
+
+    // ---------------------------------------------------------------------------
+    // Table construction (all lazy, per eccCount; benign races — identical results,
+    // atomic reference assignment)
+    // ---------------------------------------------------------------------------
+
+    // Normal-domain generator coefficients (generator[1..eccCount], leading 1
+    // dropped), zero-padded to 32 bytes. GF-multiplying zero padding contributes 0,
+    // so padded lanes are no-ops in the vector kernels.
+    private static readonly byte[]?[] s_paddedGenCache = new byte[]?[33];
+
+    private static byte[] GetPaddedGenerator(int eccCount)
+    {
+        var cached = s_paddedGenCache[eccCount];
+        if (cached is not null) return cached;
+
+        Span<byte> generator = stackalloc byte[eccCount + 1];
+        GenerateGeneratorPolynomial(generator, eccCount);
+
+        var padded = new byte[32];
+        generator.Slice(1, eccCount).CopyTo(padded);
+
+        s_paddedGenCache[eccCount] = padded;
+        return padded;
+    }
+
+    // PSHUFB nibble-split GF(256) multiplication tables: for each factor c,
+    // 32 bytes = TLo (c·n for low nibble n) followed by THi (c·(n<<4) for high
+    // nibble n), so c·x = TLo[x & 0xF] ^ THi[x >> 4]. 256 factors × 32 B = 8 KB.
+    private static readonly byte[] s_nibbleMulTable = BuildNibbleMulTable();
+
+    private static byte[] BuildNibbleMulTable()
+    {
+        var table = new byte[256 * 32];
+        for (var c = 0; c < 256; c++)
+        {
+            for (var n = 0; n < 16; n++)
+            {
+                table[c * 32 + n] = GaloisField.Multiply((byte)c, (byte)n);
+                table[c * 32 + 16 + n] = GaloisField.Multiply((byte)c, (byte)(n << 4));
+            }
+        }
+        return table;
+    }
+
+    // Shuffle-ready nibble split of (gen >> s bytes) for s = 0..3, each as
+    // [loA|hiA|loB|hiB] 16-byte blocks (A = gen bytes 0..15, B = 16..31).
+    // Offsets below; 256 bytes per eccCount.
+    private const nuint NibGenLoA = 0;
+    private const nuint NibGenHiA = 16;
+    private const nuint NibGenLoB = 32;
+    private const nuint NibGenHiB = 48;
+    private const nuint NibGenS1LoA = 64;
+    private const nuint NibGenS1HiA = 80;
+    private const nuint NibGenS1LoB = 96;
+    private const nuint NibGenS1HiB = 112;
+    private const nuint NibGenS2LoA = 128;
+    private const nuint NibGenS2HiA = 144;
+    private const nuint NibGenS2LoB = 160;
+    private const nuint NibGenS2HiB = 176;
+    private const nuint NibGenS3LoA = 192;
+    private const nuint NibGenS3HiA = 208;
+    private const nuint NibGenS3LoB = 224;
+    private const nuint NibGenS3HiB = 240;
+
+    private static readonly byte[]?[] s_nibbleCache = new byte[]?[33];
+
+    private static byte[] GetNibbleTables(int eccCount)
+    {
+        var cached = s_nibbleCache[eccCount];
+        if (cached is not null) return cached;
+
+        var padded = GetPaddedGenerator(eccCount);
+        var t = new byte[256];
+        for (var shift = 0; shift < 4; shift++)
+        {
+            var baseOff = shift * 64;
+            for (var j = 0; j < 32; j++)
+            {
+                var idx = j + shift;
+                var v = idx < padded.Length ? padded[idx] : (byte)0;
+                var half = j >> 4; // 0 = A (bytes 0..15), 1 = B (bytes 16..31)
+                var lane = j & 15;
+                t[baseOff + half * 32 + lane] = (byte)(v & 0x0F);
+                t[baseOff + half * 32 + 16 + lane] = (byte)(v >> 4);
+            }
+        }
+
+        s_nibbleCache[eccCount] = t;
+        return t;
+    }
+
+    // Quad factor tables T: T_k[b] = packed division factors (f0..f3) produced by
+    // input byte b at position k with all other bytes zero. Factors for a quad are
+    // the XOR of the four entries (GF(2)-linearity). 4 KB per eccCount.
+    private static readonly uint[]?[] s_quadFactorCache = new uint[]?[33];
+
+    private static uint[] GetQuadFactorTables(int eccCount)
+    {
+        var cached = s_quadFactorCache[eccCount];
+        if (cached is not null) return cached;
+
+        var padded = GetPaddedGenerator(eccCount);
+        var g0 = padded[0];
+        var g1 = padded[1];
+        var g2 = padded[2];
+
+        var t = new uint[4 * 256];
+        for (var k = 0; k < 4; k++)
+        {
+            for (var b = 0; b < 256; b++)
+            {
+                // Run the factor recurrence with w = b at position k, zeros elsewhere:
+                // f0 = w0; f_j = w_j ^ Σ gen[j-1-m]·f_m
+                var w0 = k == 0 ? (byte)b : (byte)0;
+                var w1 = k == 1 ? (byte)b : (byte)0;
+                var w2 = k == 2 ? (byte)b : (byte)0;
+                var w3 = k == 3 ? (byte)b : (byte)0;
+
+                var f0 = w0;
+                var f1 = (byte)(w1 ^ GaloisField.Multiply(g0, f0));
+                var f2 = (byte)(w2 ^ GaloisField.Multiply(g1, f0) ^ GaloisField.Multiply(g0, f1));
+                var f3 = (byte)(w3 ^ GaloisField.Multiply(g2, f0) ^ GaloisField.Multiply(g1, f1) ^ GaloisField.Multiply(g0, f2));
+
+                t[k * 256 + b] = f0 | ((uint)f1 << 8) | ((uint)f2 << 16) | ((uint)f3 << 24);
+            }
+        }
+
+        s_quadFactorCache[eccCount] = t;
+        return t;
+    }
+
+    // Quad update tables U: U_k[b] = bytes 0..3 of factor f_k = b's contribution to
+    // the updated remainder register (padded[j + 3 - k]·b packed for j = 0..3).
+    private static readonly uint[]?[] s_quadUpdateCache = new uint[]?[33];
+
+    private static uint[] GetQuadUpdateTables(int eccCount)
+    {
+        var cached = s_quadUpdateCache[eccCount];
+        if (cached is not null) return cached;
+
+        var padded = GetPaddedGenerator(eccCount);
+        var t = new uint[4 * 256];
+        for (var k = 0; k < 4; k++)
+        {
+            for (var b = 0; b < 256; b++)
+            {
+                var v = 0u;
+                for (var j = 0; j < 4; j++)
+                {
+                    v |= (uint)GaloisField.Multiply(padded[j + 3 - k], (byte)b) << (j * 8);
+                }
+                t[k * 256 + b] = v;
+            }
+        }
+
+        s_quadUpdateCache[eccCount] = t;
+        return t;
+    }
+
+    // Composed T∘U tables: TU_k[b] = T(U_k[b]) — the next quad's factor contribution
+    // of current factor f_k = b, folding two dependent lookup rounds into one.
+    // Valid because T and U are GF(2)-linear maps.
+    private static readonly uint[]?[] s_composedTUCache = new uint[]?[33];
+
+    private static uint[] GetComposedTUTables(int eccCount)
+    {
+        var cached = s_composedTUCache[eccCount];
+        if (cached is not null) return cached;
+
+        var qf = GetQuadFactorTables(eccCount);
+        var uf = GetQuadUpdateTables(eccCount);
+
+        var t = new uint[4 * 256];
+        for (var k = 0; k < 4; k++)
+        {
+            for (var b = 0; b < 256; b++)
+            {
+                var u = uf[k * 256 + b];
+                t[k * 256 + b] = qf[u & 0xFF]
+                    ^ qf[256 + (int)((u >> 8) & 0xFF)]
+                    ^ qf[512 + (int)((u >> 16) & 0xFF)]
+                    ^ qf[768 + (int)(u >> 24)];
+            }
+        }
+
+        s_composedTUCache[eccCount] = t;
+        return t;
+    }
+
+#if NET10_0_OR_GREATER
+    // Fused per-eccCount blob for the GFNI kernel: quad-factor tables, composed TU
+    // tables and the padded generator behind a single pointer chase (measured ~13%
+    // on the smallest QR block vs separate arrays).
+    private const nint BlobQf = 0;      // 4 × 256 uints (4096 bytes)
+    private const nint BlobTu = 4096;   // 4 × 256 uints (4096 bytes)
+    private const nuint BlobGen = 8192; // 40 bytes: padded generator + shift headroom
+
+    private static readonly byte[]?[] s_blobCache = new byte[]?[33];
+
+    private static byte[] GetBlob(int eccCount)
+    {
+        var cached = s_blobCache[eccCount];
+        if (cached is not null) return cached;
+
+        var blob = new byte[8192 + 40];
+        MemoryMarshal.AsBytes(GetQuadFactorTables(eccCount).AsSpan()).CopyTo(blob.AsSpan((int)BlobQf, 4096));
+        MemoryMarshal.AsBytes(GetComposedTUTables(eccCount).AsSpan()).CopyTo(blob.AsSpan((int)BlobTu, 4096));
+        GetPaddedGenerator(eccCount).CopyTo(blob.AsSpan((int)BlobGen, 32)); // last 8 bytes stay 0
+
+        s_blobCache[eccCount] = blob;
+        return blob;
+    }
+
+    // GFNI multiply-by-f bit matrices (universal, 2 KB). gf2p8affineqb convention:
+    // qword byte (7-i) = matrix row for result bit i, row bit k = bit i of f·2^k
+    // (identity matrix = 0x0102040810204080).
+    private static readonly ulong[] s_gfniMatrix = BuildGfniMatrices();
+
+    private static ulong[] BuildGfniMatrices()
+    {
+        var t = new ulong[256];
+        for (var f = 0; f < 256; f++)
+        {
+            var m = 0UL;
+            for (var i = 0; i < 8; i++)
+            {
+                byte row = 0;
+                for (var k = 0; k < 8; k++)
+                {
+                    var prod = GaloisField.Multiply((byte)f, (byte)(1 << k));
+                    row |= (byte)(((prod >> i) & 1) << k);
+                }
+                m |= (ulong)row << ((7 - i) * 8);
+            }
+            t[f] = m;
+        }
+        return t;
+    }
+#endif // NET10_0_OR_GREATER
+}
+#endif // NET8_0_OR_GREATER

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.Simd.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.Simd.cs
@@ -72,7 +72,7 @@ internal static partial class EccBinaryEncoder
     {
         var nib = GetNibbleTables(eccCount);
         ref var nibRef = ref MemoryMarshal.GetArrayDataReference(nib);
-        ref var mulBase = ref MemoryMarshal.GetArrayDataReference(s_nibbleMulTable);
+        ref var mulBase = ref MemoryMarshal.GetArrayDataReference(_nibbleMulTable);
         ref var qf = ref MemoryMarshal.GetArrayDataReference(GetQuadFactorTables(eccCount));
         ref var tu = ref MemoryMarshal.GetArrayDataReference(GetComposedTUTables(eccCount));
         ref var dataRef = ref MemoryMarshal.GetReference(data);
@@ -152,7 +152,7 @@ internal static partial class EccBinaryEncoder
     {
         var nib = GetNibbleTables(eccCount);
         ref var nibRef = ref MemoryMarshal.GetArrayDataReference(nib);
-        ref var mulBase = ref MemoryMarshal.GetArrayDataReference(s_nibbleMulTable);
+        ref var mulBase = ref MemoryMarshal.GetArrayDataReference(_nibbleMulTable);
         ref var qf = ref MemoryMarshal.GetArrayDataReference(GetQuadFactorTables(eccCount));
         ref var tu = ref MemoryMarshal.GetArrayDataReference(GetComposedTUTables(eccCount));
         ref var dataRef = ref MemoryMarshal.GetReference(data);
@@ -298,7 +298,7 @@ internal static partial class EccBinaryEncoder
     private static void GfniCore128(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
     {
         ref var blob = ref MemoryMarshal.GetArrayDataReference(GetBlob(eccCount));
-        ref var gm = ref MemoryMarshal.GetArrayDataReference(s_gfniMatrix);
+        ref var gm = ref MemoryMarshal.GetArrayDataReference(_gfniMatrix);
         ref var dataRef = ref MemoryMarshal.GetReference(data);
 
         // Raw shifted generator vectors: (gen >> s)[j] = gen[j + s]
@@ -365,7 +365,7 @@ internal static partial class EccBinaryEncoder
     private static void GfniCore256(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
     {
         ref var blob = ref MemoryMarshal.GetArrayDataReference(GetBlob(eccCount));
-        ref var gm = ref MemoryMarshal.GetArrayDataReference(s_gfniMatrix);
+        ref var gm = ref MemoryMarshal.GetArrayDataReference(_gfniMatrix);
         ref var dataRef = ref MemoryMarshal.GetReference(data);
 
         var gen0v = Vector256.LoadUnsafe(ref blob, BlobGen);
@@ -473,11 +473,11 @@ internal static partial class EccBinaryEncoder
     // Normal-domain generator coefficients (generator[1..eccCount], leading 1
     // dropped), zero-padded to 32 bytes. GF-multiplying zero padding contributes 0,
     // so padded lanes are no-ops in the vector kernels.
-    private static readonly byte[]?[] s_paddedGenCache = new byte[]?[33];
+    private static readonly byte[]?[] _paddedGenCache = new byte[]?[33];
 
     private static byte[] GetPaddedGenerator(int eccCount)
     {
-        var cached = s_paddedGenCache[eccCount];
+        var cached = _paddedGenCache[eccCount];
         if (cached is not null) return cached;
 
         Span<byte> generator = stackalloc byte[eccCount + 1];
@@ -486,14 +486,14 @@ internal static partial class EccBinaryEncoder
         var padded = new byte[32];
         generator.Slice(1, eccCount).CopyTo(padded);
 
-        Volatile.Write(ref s_paddedGenCache[eccCount], padded);
+        Volatile.Write(ref _paddedGenCache[eccCount], padded);
         return padded;
     }
 
     // PSHUFB nibble-split GF(256) multiplication tables: for each factor c,
     // 32 bytes = TLo (c·n for low nibble n) followed by THi (c·(n<<4) for high
     // nibble n), so c·x = TLo[x & 0xF] ^ THi[x >> 4]. 256 factors × 32 B = 8 KB.
-    private static readonly byte[] s_nibbleMulTable = BuildNibbleMulTable();
+    private static readonly byte[] _nibbleMulTable = BuildNibbleMulTable();
 
     private static byte[] BuildNibbleMulTable()
     {
@@ -529,11 +529,11 @@ internal static partial class EccBinaryEncoder
     private const nuint NibGenS3LoB = 224;
     private const nuint NibGenS3HiB = 240;
 
-    private static readonly byte[]?[] s_nibbleCache = new byte[]?[33];
+    private static readonly byte[]?[] _nibbleCache = new byte[]?[33];
 
     private static byte[] GetNibbleTables(int eccCount)
     {
-        var cached = s_nibbleCache[eccCount];
+        var cached = _nibbleCache[eccCount];
         if (cached is not null) return cached;
 
         var padded = GetPaddedGenerator(eccCount);
@@ -552,18 +552,18 @@ internal static partial class EccBinaryEncoder
             }
         }
 
-        Volatile.Write(ref s_nibbleCache[eccCount], t);
+        Volatile.Write(ref _nibbleCache[eccCount], t);
         return t;
     }
 
     // Quad factor tables T: T_k[b] = packed division factors (f0..f3) produced by
     // input byte b at position k with all other bytes zero. Factors for a quad are
     // the XOR of the four entries (GF(2)-linearity). 4 KB per eccCount.
-    private static readonly uint[]?[] s_quadFactorCache = new uint[]?[33];
+    private static readonly uint[]?[] _quadFactorCache = new uint[]?[33];
 
     private static uint[] GetQuadFactorTables(int eccCount)
     {
-        var cached = s_quadFactorCache[eccCount];
+        var cached = _quadFactorCache[eccCount];
         if (cached is not null) return cached;
 
         var padded = GetPaddedGenerator(eccCount);
@@ -592,17 +592,17 @@ internal static partial class EccBinaryEncoder
             }
         }
 
-        Volatile.Write(ref s_quadFactorCache[eccCount], t);
+        Volatile.Write(ref _quadFactorCache[eccCount], t);
         return t;
     }
 
     // Quad update tables U: U_k[b] = bytes 0..3 of factor f_k = b's contribution to
     // the updated remainder register (padded[j + 3 - k]·b packed for j = 0..3).
-    private static readonly uint[]?[] s_quadUpdateCache = new uint[]?[33];
+    private static readonly uint[]?[] _quadUpdateCache = new uint[]?[33];
 
     private static uint[] GetQuadUpdateTables(int eccCount)
     {
-        var cached = s_quadUpdateCache[eccCount];
+        var cached = _quadUpdateCache[eccCount];
         if (cached is not null) return cached;
 
         var padded = GetPaddedGenerator(eccCount);
@@ -620,18 +620,18 @@ internal static partial class EccBinaryEncoder
             }
         }
 
-        Volatile.Write(ref s_quadUpdateCache[eccCount], t);
+        Volatile.Write(ref _quadUpdateCache[eccCount], t);
         return t;
     }
 
     // Composed T∘U tables: TU_k[b] = T(U_k[b]) — the next quad's factor contribution
     // of current factor f_k = b, folding two dependent lookup rounds into one.
     // Valid because T and U are GF(2)-linear maps.
-    private static readonly uint[]?[] s_composedTUCache = new uint[]?[33];
+    private static readonly uint[]?[] _composedTUCache = new uint[]?[33];
 
     private static uint[] GetComposedTUTables(int eccCount)
     {
-        var cached = s_composedTUCache[eccCount];
+        var cached = _composedTUCache[eccCount];
         if (cached is not null) return cached;
 
         var qf = GetQuadFactorTables(eccCount);
@@ -650,7 +650,7 @@ internal static partial class EccBinaryEncoder
             }
         }
 
-        Volatile.Write(ref s_composedTUCache[eccCount], t);
+        Volatile.Write(ref _composedTUCache[eccCount], t);
         return t;
     }
 
@@ -662,11 +662,11 @@ internal static partial class EccBinaryEncoder
     private const nint BlobTu = 4096;   // 4 × 256 uints (4096 bytes)
     private const nuint BlobGen = 8192; // 40 bytes: padded generator + shift headroom
 
-    private static readonly byte[]?[] s_blobCache = new byte[]?[33];
+    private static readonly byte[]?[] _blobCache = new byte[]?[33];
 
     private static byte[] GetBlob(int eccCount)
     {
-        var cached = s_blobCache[eccCount];
+        var cached = _blobCache[eccCount];
         if (cached is not null) return cached;
 
         var blob = new byte[8192 + 40];
@@ -674,14 +674,14 @@ internal static partial class EccBinaryEncoder
         MemoryMarshal.AsBytes(GetComposedTUTables(eccCount).AsSpan()).CopyTo(blob.AsSpan((int)BlobTu, 4096));
         GetPaddedGenerator(eccCount).CopyTo(blob.AsSpan((int)BlobGen, 32)); // last 8 bytes stay 0
 
-        Volatile.Write(ref s_blobCache[eccCount], blob);
+        Volatile.Write(ref _blobCache[eccCount], blob);
         return blob;
     }
 
     // GFNI multiply-by-f bit matrices (universal, 2 KB). gf2p8affineqb convention:
     // qword byte (7-i) = matrix row for result bit i, row bit k = bit i of f·2^k
     // (identity matrix = 0x0102040810204080).
-    private static readonly ulong[] s_gfniMatrix = BuildGfniMatrices();
+    private static readonly ulong[] _gfniMatrix = BuildGfniMatrices();
 
     private static ulong[] BuildGfniMatrices()
     {

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.cs
@@ -1,3 +1,6 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 namespace SkiaSharp.QrCode.Internals.BinaryEncoders;
 
 /// <summary>
@@ -5,8 +8,12 @@ namespace SkiaSharp.QrCode.Internals.BinaryEncoders;
 /// </summary>
 /// <remarks>
 /// This encoder implements the Reed-Solomon error correction algorithm as specified in ISO/IEC 18004 Section 8.5.
+/// The public entry point dispatches to the fastest kernel the runtime supports:
+/// GFNI (net10.0+, ~64x over the naive form), SSSE3 (net8.0+, ~52x), or a portable
+/// scalar kernel (~4.4x) used on netstandard, ARM64, and pre-SSSE3 x86.
+/// All kernels produce byte-identical output; see the kernel parity tests.
 /// </remarks>
-internal static class EccBinaryEncoder
+internal static partial class EccBinaryEncoder
 {
     // Algorithm (ISO/IEC 18004 Section 8.5):
     // 1. Create Reed-solomon generator polynomial G(x) = G(256) = (x-α^0)(x-α^1)...(x-α^(n-1))
@@ -19,15 +26,14 @@ internal static class EccBinaryEncoder
     // - Data: [64, 86, 134, 86] → M(x) = 64x^3 + 86x^2 + 134x + 86
     // - ECC count: 10
     // - Generator: G(x) = (x-α^0)(x-α^1)...(x-α^9)
-    // - Result: 10 ECC codewords [196, 35, 39, 119, 235, 215, 231, 226, 93, 23]
+    // - Result: 10 ECC codewords
 
     /// <summary>
     /// Calculates error correction codewords using Reed-Solomon algorithm.
     /// </summary>
-    /// <param name="data">Binary string representing data codewords (multiple of 8 bits).</param>
+    /// <param name="data">Data codewords.</param>
     /// <param name="ecc">Output buffer for ECC codewords (must be at least <paramref name="eccCount"/> bytes).</param>
     /// <param name="eccCount">Number of error correction codewords to generate.</param>
-    /// <returns>List of ECC codewords as binary strings (8 bits each).</returns>
     /// <remarks>
     /// Uses Galois Field GF(256) arithmetic from <see cref="GaloisField"/> for polynomial operations.
     /// The generator polynomial is built using primitive polynomial x^8 + x^4 + x^3 + x^2 + 1 (0x11D).
@@ -39,29 +45,92 @@ internal static class EccBinaryEncoder
         if (eccCount < 1 || eccCount > 255)
             throw new ArgumentOutOfRangeException(nameof(eccCount), $"ECC count must be 1-255, got {eccCount}");
 
-        // Generate generator polynomial
-        Span<byte> generator = stackalloc byte[eccCount + 1];
-        GenerateGeneratorPolynomial(generator, eccCount);
+#if NET8_0_OR_GREATER
+        // QR codes use at most 30 ECC codewords per block, so the vectorized kernels
+        // (which keep the remainder register in one or two vector registers) cover
+        // every real input; the <= 32 guard is a safety net for non-QR callers.
+        if (eccCount <= 32 && System.Runtime.Intrinsics.X86.Ssse3.IsSupported)
+        {
+            CalculateEccSimd(data, ecc, eccCount);
+            return;
+        }
+#endif
+        CalculateEccScalar(data, ecc, eccCount);
+    }
 
-        // Initialize message polynomial from data bits (data + zero padding for ECC)
+    /// <summary>
+    /// Portable scalar kernel. Runs on every target (netstandard2.0+, ARM64, old x86).
+    /// </summary>
+    /// <remarks>
+    /// Two optimizations over the naive polynomial division, both measured (~4.4x combined):
+    /// - The generator polynomial depends only on <paramref name="eccCount"/> and QR uses a
+    ///   small fixed set of counts, so it is cached in log domain per count. This removes the
+    ///   O(eccCount²) per-call construction and lets the inner loop do a single Exp lookup
+    ///   instead of a full GF multiply (2 Log lookups + zero checks) per element.
+    /// - Table and buffer accesses go through refs so the JIT emits no bounds checks in the
+    ///   inner loop (measured ~17% on top of the caching).
+    /// </remarks>
+    internal static void CalculateEccScalar(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        var logGen = GetLogGenerator(eccCount);
+
+        // Message polynomial: data followed by eccCount zero bytes; the division
+        // remainder accumulates in the zero tail.
         Span<byte> message = stackalloc byte[data.Length + eccCount];
         data.CopyTo(message);
 
-        // Polynomial division in GF(256)
+        ref var exp = ref MemoryMarshal.GetReference(GaloisField.Exp);
+        ref var log = ref MemoryMarshal.GetReference(GaloisField.Log);
+        ref var gen = ref MemoryMarshal.GetReference(logGen.AsSpan());
+        ref var msg = ref MemoryMarshal.GetReference(message);
+
         for (var i = 0; i < data.Length; i++)
         {
-            var coefficient = message[i];
+            var coefficient = Unsafe.Add(ref msg, i);
             if (coefficient == 0) continue;
 
-            // XOR with generator polynomial scaled by lead coefficient
+            int logC = Unsafe.Add(ref log, coefficient);
+            ref var target = ref Unsafe.Add(ref msg, i + 1);
             for (var j = 0; j < eccCount; j++)
             {
-                message[i + j + 1] ^= GaloisField.Multiply(generator[j + 1], coefficient);
+                // message[i + j + 1] ^= generator[j + 1] · coefficient, in log domain.
+                // Exp is 512 entries, so logGen[j] + logC (max 508) needs no % 255.
+                Unsafe.Add(ref target, j) ^= Unsafe.Add(ref exp, Unsafe.Add(ref gen, j) + logC);
             }
         }
 
-        // Extract ECC bytes (remainder of division)
         message.Slice(data.Length, eccCount).CopyTo(ecc);
+    }
+
+    // Log-domain generator polynomial cache, indexed by eccCount (1..255).
+    // logGen[j] = Log[generator[j + 1]] (the leading 1 coefficient is implicit).
+    // Benign race: concurrent builds produce identical arrays and reference
+    // assignment is atomic.
+    private static readonly byte[]?[] s_logGenCache = new byte[]?[256];
+
+    private static byte[] GetLogGenerator(int eccCount)
+    {
+        var cached = s_logGenCache[eccCount];
+        if (cached is not null) return cached;
+
+        Span<byte> generator = stackalloc byte[eccCount + 1];
+        GenerateGeneratorPolynomial(generator, eccCount);
+
+        var logGen = new byte[eccCount];
+        for (var j = 0; j < eccCount; j++)
+        {
+            var coefficient = generator[j + 1];
+            if (coefficient == 0)
+            {
+                // Reed-Solomon generator polynomials (distinct roots α^0..α^(n-1)) have no
+                // zero coefficients; the log-domain representation relies on that.
+                throw new InvalidOperationException($"RS generator polynomial has zero coefficient at {j + 1} for eccCount={eccCount}.");
+            }
+            logGen[j] = GaloisField.Log[coefficient];
+        }
+
+        s_logGenCache[eccCount] = logGen;
+        return logGen;
     }
 
     /// <summary>

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.cs
@@ -73,6 +73,14 @@ internal static partial class EccBinaryEncoder
     internal static void CalculateEccScalar(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
     {
         var logGen = GetLogGenerator(eccCount);
+        if (logGen is null)
+        {
+            // eccCount == 255 degenerates to G(x) = x^255 + 1, which has zero coefficients
+            // and therefore no log-domain representation. Never produced by QR; handled by
+            // the naive kernel so every documented eccCount stays correct.
+            CalculateEccNaive(data, ecc, eccCount);
+            return;
+        }
 
         // Message polynomial: data followed by eccCount zero bytes; the division
         // remainder accumulates in the zero tail.
@@ -102,16 +110,58 @@ internal static partial class EccBinaryEncoder
         message.Slice(data.Length, eccCount).CopyTo(ecc);
     }
 
+    /// <summary>
+    /// Naive polynomial division (the pre-optimization implementation). Used only when
+    /// the generator polynomial has no log-domain representation (eccCount == 255).
+    /// </summary>
+    private static void CalculateEccNaive(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        Span<byte> generator = stackalloc byte[eccCount + 1];
+        GenerateGeneratorPolynomial(generator, eccCount);
+
+        Span<byte> message = stackalloc byte[data.Length + eccCount];
+        data.CopyTo(message);
+
+        for (var i = 0; i < data.Length; i++)
+        {
+            var coefficient = message[i];
+            if (coefficient == 0) continue;
+
+            for (var j = 0; j < eccCount; j++)
+            {
+                message[i + j + 1] ^= GaloisField.Multiply(generator[j + 1], coefficient);
+            }
+        }
+
+        message.Slice(data.Length, eccCount).CopyTo(ecc);
+    }
+
     // Log-domain generator polynomial cache, indexed by eccCount (1..255).
     // logGen[j] = Log[generator[j + 1]] (the leading 1 coefficient is implicit).
-    // Benign race: concurrent builds produce identical arrays and reference
-    // assignment is atomic.
+    // A sentinel empty array marks counts whose generator cannot be represented in
+    // log domain. Benign race: concurrent builds produce identical arrays; published
+    // with Volatile.Write so readers on weakly-ordered runtimes never observe a
+    // partially initialized array.
     private static readonly byte[]?[] s_logGenCache = new byte[]?[256];
+    private static readonly byte[] s_logGenUnrepresentable = [];
 
-    private static byte[] GetLogGenerator(int eccCount)
+    /// <summary>
+    /// Returns the cached log-domain generator polynomial, or null when it has no
+    /// log-domain representation.
+    /// </summary>
+    /// <remarks>
+    /// Reed-Solomon generator polynomials have all-nonzero coefficients for
+    /// eccCount ≤ 254: G(x) is itself a codeword of the length-255 RS code with
+    /// minimum distance eccCount + 1 (MDS), so its weight must be ≥ eccCount + 1 —
+    /// every one of its eccCount + 1 coefficients. The single exception is
+    /// eccCount == 255, where G(x) = Π(x - α^i) over all nonzero field elements
+    /// collapses to x^255 + 1 (254 zero coefficients). Verified by exhaustive scan
+    /// over eccCount 1..255.
+    /// </remarks>
+    private static byte[]? GetLogGenerator(int eccCount)
     {
         var cached = s_logGenCache[eccCount];
-        if (cached is not null) return cached;
+        if (cached is not null) return cached.Length == 0 ? null : cached;
 
         Span<byte> generator = stackalloc byte[eccCount + 1];
         GenerateGeneratorPolynomial(generator, eccCount);
@@ -122,14 +172,13 @@ internal static partial class EccBinaryEncoder
             var coefficient = generator[j + 1];
             if (coefficient == 0)
             {
-                // Reed-Solomon generator polynomials (distinct roots α^0..α^(n-1)) have no
-                // zero coefficients; the log-domain representation relies on that.
-                throw new InvalidOperationException($"RS generator polynomial has zero coefficient at {j + 1} for eccCount={eccCount}.");
+                Volatile.Write(ref s_logGenCache[eccCount], s_logGenUnrepresentable);
+                return null;
             }
             logGen[j] = GaloisField.Log[coefficient];
         }
 
-        s_logGenCache[eccCount] = logGen;
+        Volatile.Write(ref s_logGenCache[eccCount], logGen);
         return logGen;
     }
 

--- a/tests/SkiaSharp.QrCode.Tests/EccBinaryEncoderKernelParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/EccBinaryEncoderKernelParityTest.cs
@@ -1,0 +1,177 @@
+using SkiaSharp.QrCode.Internals;
+using SkiaSharp.QrCode.Internals.BinaryEncoders;
+using Xunit;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// Verifies that every ECC kernel (scalar, SSSE3, GFNI) produces byte-identical
+/// output to a naive reference implementation of ISO/IEC 18004 Section 8.5
+/// polynomial division. CalculateECC dispatches by hardware capability, so these
+/// tests exercise each kernel directly in addition to the public entry point.
+/// </summary>
+public class EccBinaryEncoderKernelParityTest
+{
+    // (dataLength, eccCount) pairs covering QR extremes and boundary conditions:
+    // smallest/largest real blocks, the 16/17 register-width split, eccCount 1,
+    // data shorter than one 4-byte quad, and data not a multiple of 4.
+    public static TheoryData<int, int> Combos => new()
+    {
+        { 1, 1 },
+        { 1, 7 },
+        { 3, 10 },
+        { 16, 10 },   // version 1-M block
+        { 19, 16 },   // eccCount at the 128-bit register boundary
+        { 20, 17 },   // eccCount just above the boundary
+        { 34, 28 },
+        { 119, 30 },  // version 40-L block
+        { 2956, 30 }, // far beyond any single QR block (large-data safety)
+    };
+
+    [Theory]
+    [MemberData(nameof(Combos))]
+    public void CalculateECC_MatchesNaiveReference(int dataLength, int eccCount)
+    {
+        foreach (var data in EnumerateInputs(dataLength))
+        {
+            var expected = new byte[eccCount];
+            NaiveReferenceECC(data, expected, eccCount);
+
+            var actual = new byte[eccCount];
+            EccBinaryEncoder.CalculateECC(data, actual, eccCount);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Combos))]
+    public void ScalarKernel_MatchesNaiveReference(int dataLength, int eccCount)
+    {
+        foreach (var data in EnumerateInputs(dataLength))
+        {
+            var expected = new byte[eccCount];
+            NaiveReferenceECC(data, expected, eccCount);
+
+            var actual = new byte[eccCount];
+            EccBinaryEncoder.CalculateEccScalar(data, actual, eccCount);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Combos))]
+    public void Ssse3Kernel_MatchesNaiveReference(int dataLength, int eccCount)
+    {
+        Assert.SkipUnless(System.Runtime.Intrinsics.X86.Ssse3.IsSupported, "SSSE3 not supported on this machine");
+
+        foreach (var data in EnumerateInputs(dataLength))
+        {
+            var expected = new byte[eccCount];
+            NaiveReferenceECC(data, expected, eccCount);
+
+            var actual = new byte[eccCount];
+            EccBinaryEncoder.CalculateEccSsse3(data, actual, eccCount);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+#if NET10_0_OR_GREATER
+    [Theory]
+    [MemberData(nameof(Combos))]
+    public void GfniKernel_MatchesNaiveReference(int dataLength, int eccCount)
+    {
+        Assert.SkipUnless(System.Runtime.Intrinsics.X86.Gfni.IsSupported, "GFNI not supported on this machine");
+
+        foreach (var data in EnumerateInputs(dataLength))
+        {
+            var expected = new byte[eccCount];
+            NaiveReferenceECC(data, expected, eccCount);
+
+            var actual = new byte[eccCount];
+            EccBinaryEncoder.CalculateEccGfni(data, actual, eccCount);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+#endif
+
+    [Fact]
+    public void CalculateECC_EccCountAboveVectorLimit_UsesScalarPath()
+    {
+        // eccCount > 32 bypasses the vector kernels; verify the dispatch stays correct.
+        var data = new byte[50];
+        new Random(7).NextBytes(data);
+        var eccCount = 40;
+
+        var expected = new byte[eccCount];
+        NaiveReferenceECC(data, expected, eccCount);
+
+        var actual = new byte[eccCount];
+        EccBinaryEncoder.CalculateECC(data, actual, eccCount);
+
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Input variations per size: seeded random (several seeds), all-zero
+    /// (exercises every zero-skip path), and all-0xFF.
+    /// </summary>
+    private static IEnumerable<byte[]> EnumerateInputs(int dataLength)
+    {
+        for (var seed = 0; seed < 3; seed++)
+        {
+            var data = new byte[dataLength];
+            new Random(seed).NextBytes(data);
+            yield return data;
+        }
+
+        yield return new byte[dataLength]; // all zeros
+
+        var ones = new byte[dataLength];
+        ones.AsSpan().Fill(0xFF);
+        yield return ones;
+    }
+
+    /// <summary>
+    /// Naive ISO/IEC 18004 Section 8.5 polynomial division, kept deliberately
+    /// simple and independent from the production kernels: builds the generator
+    /// polynomial per call and multiplies element-wise via GaloisField.Multiply.
+    /// </summary>
+    private static void NaiveReferenceECC(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        // Generator polynomial (x - α^0)(x - α^1)...(x - α^(eccCount-1))
+        var generator = new byte[eccCount + 1];
+        generator[0] = 1;
+        var temp = new byte[generator.Length];
+        for (var i = 0; i < eccCount; i++)
+        {
+            Array.Clear(temp);
+            for (var j = 0; j <= i; j++)
+            {
+                var coefficient = generator[j];
+                if (coefficient == 0) continue;
+                temp[j] ^= coefficient;
+                temp[j + 1] ^= GaloisField.Multiply(coefficient, GaloisField.Exp[i]);
+            }
+            temp.CopyTo(generator.AsSpan());
+        }
+
+        // Polynomial division
+        var message = new byte[data.Length + eccCount];
+        data.CopyTo(message);
+        for (var i = 0; i < data.Length; i++)
+        {
+            var coefficient = message[i];
+            if (coefficient == 0) continue;
+            for (var j = 0; j < eccCount; j++)
+            {
+                message[i + j + 1] ^= GaloisField.Multiply(generator[j + 1], coefficient);
+            }
+        }
+
+        message.AsSpan(data.Length, eccCount).CopyTo(ecc);
+    }
+}

--- a/tests/SkiaSharp.QrCode.Tests/EccBinaryEncoderKernelParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/EccBinaryEncoderKernelParityTest.cs
@@ -115,6 +115,29 @@ public class EccBinaryEncoderKernelParityTest
         Assert.Equal(expected, actual);
     }
 
+    [Theory]
+    [InlineData(254)] // largest eccCount whose generator is log-domain representable
+    [InlineData(255)] // generator degenerates to x^255 + 1 (zero coefficients) — naive fallback
+    public void CalculateECC_MaxEccCounts_MatchesNaiveReference(int eccCount)
+    {
+        // eccCount == 255 is the only count whose generator polynomial has zero
+        // coefficients (all others are all-nonzero by the MDS property), so it cannot
+        // use the log-domain fast path. Both counts must still produce correct ECC.
+        foreach (var data in EnumerateInputs(64))
+        {
+            var expected = new byte[eccCount];
+            NaiveReferenceECC(data, expected, eccCount);
+
+            var viaPublicApi = new byte[eccCount];
+            EccBinaryEncoder.CalculateECC(data, viaPublicApi, eccCount);
+            Assert.Equal(expected, viaPublicApi);
+
+            var viaScalarKernel = new byte[eccCount];
+            EccBinaryEncoder.CalculateEccScalar(data, viaScalarKernel, eccCount);
+            Assert.Equal(expected, viaScalarKernel);
+        }
+    }
+
     /// <summary>
     /// Input variations per size: seeded random (several seeds), all-zero
     /// (exercises every zero-skip path), and all-0xFF.


### PR DESCRIPTION
## Summary

Rewrites the Reed-Solomon ECC encoder (`EccBinaryEncoder.CalculateECC`) with
hardware-accelerated kernels selected at runtime, plus a faster portable scalar
fallback. Output is byte-identical to the previous implementation; no public API
changes.

## Motivation

ECC calculation was the largest single hot spot inside `CreateQrCode` that could
be optimized without touching the QR pipeline structure. The kernel was tuned
through a benchmark-driven loop (BenchmarkDotNet + JIT disassembly analysis over
21 variants), and the three winners are shipped here:

- **GFNI** (net10.0, Ice Lake+/Zen 4+): remainder register kept in vector
  registers, 4 data bytes per iteration via GF(2)-linearized factor tables,
  software-pipelined so the vector update stays off the critical chain, and
  `gf2p8affineqb` for the GF(256) multiply — ~25-69x over the previous kernel.
- **SSSE3** (net8.0+, any x64 incl. AVX2-only CPUs): same structure with the
  classic PSHUFB nibble-split multiply — ~16-57x.
- **Scalar** (netstandard2.0/2.1, ARM64, pre-SSSE3): cached log-domain generator
  polynomial + bounds-check-free inner loop — ~4.6x.

## Expected behavior

- Byte-identical ECC output on every path (new parity tests compare all three
  kernels against a naive ISO/IEC 18004 §8.5 reference across sizes, seeds, and
  edge inputs; existing ISO test vectors unchanged).
- Runtime dispatch: GFNI → SSSE3 → scalar, decided by `IsSupported` checks;
  eccCount > 32 (never produced by QR) also routes to scalar.
- NativeAOT/trimming safe: no reflection or dynamic codegen; verified that a
  NativeAOT publish produces bit-identical QR matrices to CoreCLR, and ILC
  handles the GFNI startup check (`IlcInstructionSet=gfni` also accepted).
- Memory: lookup tables build lazily, ~8 KB (SSSE3) / ~2 KB (GFNI) static plus
  ~10-20 KB per distinct ECC block size actually used. Zero per-call allocations
  (unchanged).

## Benchmarks

End-to-end via public API (`QRCodeGenerator.CreateQrCode`, `QrCodeEndToEnd`
benchmark, .NET 10.0.9, Ryzen 9 7950X3D, LaunchCount=3 / IterationCount=15):

| Scenario | main | this PR | Δ |
|---|---:|---:|---:|
| Short_M (~version 1) | 16.56 us | 16.14 us | −2.5% |
| Url_M (~version 5) | 83.68 us | 78.74 us | −5.9% |
| Long_L (version 40, level L) | 3,214.26 us | 2,861.48 us | **−11.0%** |
| Long_H (version 40, level H) | 3,043.64 us | 2,839.25 us | −6.7% |

Allocations unchanged in all scenarios. ECC is only a single-digit percentage of
`CreateQrCode` (mask evaluation dominates), which bounds the end-to-end gain.

Kernel-level (isolated `CalculateECC`, same machine; v1M = 16-byte block/10 ecc,
v40L = 119-byte block/30 ecc):

| Kernel | v1M block | v40L block | Speedup (v40L) |
|---|---:|---:|---:|
| previous implementation | 421.3 ns | 7,525.2 ns | 1.0x |
| scalar (this PR, fallback) | 90.7 ns | 1,635.0 ns | 4.6x |
| SSSE3 (this PR) | 25.6 ns | 132.6 ns | 56.7x |
| GFNI (this PR) | 17.2 ns | 109.5 ns | 68.7x |