### PR TITLE
feat: improve memory allocation during creating QRCodeData

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/ModulePlacer.Masking.cs
+++ b/src/SkiaSharp.QrCode/Internals/ModulePlacer.Masking.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -98,8 +99,8 @@ internal static partial class ModulePlacer
             var bitOffset = y * size;
             var byteOff = bitOffset >> 3;
             var sh = bitOffset & 7;
-            var u0 = MemoryMarshal.Read<ulong>(padded.Slice(byteOff));
-            var u1 = MemoryMarshal.Read<ulong>(padded.Slice(byteOff + 8));
+            var u0 = NormalizeEndianness(MemoryMarshal.Read<ulong>(padded.Slice(byteOff)));
+            var u1 = NormalizeEndianness(MemoryMarshal.Read<ulong>(padded.Slice(byteOff + 8)));
             var blocked = sh == 0 ? u0 : (u0 >> sh) | (u1 << (64 - sh));
             allowed[y] = ~blocked & rowMask;
         }
@@ -291,7 +292,7 @@ internal static partial class ModulePlacer
         var c = 0;
         for (; c + 8 <= row.Length; c += 8)
         {
-            var u = MemoryMarshal.Read<ulong>(row.Slice(c));
+            var u = NormalizeEndianness(MemoryMarshal.Read<ulong>(row.Slice(c)));
             w |= ((u * 0x0102040810204080UL) >> 56) << c;
         }
         for (; c < row.Length; c++)
@@ -321,8 +322,10 @@ internal static partial class ModulePlacer
             spread |= spread >> 1;
             spread &= 0x0101010101010101UL;
             ref var p = ref Unsafe.Add(ref rowRef, c);
+            // cur round-trips through the same byte order, so only the spread
+            // (logical little-endian) needs normalizing before the XOR store.
             var cur = Unsafe.ReadUnaligned<ulong>(ref p);
-            Unsafe.WriteUnaligned(ref p, cur ^ spread);
+            Unsafe.WriteUnaligned(ref p, cur ^ NormalizeEndianness(spread));
         }
         for (; c < row.Length; c++)
         {
@@ -689,8 +692,10 @@ internal static partial class ModulePlacer
                 spread |= spread >> 1;
                 spread &= 0x0101010101010101UL;
                 ref var p = ref Unsafe.Add(ref rowRef, c);
+                // cur round-trips through the same byte order, so only the spread
+                // (logical little-endian) needs normalizing before the XOR store.
                 var cur = Unsafe.ReadUnaligned<ulong>(ref p);
-                Unsafe.WriteUnaligned(ref p, cur ^ spread);
+                Unsafe.WriteUnaligned(ref p, cur ^ NormalizeEndianness(spread));
             }
             for (; c < wordEnd; c++)
             {
@@ -720,6 +725,16 @@ internal static partial class ModulePlacer
         var nextMultipleOf5 = Math.Abs((int)Math.Ceiling(percent / 5) * 5 - 50) / 5;
         return Math.Min(prevMultipleOf5, nextMultipleOf5) * 10;
     }
+
+    /// <summary>
+    /// Maps between machine byte order and the logical little-endian order the
+    /// SWAR pack/unpack constants assume (memory offset k = ulong byte k).
+    /// The same swap works for both reads and writes; BitConverter.IsLittleEndian
+    /// is a JIT-time constant, so little-endian codegen is unaffected.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ulong NormalizeEndianness(ulong value)
+        => BitConverter.IsLittleEndian ? value : BinaryPrimitives.ReverseEndianness(value);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int PopCount(ulong value)
@@ -889,7 +904,7 @@ internal static partial class ModulePlacer
             var c = 0;
             for (; c + 8 <= row.Length; c += 8)
             {
-                var u = MemoryMarshal.Read<ulong>(row.Slice(c));
+                var u = NormalizeEndianness(MemoryMarshal.Read<ulong>(row.Slice(c)));
                 var bits = (u * 0x0102040810204080UL) >> 56;
                 if (c < 64) w0 |= bits << c;
                 else if (c < 128) w1 |= bits << (c - 64);
@@ -916,14 +931,14 @@ internal static partial class ModulePlacer
         {
             var byteOff = bitOffset >> 3;
             var sh = bitOffset & 7;
-            var u0 = MemoryMarshal.Read<ulong>(data.Slice(byteOff));
-            var u1 = MemoryMarshal.Read<ulong>(data.Slice(byteOff + 8));
-            var u2 = MemoryMarshal.Read<ulong>(data.Slice(byteOff + 16));
+            var u0 = NormalizeEndianness(MemoryMarshal.Read<ulong>(data.Slice(byteOff)));
+            var u1 = NormalizeEndianness(MemoryMarshal.Read<ulong>(data.Slice(byteOff + 8)));
+            var u2 = NormalizeEndianness(MemoryMarshal.Read<ulong>(data.Slice(byteOff + 16)));
             if (sh == 0)
             {
                 return new Row192(u0, u1, u2);
             }
-            var u3 = MemoryMarshal.Read<ulong>(data.Slice(byteOff + 24));
+            var u3 = NormalizeEndianness(MemoryMarshal.Read<ulong>(data.Slice(byteOff + 24)));
             var inv = 64 - sh;
             return new Row192((u0 >> sh) | (u1 << inv), (u1 >> sh) | (u2 << inv), (u2 >> sh) | (u3 << inv));
         }

--- a/src/SkiaSharp.QrCode/QRCodeData.cs
+++ b/src/SkiaSharp.QrCode/QRCodeData.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -474,7 +475,10 @@ public class QRCodeData
 
         // Unpack 8 modules per step: replicate the payload byte across a ulong,
         // isolate each bit on its byte's diagonal, then OR-cascade down to bit 0
-        // so byte k of the ulong becomes module bit (7-k) as 0/1.
+        // so byte k of the ulong becomes module bit (7-k) as 0/1. The gather
+        // constants assume little-endian byte order (ulong byte k = memory
+        // offset k); reverse on big-endian targets — the check is a JIT-time
+        // constant, so little-endian codegen is unaffected.
         ref var destRef = ref MemoryMarshal.GetReference(destination);
         var m = 0;
         for (; m + 8 <= totalModules; m += 8)
@@ -484,6 +488,10 @@ public class QRCodeData
             spread |= spread >> 2;
             spread |= spread >> 1;
             spread &= 0x0101010101010101UL;
+            if (!BitConverter.IsLittleEndian)
+            {
+                spread = BinaryPrimitives.ReverseEndianness(spread);
+            }
             Unsafe.WriteUnaligned(ref Unsafe.Add(ref destRef, m), spread);
         }
         for (; m < totalModules; m++)
@@ -507,12 +515,19 @@ public class QRCodeData
         // The payload bit stream is flat row-major module order — the same
         // order as the source buffer — so pack 8 modules per byte via the
         // MSB multiply-gather (byte k of a ulong of 0/1 bytes lands at bit
-        // 56+(7-k) after * 0x8040...01).
+        // 56+(7-k) after * 0x8040...01). The gather constant assumes
+        // little-endian byte order (source[m+k] = ulong byte k); reverse on
+        // big-endian targets — the check is a JIT-time constant, so
+        // little-endian codegen is unaffected.
         ref var srcRef = ref MemoryMarshal.GetReference(source);
         var m = 0;
         for (; m + 8 <= totalModules; m += 8)
         {
             var u = Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref srcRef, m));
+            if (!BitConverter.IsLittleEndian)
+            {
+                u = BinaryPrimitives.ReverseEndianness(u);
+            }
             _bits[m >> 3] = (byte)((u * 0x8040201008040201UL) >> 56);
         }
         if (m < totalModules)

--- a/src/SkiaSharp.QrCode/QRCodeData.cs
+++ b/src/SkiaSharp.QrCode/QRCodeData.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace SkiaSharp.QrCode;
 
@@ -18,18 +19,28 @@ public class QRCodeData
     // Memory Layout
     // =====================================================================
     //
-    // QRCodeData manages a 1D byte array representing a 2D QR code matrix.
-    // The array may include an optional quiet zone (white border).
+    // QRCodeData stores CORE modules only (no quiet zone), bit-packed in the
+    // exact layout of the "QRR" serialization payload: a continuous MSB-first
+    // bit stream in flat row-major module order, zero-padded to a whole byte.
+    //
+    //   bitIndex = coreRow * _baseSize + coreCol
+    //   dark(coreRow, coreCol) = (_bits[bitIndex >> 3] >> (7 - (bitIndex & 7))) & 1
     //
     // ┌─────────────────────────────────────────────────────────┐
-    // │ Memory Layout (with QuietZone = 4)                      │
+    // │ Example (Version 2, QuietZone = 4)                      │
     // ├─────────────────────────────────────────────────────────┤
-    // │ Version: 2                                              │
     // │ _baseSize: 25 (core QR modules, no quiet zone)          │
     // │ _quietZoneSize: 4 (border width)                        │
     // │ _size: 33 (25 + 4*2, including quiet zone)              │
-    // │ _moduleData.Length: 1,089 bytes (33 × 33)               │
+    // │ _bits.Length: 79 bytes (ceil(25 * 25 / 8))              │
+    // │   (previous byte-per-module layout: 1,089 bytes)        │
     // └─────────────────────────────────────────────────────────┘
+    //
+    // The quiet zone is VIRTUAL: it is all-light by definition, so the public
+    // indexer answers false for coordinates outside the core area instead of
+    // storing border modules. _size/_quietZoneSize only affect coordinate
+    // translation. The COORDINATE SPACE seen through the public indexer is
+    // unchanged from the byte-per-module days:
     //
     // Visual Representation (33×33 with QuietZone=4):
     //
@@ -43,13 +54,13 @@ public class QRCodeData
     //   ├───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
     // 3 │ Q │ Q │ Q │ Q │ Q │ Q │...│ Q │ Q │ Q │ Q │ Q │
     //   ├───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
-    // 4 │ Q │ Q │ Q │ Q │ C │ C │...│ C │ Q │ Q │ Q │ Q │ ← CoreData starts (col 4-28)
+    // 4 │ Q │ Q │ Q │ Q │ C │ C │...│ C │ Q │ Q │ Q │ Q │ ← Core starts (col 4-28)
     //   ├───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
     // 5 │ Q │ Q │ Q │ Q │ C │ C │...│ C │ Q │ Q │ Q │ Q │
     //   ├───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
     //   │...│...│...│...│...│...│...│...│...│...│...│...│
     //   ├───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
-    // 28│ Q │ Q │ Q │ Q │ C │ C │...│ C │ Q │ Q │ Q │ Q │ ← CoreData ends
+    // 28│ Q │ Q │ Q │ Q │ C │ C │...│ C │ Q │ Q │ Q │ Q │ ← Core ends
     //   ├───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
     // 29│ Q │ Q │ Q │ Q │ Q │ Q │...│ Q │ Q │ Q │ Q │ Q │ ← QuietZone (row 29-32)
     //   ├───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
@@ -62,22 +73,23 @@ public class QRCodeData
     //     ↑               ↑                       ↑       ↑
     //   col 0           col 4                   col 28  col 32
     //
-    // Q = QuietZone (white border, value = 0)
-    // C = CoreData (actual QR code modules)
+    // Q = QuietZone (white border, VIRTUAL — not stored, indexer returns false)
+    // C = Core modules (stored bit-packed in _bits)
     //
     // ┌─────────────────────────────────────────────────────────┐
-    // │ 1D Array Mapping (Row-Major Order)                      │
+    // │ Bit Mapping (core only, row-major, MSB-first)           │
     // ├─────────────────────────────────────────────────────────┤
-    // │ Index = row × _size + col                               │
+    // │ coreRow  = row - _quietZoneSize                         │
+    // │ coreCol  = col - _quietZoneSize                         │
+    // │   (outside 0..baseSize-1 → quiet zone → false)          │
+    // │ bitIndex = coreRow × _baseSize + coreCol                │
+    // │ dark     = (_bits[bitIndex >> 3] >> (7 - (bitIndex &    │
+    // │             7))) & 1                                    │
     // │                                                         │
-    // │ Example: Access (row=5, col=6)                          │
-    // │   → Index = 5 × 33 + 6 = 171                            │
-    // │   → _moduleData[171]                                    │
-    // │                                                         │
-    // │ CoreData Offset Calculation:                            │
-    // │   coreRow = row - _quietZoneSize                        │
-    // │   coreCol = col - _quietZoneSize                        │
-    // │   coreIndex = coreRow × _baseSize + coreCol             │
+    // │ Example: Access (row=5, col=6) with QuietZone=4         │
+    // │   → coreRow = 1, coreCol = 2                            │
+    // │   → bitIndex = 1 × 25 + 2 = 27                          │
+    // │   → _bits[3], bit 4 (= 7 - (27 & 7))                    │
     // └─────────────────────────────────────────────────────────┘
     //
     // ┌─────────────────────────────────────────────────────────┐
@@ -87,12 +99,14 @@ public class QRCodeData
     // │ _baseSize: 25                                           │
     // │ _quietZoneSize: 0                                       │
     // │ _size: 25 (same as _baseSize)                           │
-    // │ _moduleData.Length: 625 bytes (25 × 25)                 │
+    // │ _bits.Length: 79 bytes — IDENTICAL to the QuietZone=4   │
+    // │ case: only core modules are stored, so the quiet zone   │
+    // │ costs no memory and only changes coordinate translation │
     // └─────────────────────────────────────────────────────────┘
     //
     //     0   1   2   3   4 ... 20  21  22  23  24
     //   ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
-    // 0 │ C │ C │ C │ C │ C │...│ C │ C │ C │ C │ ← CoreData only
+    // 0 │ C │ C │ C │ C │ C │...│ C │ C │ C │ C │ ← Core only
     //   ├───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
     // 1 │ C │ C │ C │ C │ C │...│ C │ C │ C │ C │
     //   ├───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
@@ -102,41 +116,42 @@ public class QRCodeData
     //   └───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
     //
     // When _quietZoneSize = 0:
-    //   - _size == _baseSize
-    //   - No offset needed for CoreData access
-    //   - Direct 1:1 mapping: _moduleData[row × _size + col]
+    //   - _size == _baseSize, no coordinate translation
+    //   - bitIndex = row × _size + col directly
     //
-    // =====================================================================
-
+    // Why this layout (measured, see the MatrixStorage micro-benchmark log):
+    // - 8.7x smaller per-instance allocation (34,225 -> 3,944 bytes at v40/qz4),
+    //   which was essentially 100% of CreateQrCode's allocation.
+    // - _bits IS the serialization payload, so GetRawData collapses to
+    //   header + copy (~800x) and deserialization to the mirror copy — the
+    //   previous implementation round-tripped through a byte-per-module
+    //   temporary (a ~31 KB stackalloc at v40).
+    // - The cost is one shift+mask per indexer read (~+45% on a raw
+    //   full-matrix sweep), negligible under real rendering work.
+    //
     // =====================================================================
     // Serialization / Deserialization
     // =====================================================================
     //
-    // Data Flow for Serialization/Deserialization
-    //
     // ┌──────────────────────────────────────────────────┐
     // │ Serialization (GetRawData)                       │
     // ├──────────────────────────────────────────────────┤
-    // │ _moduleData (with QuietZone)                     │
-    // │   ↓ GetCoreData()                                │
-    // │ coreData (without QuietZone)                     │
-    // │   ↓ Pack bits                                    │
-    // │ rawData (header + packed core bits)              │
+    // │ _bits (already the packed payload)               │
+    // │   ↓ copy                                         │
+    // │ rawData ("QRR" + size byte + _bits)              │
     // └──────────────────────────────────────────────────┘
     //
     // ┌──────────────────────────────────────────────────┐
     // │ Deserialization (Constructor)                    │
     // ├──────────────────────────────────────────────────┤
-    // │ rawData (header + packed core bits)              │
-    // │   ↓ Unpack bits                                  │
-    // │ coreData (without QuietZone)                     │
-    // │   ↓ SetCoreData()                                │
-    // │ _moduleData (with QuietZone)                     │
+    // │ rawData ("QRR" + size byte + packed core bits)   │
+    // │   ↓ copy (padding bits masked to zero)           │
+    // │ _bits                                            │
     // └──────────────────────────────────────────────────┘
 
-    // 1D byte array (row-major order) representing the QR code modules including quiet zone if present
-    // Aligned to 64-byte boundary for AVX-512 optimizations
-    private byte[] _moduleData;
+    // Core modules, bit-packed as the QRR payload (MSB-first, flat row-major,
+    // zero-padded tail). See the layout notes above.
+    private byte[] _bits;
     private int _size; // module count per side (including quiet zone if present)
     private int _baseSize; // module count without quiet zone
     private int _quietZoneSize; // quiet zone size in modules
@@ -154,13 +169,48 @@ public class QRCodeData
     /// <summary>
     /// Gets or sets the module state at the specified position.
     /// </summary>
-    /// <param name="row">Row index (0-based).</param>
-    /// <param name="col">Column index (0-based).</param>
+    /// <param name="row">Row index (0-based, including quiet zone if present).</param>
+    /// <param name="col">Column index (0-based, including quiet zone if present).</param>
     /// <returns>True if module is dark/black, false if light/white.</returns>
+    /// <remarks>
+    /// Quiet zone positions always read false (the quiet zone is light by
+    /// definition and is not stored). The internal setter only accepts core
+    /// positions — quiet zone modules cannot be modified.
+    /// </remarks>
     public bool this[int row, int col]
     {
-        get => _moduleData[row * _size + col] != 0;
-        internal set => _moduleData[row * _size + col] = value ? (byte)1 : (byte)0;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            if ((uint)row >= (uint)_size || (uint)col >= (uint)_size)
+                throw new IndexOutOfRangeException();
+
+            var coreRow = row - _quietZoneSize;
+            var coreCol = col - _quietZoneSize;
+            if ((uint)coreRow >= (uint)_baseSize || (uint)coreCol >= (uint)_baseSize)
+                return false; // virtual quiet zone
+
+            var bitIndex = coreRow * _baseSize + coreCol;
+            return (_bits[bitIndex >> 3] & (1 << (7 - (bitIndex & 7)))) != 0;
+        }
+        internal set
+        {
+            var coreRow = row - _quietZoneSize;
+            var coreCol = col - _quietZoneSize;
+            if ((uint)coreRow >= (uint)_baseSize || (uint)coreCol >= (uint)_baseSize)
+                throw new ArgumentOutOfRangeException(nameof(row), $"Position ({row}, {col}) is outside the core area; quiet zone modules are not writable.");
+
+            var bitIndex = coreRow * _baseSize + coreCol;
+            var mask = (byte)(1 << (7 - (bitIndex & 7)));
+            if (value)
+            {
+                _bits[bitIndex >> 3] |= mask;
+            }
+            else
+            {
+                _bits[bitIndex >> 3] &= (byte)~mask;
+            }
+        }
     }
 
     /// <summary>
@@ -180,7 +230,7 @@ public class QRCodeData
         _baseSize = SizeFromVersion(version);
         _quietZoneSize = quietZoneSize;
         _size = _baseSize + (quietZoneSize * 2);
-        _moduleData = new byte[_size * _size];
+        _bits = new byte[PayloadBytes(_baseSize)];
     }
 
     /// <summary>
@@ -260,38 +310,21 @@ public class QRCodeData
         _size = _baseSize + (_quietZoneSize * 2);
         var coreTotalBits = _baseSize * _baseSize; // core data size (without quiet zone)
 
-        // Allocate full array (include quiet zone)
-        _moduleData = new byte[_size * _size];
+        // The payload IS the internal representation — copy it directly.
+        var payloadBytes = PayloadBytes(_baseSize);
+        var available = rawDataSpan.Length - 4;
+        if (available < payloadBytes)
+            throw new InvalidOperationException($"Insufficient data: expected {coreTotalBits} bits, got {Math.Max(available, 0) * 8}.");
 
-        // unpack bits to bytes
-        const int StackallocThreshold = 2048;
-        byte[]? rentedBuffer = null;
-        Span<byte> coreData = coreTotalBits <= StackallocThreshold
-            ? stackalloc byte[coreTotalBits]
-            : (rentedBuffer = ArrayPool<byte>.Shared.Rent(coreTotalBits)).AsSpan(0, coreTotalBits);
-        try
+        _bits = rawDataSpan.Slice(4, payloadBytes).ToArray();
+
+        // Mask the padding bits of the final byte to zero so instances are
+        // canonical regardless of input tail garbage (the serializer always
+        // writes zero padding).
+        var remainder = coreTotalBits & 7;
+        if (remainder != 0)
         {
-            var bitIndex = 0;
-            for (var byteIndex = 4; byteIndex < rawDataSpan.Length && bitIndex < coreTotalBits; byteIndex++)
-            {
-                var b = rawDataSpan[byteIndex];
-                for (int i = 7; i >= 0 && bitIndex < coreTotalBits; i--)
-                {
-                    coreData[bitIndex] = (b & (1 << i)) != 0 ? (byte)1 : (byte)0;
-                    bitIndex++;
-                }
-            }
-
-            if (bitIndex < coreTotalBits)
-                throw new InvalidOperationException($"Insufficient data: expected {coreTotalBits} bits, got {bitIndex}.");
-
-            // Copy core data to _moduleData with quiet zone offset
-            SetCoreData(coreData);
-        }
-        finally
-        {
-            if (rentedBuffer != null)
-                ArrayPool<byte>.Shared.Return(rentedBuffer);
+            _bits[^1] &= (byte)(0xFF << (8 - remainder));
         }
     }
 
@@ -327,49 +360,9 @@ public class QRCodeData
     /// </returns>
     public byte[] GetRawData()
     {
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-        var writer = new ArrayBufferWriter<byte>(GetRawDataSize());
-        GetRawData(writer);
-        return writer.WrittenSpan.ToArray();
-#else
-        // "QRR"
-        ReadOnlySpan<byte> _headerSignature = [0x51, 0x52, 0x52];
-
-        // size calculations
-        var totalBits = _baseSize * _baseSize; // only core data without quiet zone
-        var paddingBits = GetPaddingBits(totalBits);
-        var dataBytes = (totalBits + paddingBits) / 8;
-        var headerSize = _headerSignature.Length + 1; // signature length + 1 byte for size
-        var totalSize = headerSize + dataBytes;
-
-        var result = new byte[totalSize];
-        var resultSpan = result.AsSpan();
-        // Write header - signature ("QRR") & raw size
-        resultSpan[0] = _headerSignature[0];
-        resultSpan[1] = _headerSignature[1];
-        resultSpan[2] = _headerSignature[2];
-        resultSpan[3] = (byte)_baseSize; // only core size without quiet zone
-
-        // Get core data (without quiet zone)
-        Span<byte> coreData = stackalloc byte[totalBits];
-        GetCoreData(coreData);
-
-        // Pack bits
-        var bitIndex = 0;
-        for (var byteIndex = 0; byteIndex < dataBytes; byteIndex++)
-        {
-            byte b = 0;
-            for (var i = 7; i >= 0; i--)
-            {
-                if (bitIndex < totalBits && coreData[bitIndex] != 0)
-                    b |= (byte)(1 << i);
-                bitIndex++;
-            }
-            resultSpan[headerSize + byteIndex] = b;
-        }
-
+        var result = new byte[GetRawDataSize()];
+        WriteRawData(result);
         return result;
-#endif
     }
 
     /// <summary>
@@ -391,45 +384,24 @@ public class QRCodeData
     /// </remarks>
     public int GetRawData(IBufferWriter<byte> writer)
     {
-        // "QRR"
-        ReadOnlySpan<byte> _headerSignature = [0x51, 0x52, 0x52];
-
-        // size calculations
-        var totalBits = _baseSize * _baseSize; // only core data without quiet zone
-        var paddingBits = GetPaddingBits(totalBits);
-        var dataBytes = (totalBits + paddingBits) / 8;
-        var headerSize = _headerSignature.Length + 1; // signature length + 1 byte for size
-        var totalSize = headerSize + dataBytes;
-
+        var totalSize = GetRawDataSize();
         var buffer = writer.GetSpan(totalSize);
-
-        // Write header - signature ("QRR") & raw size
-        buffer[0] = _headerSignature[0];
-        buffer[1] = _headerSignature[1];
-        buffer[2] = _headerSignature[2];
-        buffer[3] = (byte)_baseSize; // only core size without quiet zone
-
-        // Get core data (without quiet zone)
-        Span<byte> coreData = stackalloc byte[totalBits];
-        GetCoreData(coreData);
-
-        // Pack bits
-        var bitIndex = 0;
-        for (var byteIndex = 0; byteIndex < dataBytes; byteIndex++)
-        {
-            byte b = 0;
-            for (var i = 7; i >= 0; i--)
-            {
-                if (bitIndex < totalBits && coreData[bitIndex] != 0)
-                    b |= (byte)(1 << i);
-                bitIndex++;
-            }
-            buffer[headerSize + byteIndex] = b;
-        }
-
+        WriteRawData(buffer);
         writer.Advance(totalSize);
-
         return totalSize;
+    }
+
+    /// <summary>
+    /// Writes the "QRR" header and the payload. The internal representation is
+    /// already the serialized payload, so this is a header write plus one copy.
+    /// </summary>
+    private void WriteRawData(Span<byte> destination)
+    {
+        destination[0] = 0x51; // 'Q'
+        destination[1] = 0x52; // 'R'
+        destination[2] = 0x52; // 'R'
+        destination[3] = (byte)_baseSize; // only core size without quiet zone
+        _bits.CopyTo(destination.Slice(4));
     }
 
     /// <summary>
@@ -483,75 +455,83 @@ public class QRCodeData
     }
 
     /// <summary>
-    /// Gets the entire data as span
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal ReadOnlySpan<byte> GetData() => _moduleData.AsSpan();
-
-    /// <summary>
-    /// Gets the entire data as a mutable span
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal Span<byte> GetMutableData() => _moduleData.AsSpan();
-
-    /// <summary>
     /// Gets the core data size (without quiet zone).
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal int GetCoreSize() => _baseSize;
 
     /// <summary>
-    /// Copies core data (without quiet zone) to the destination buffer.
+    /// Copies core data (without quiet zone) to the destination buffer as one
+    /// byte (0/1) per module.
     /// </summary>
     /// <param name="destination">Destination buffer (must be at least baseSize * baseSize bytes)</param>
     /// <exception cref="ArgumentException"></exception>
     internal void GetCoreData(Span<byte> destination)
     {
-        if (destination.Length < _baseSize * _baseSize)
-            throw new ArgumentException($"Destination span size too small: expected at least {_baseSize * _baseSize} bytes (baseSize={_baseSize}), got {destination.Length} bytes");
+        var totalModules = _baseSize * _baseSize;
+        if (destination.Length < totalModules)
+            throw new ArgumentException($"Destination span size too small: expected at least {totalModules} bytes (baseSize={_baseSize}), got {destination.Length} bytes");
 
-        if (_quietZoneSize == 0)
+        // Unpack 8 modules per step: replicate the payload byte across a ulong,
+        // isolate each bit on its byte's diagonal, then OR-cascade down to bit 0
+        // so byte k of the ulong becomes module bit (7-k) as 0/1.
+        ref var destRef = ref MemoryMarshal.GetReference(destination);
+        var m = 0;
+        for (; m + 8 <= totalModules; m += 8)
         {
-            // No quiet zone, copy directly
-            _moduleData.AsSpan(0, _baseSize * _baseSize).CopyTo(destination);
+            var spread = (_bits[m >> 3] * 0x0101010101010101UL) & 0x0102040810204080UL;
+            spread |= spread >> 4;
+            spread |= spread >> 2;
+            spread |= spread >> 1;
+            spread &= 0x0101010101010101UL;
+            Unsafe.WriteUnaligned(ref Unsafe.Add(ref destRef, m), spread);
         }
-        else
+        for (; m < totalModules; m++)
         {
-            // Copy core data excluding quiet zone
-            for (var row = 0; row < _baseSize; row++)
-            {
-                var srcOffset = (row + _quietZoneSize) * _size + _quietZoneSize;
-                var destOffset = row * _baseSize;
-                _moduleData.AsSpan(srcOffset, _baseSize).CopyTo(destination.Slice(destOffset, _baseSize));
-            }
+            destination[m] = (byte)((_bits[m >> 3] >> (7 - (m & 7))) & 1);
         }
     }
 
     /// <summary>
-    /// Sets the core data (without quiet zone) from the source buffer.
+    /// Sets the core data (without quiet zone) from a one-byte-per-module
+    /// (0/1) source buffer.
     /// </summary>
-    /// <param name="source">Source buffer (must be at least baseSize * baseSize bytes)</param>
+    /// <param name="source">Source buffer (must be exactly baseSize * baseSize bytes)</param>
     /// <exception cref="ArgumentException"></exception>
     internal void SetCoreData(ReadOnlySpan<byte> source)
     {
-        if (source.Length != _baseSize * _baseSize)
-            throw new ArgumentException($"Source span size mismatch: expected {_baseSize * _baseSize} bytes (baseSize={_baseSize}), got {source.Length} bytes");
+        var totalModules = _baseSize * _baseSize;
+        if (source.Length != totalModules)
+            throw new ArgumentException($"Source span size mismatch: expected {totalModules} bytes (baseSize={_baseSize}), got {source.Length} bytes");
 
-        if (_quietZoneSize == 0)
+        // The payload bit stream is flat row-major module order — the same
+        // order as the source buffer — so pack 8 modules per byte via the
+        // MSB multiply-gather (byte k of a ulong of 0/1 bytes lands at bit
+        // 56+(7-k) after * 0x8040...01).
+        ref var srcRef = ref MemoryMarshal.GetReference(source);
+        var m = 0;
+        for (; m + 8 <= totalModules; m += 8)
         {
-            // No quiet zone, copy directly
-            source.CopyTo(_moduleData);
+            var u = Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref srcRef, m));
+            _bits[m >> 3] = (byte)((u * 0x8040201008040201UL) >> 56);
         }
-        else
+        if (m < totalModules)
         {
-            // Copy core data excluding quiet zone
-            for (var row = 0; row < _baseSize; row++)
+            byte b = 0;
+            for (var i = 0; m + i < totalModules; i++)
             {
-                var srcOffset = row * _baseSize;
-                var destOffset = (row + _quietZoneSize) * _size + _quietZoneSize;
-                source.Slice(srcOffset, _baseSize).CopyTo(_moduleData.AsSpan(destOffset, _baseSize));
+                if (source[m + i] != 0) b |= (byte)(1 << (7 - i));
             }
+            _bits[m >> 3] = b;
         }
+    }
+
+    /// <summary>Serialized payload length in bytes for a core of the given size (bits rounded up to whole bytes).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int PayloadBytes(int baseSize)
+    {
+        var totalBits = baseSize * baseSize;
+        return (totalBits + GetPaddingBits(totalBits)) / 8;
     }
 
     /// <summary>

--- a/tests/SkiaSharp.QrCode.Tests/ModulePlacerBinaryUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/ModulePlacerBinaryUnitTest.cs
@@ -73,8 +73,8 @@ public class ModulePlacerBinaryUnitTest
     {
         // Arrange
         var qrCode = CreateEmptyQRCodeData(version);
-        var buffer = qrCode.GetMutableData();
         var size = qrCode.Size;
+        Span<byte> buffer = new byte[size * size]; // byte-per-module work buffer, loaded via SetCoreData below
         Span<Rectangle> blockedModules = stackalloc Rectangle[30];
         var blockedCount = 0;
 
@@ -90,6 +90,7 @@ public class ModulePlacerBinaryUnitTest
 
         // Act
         ModulePlacer.PlaceDataWords(buffer, size, data, blockedMask);
+        qrCode.SetCoreData(buffer);
 
         // Assert - Verify data is placed (not all zeros/all ones)
         int darkCount = 0;


### PR DESCRIPTION
## Summary

Change `QRCodeData`'s internal matrix storage from one byte per module (quiet zone materialized) to bit-packed core modules stored in the exact layout of the "QRR" serialization payload (flat row-major, MSB-first). The quiet zone becomes virtual — it is all-light by definition, so the indexer answers `false` outside the core area instead of storing border modules.

## Intent

The matrix buffer was essentially 100% of `CreateQrCode`'s allocation (34,296 B for a version-40 code with quiet zone 4). We micro-benchmarked six representations (byte-per-module baseline, virtual quiet zone, row-aligned bit packing, serialization-layout bit packing, ArrayPool-backed, bit packing with materialized quiet zone) across the storage lifecycle: Create, full-matrix indexer sweep, and `GetRawData`.

Serialization-layout bit packing won:

- 8.7x smaller allocation (34,225 → 3,944 B at v40/qz4); the quiet zone costs no memory at any setting.
- The internal buffer IS the QRR payload, so `GetRawData` collapses to header + copy (27 µs → 33 ns, ~800x) and the deserialization constructor to the mirror copy — both previously round-tripped through a byte-per-module temporary, including a ~31 KB stackalloc inside `GetRawData` at v40.
- Rejected (measured): row-aligned bit layout (dominated everywhere), materialized-quiet-zone bits (branchless indexer did not recover the sweep cost; the variable-shift bit extract dominates, not the bounds check). ArrayPool backing reaches 0 B but requires `IDisposable` — deferred as an API decision, orthogonal to this layout.
- Accepted trade-off: a raw full-matrix indexer sweep costs ~+45% (one shift+mask per read). Real renderers skip quiet-zone coordinates and spend their time in drawing calls, so the practical impact is negligible.

This also sets up the planned `Measure` + caller-provided `Span<byte>` generation API: the payload is at most 3,917 B (stackalloc-friendly), and the new shared `WriteRawData` core is the natural foundation.

## Expected behavior

No public API or format change for valid inputs:

- Indexer values (including `false` in the quiet zone), `Size`, `Version`, `IsFinderPattern`, `GetFinderPatternIndex` are unchanged.
- `GetRawData()` / `GetRawData(IBufferWriter<byte>)` / `GetRawDataSize()` produce byte-identical output; the raw-data constructor accepts the same inputs with the same exceptions, and now masks padding bits so instances are canonical even for hand-crafted input tails.
- Out-of-range indexer access now always throws `IndexOutOfRangeException`; previously `[0, Size]` silently read the next row due to flat-index arithmetic. Strictness fix, not a behavior users could rely on.
- Internal-only changes: `GetData()`/`GetMutableData()` removed (no consumers; one test adapted to use its own buffer + `SetCoreData`); the internal indexer setter no longer accepts quiet-zone positions (no callers existed).
- Full test suite passes on net8.0/net10.0, including serialization round-trip, quiet-zone preservation, decodability, and visual-compatibility tests.

## Benchmarks

`MatrixStorage` micro-benchmark (Ryzen 9 7950X3D, .NET 10, 15 iterations), v40/qz4, before → after:

| Operation | Before | After | Change |
|---|---:|---:|---:|
| Create allocation | 34,256 B | 3,944 B | 0.12x |
| Create time | 2.54 µs | 3.34 µs | +0.8 µs (v1: 81 → 50 ns, faster) |
| GetRawData | 27.1 µs | 0.033 µs | ~800x |
| Full indexer sweep | 20.7 µs | 30.0 µs | +45% (see trade-off above) |

End-to-end (`QrCodeEndToEnd`, public `CreateQrCode` API; generation time unchanged):

| Scenario | Allocated before | Allocated after | Change |
|---|---:|---:|---:|
| Short_M (v1–2) | 912 B | 120 B | −87% |
| Url_M (v4–5) | 2,472 B | 280 B | −89% |
| Long_L (v40) | 34,296 B | 3,984 B | −88% |
| Long_H (v40) | 32,832 B | 3,808 B | −88% |
