### PR TITLE
feat: Optimized QR data placement with 64-bit buffering, paired module processing, and bounds-check elimination.

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
@@ -1,4 +1,6 @@
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace SkiaSharp.QrCode.Internals;
 
@@ -17,7 +19,7 @@ internal static partial class ModulePlacer
     /// <param name="interleavedData">Interleaved data and ECC bytes.</param>
     /// <param name="blockedMask">blocked mask bytes.</param>
     /// <remarks>
-    /// Bits are read MSG-first (most significant bit first) from the byte array.
+    /// Bits are read MSB-first (most significant bit first) from the byte array.
     ///
     /// Data placement pattern (ISO/IEC 18004 Section 7.7.3):
     /// - Start from bottom-right corner
@@ -25,12 +27,42 @@ internal static partial class ModulePlacer
     /// - Alternate direction at top/bottom edges.
     /// - Skip timing pattern column (column 6)
     /// - Fill out non-blocked modules
+    ///
+    /// Performance (see the micro-optimization findings log, ~2x over the
+    /// per-module implementation at every version, zero allocations):
+    /// - The stream is consumed strictly sequentially, so the next up-to-64 bits
+    ///   are kept MSB-aligned in a ulong register and refilled 8 bytes at a time,
+    ///   replacing an indexed byte load + variable shift per module.
+    /// - The two modules of a strip row sit at adjacent bit indices (b, b-1) in
+    ///   the blocked mask and ~90% of rows have both free: one 2-bit mask window
+    ///   read + one 2-bit stream consume handles the pair on the fast path.
+    /// - Once the stream is exhausted nothing can be written again, so the
+    ///   remainder modules end the walk via return instead of a per-module guard.
+    /// - Buffer/mask accesses go through refs so the JIT emits no bounds checks
+    ///   in the row loop (measured ~15% at version 10); the index range is
+    ///   validated once up front instead.
     /// </remarks>
     public static void PlaceDataWords(Span<byte> buffer, int size, ReadOnlySpan<byte> interleavedData, ReadOnlySpan<byte> blockedMask)
     {
-        var bitPos = 0;
-        var totalBits = interleavedData.Length * 8;
+        // Ref-based access below elides per-module bounds checks, so validate the
+        // whole traversal range here. size >= 7 keeps the strip column x >= 1
+        // (real QR sizes are 21..177), so b-1 never goes negative.
+        if (size < 7)
+            throw new ArgumentOutOfRangeException(nameof(size), $"size must be >= 7, got {size}");
+        if (buffer.Length < size * size)
+            throw new ArgumentException($"buffer too small: required {size * size}, got {buffer.Length}", nameof(buffer));
+        if (blockedMask.Length < (size * size + 7) / 8)
+            throw new ArgumentException($"blockedMask too small: required {(size * size + 7) / 8}, got {blockedMask.Length}", nameof(blockedMask));
+
         var up = true;
+
+        // Next up-to-64 stream bits, MSB-aligned; accBits of them are valid.
+        var acc = 0ul;
+        var accBits = 0;
+        var bytePos = 0;
+
+        ref var buf = ref MemoryMarshal.GetReference(buffer);
+        ref var mask = ref MemoryMarshal.GetReference(blockedMask);
 
         for (var x = size - 1; x >= 0; x -= 2)
         {
@@ -38,32 +70,101 @@ internal static partial class ModulePlacer
             if (x == 6)
                 x--;
 
-            // Process each row in zigzag pattern
-            for (var yMod = 1; yMod <= size; yMod++)
+            // Walk the strip via the flat index: right module at b = y * size + x,
+            // left at b - 1; direction alternates per strip.
+            var b = up ? (size - 1) * size + x : x;
+            var step = up ? -size : size;
+
+            for (var rows = 0; rows < size; rows++, b += step)
             {
-                // zigzag direction
-                var y = up ? size - yMod : yMod - 1;
+                // rightmodule = b, leftmodule = b - 1
+                // b tracks the right module's flat index directly; stepping by ±size avoids per-row y computation and re-multiplication.
 
-                // Process 2 columns (x and x-1)
-                for (var xOffset = 0; xOffset < 2; xOffset++)
+                // Blocked bits for the row pair: w bit1 = blocked(b), bit0 = blocked(b-1).
+                // |    `w` |  right `b` | left `b-1` |
+                // | -----: | ---------: | ---------: |
+                // | `0b00` |       free |       free |
+                // | `0b01` |       free |    blocked |
+                // | `0b10` |    blocked |       free |
+                // | `0b11` |    blocked |    blocked |
+                var byteIdx = b >> 3;
+                var sh = b & 7;
+                var w = sh == 0
+                    ? (uint)(((Unsafe.Add(ref mask, byteIdx) & 1) << 1) | (Unsafe.Add(ref mask, byteIdx - 1) >> 7))
+                    : ((uint)Unsafe.Add(ref mask, byteIdx) >> (sh - 1)) & 3u;
+
+                if (w == 0 && accBits >= 2)
                 {
-                    var xModule = x - xOffset;
-                    var bitIndex = y * size + xModule;
+                    // Fast path: both modules free AND >= 2 stream bits buffered.
+                    // Taken for ~90% of rows: blocked regions (finder/timing/alignment/format)
+                    // cover only ~10-15% of the matrix, and the accumulator dips below 2 bits
+                    // at most once per 64 consumed bits.
+                    // 1. w == 0, both right and left modules are free, so we can consume 2 bits from the accumulator.
+                    // 2. accBits >= 2, we have at least 2 bits in the accumulator to write.
 
-                    if (!IsModuleBlocked(blockedMask, bitIndex) && bitPos < totalBits)
+                    Unsafe.Add(ref buf, b) = (byte)(acc >> 63); // place right module (b) with the MSB of acc
+                    Unsafe.Add(ref buf, b - 1) = (byte)((acc >> 62) & 1); // place left module (b-1) with the next bit of acc
+                    acc <<= 2;
+                    accBits -= 2;
+                }
+                else
+                {
+                    // Slow path: a module is blocked, or fewer than 2 bits are buffered.
+                    // Handle each module independently; refill happens only when the
+                    // accumulator is empty (a leftover single bit is consumed first).
+                    if ((w & 2) == 0)
                     {
-                        var byteIndex = bitPos >> 3;
-                        var bitMask = 1 << (7 - (bitPos & 7)); // MSB first
-                        var module = (interleavedData[byteIndex] & bitMask) != 0 ? (byte)1 : (byte)0;
-                        buffer[bitIndex] = module;
-                        bitPos++;
+                        // w bit1 == 0, right module is free
+                        if (accBits == 0 && !RefillAccumulator(interleavedData, ref bytePos, ref acc, ref accBits))
+                            return;
+                        Unsafe.Add(ref buf, b) = (byte)(acc >> 63);
+                        acc <<= 1;
+                        accBits--;
+                    }
+                    if ((w & 1) == 0)
+                    {
+                        // w bit0 == 0, left module is free. Same as above, but for the left module (b-1)
+                        if (accBits == 0 && !RefillAccumulator(interleavedData, ref bytePos, ref acc, ref accBits))
+                            return;
+                        Unsafe.Add(ref buf, b - 1) = (byte)(acc >> 63);
+                        acc <<= 1;
+                        accBits--;
                     }
                 }
             }
 
-            // Alternate direction
+            // Alternate direction for zigzag pattern
             up = !up;
         }
+    }
+
+    /// <summary>
+    /// Loads the next up-to-8 stream bytes MSB-aligned into the accumulator.
+    /// Returns false when the stream is exhausted.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool RefillAccumulator(ReadOnlySpan<byte> data, ref int bytePos, ref ulong acc, ref int accBits)
+    {
+        var remaining = data.Length - bytePos;
+        if (remaining >= 8)
+        {
+            acc = BinaryPrimitives.ReadUInt64BigEndian(data.Slice(bytePos));
+            accBits = 64;
+            bytePos += 8;
+            return true;
+        }
+        if (remaining == 0)
+            return false;
+
+        ulong v = 0;
+        for (var i = 0; i < remaining; i++)
+        {
+            v = (v << 8) | data[bytePos + i];
+        }
+        acc = v << (64 - remaining * 8);
+        accBits = remaining * 8;
+        bytePos = data.Length;
+        return true;
     }
 
     // TODO: Text API, will be removed when text mode is deprecated
@@ -369,13 +470,13 @@ internal static partial class ModulePlacer
     private static bool IsModuleBlocked(ReadOnlySpan<byte> mask, int bitIndex)
     {
         // Performance: O(1) constant-time lookup using bitwise operations.
-        // 
+        //
         // Bit extraction:
         // - Byte index = bitIndex >> 3 (equivalent to bitIndex / 8)
         // - Bit position = bitIndex & 7 (equivalent to bitIndex % 8)
         // - Mask = 1 << bit_position
         // - Result = (byte & mask) != 0
-        // 
+        //
         // Example (bitIndex = 10):
         // - Byte index: 10 >> 3 = 1 (second byte)
         // - Bit position: 10 & 7 = 2 (third bit from LSB)
@@ -397,7 +498,7 @@ internal static partial class ModulePlacer
     /// 2. Use bitwise operations (&amp;, ^) instead of modulo where possible
     /// 3. Avoid repeated Math.Floor calculations
     /// </code>
-    /// 
+    ///
     /// Pre-calculated values (shared across all patterns):
     /// <code>
     /// - rMod2[i] = i % 2  (row modulo 2)
@@ -407,7 +508,7 @@ internal static partial class ModulePlacer
     /// - cDiv3[i] = i / 3  (column integer division by 3)
     /// - cMod3[i] = i % 3  (column modulo 3)
     /// </code>
-    /// 
+    ///
     /// For mathematical background, see:
     /// <code>
     /// - ISO/IEC 18004:2015 Section 7.8.2 (Data Masking)
@@ -426,7 +527,7 @@ internal static partial class ModulePlacer
         /// <code>
         /// (x + y) % 2 == 0
         /// </code>
-        /// 
+        ///
         /// Visual Pattern (8×8 sample, ■=dark, □=light):
         /// <code>
         /// ■□■□■□■□
@@ -438,13 +539,13 @@ internal static partial class ModulePlacer
         /// ■□■□■□■□
         /// □■□■□■□■
         /// </code>
-        /// 
+        ///
         /// Mathematical Properties:
         /// <code>
         /// (a % 2) + (b % 2) ≡ (a + b) % 2
         /// (a % 2) ⊕ (b % 2) == 0 ⟺ (a + b) % 2 == 0  (XOR equivalence)
         /// </code>
-        /// 
+        ///
         /// Optimization:
         /// <code>
         /// Instead of: (row + col) % 2 == 0
@@ -473,7 +574,7 @@ internal static partial class ModulePlacer
         /// <code>
         /// y % 2 == 0
         /// </code>
-        /// 
+        ///
         /// Visual Pattern (8×8 sample, ■=dark, □=light):
         /// <code>
         /// ■■■■■■■■
@@ -485,14 +586,14 @@ internal static partial class ModulePlacer
         /// ■■■■■■■■
         /// □□□□□□□□
         /// </code>
-        /// 
+        ///
         /// Characteristics:
         /// <code>
         /// - Alternating horizontal rows
         /// - Independent of x coordinate
         /// - Period: 2 rows
         /// </code>
-        /// 
+        ///
         /// Example:
         /// <code>
         /// Row 0: 0%2==0 → true  ■■■■
@@ -513,7 +614,7 @@ internal static partial class ModulePlacer
         /// <code>
         /// x % 3 == 0
         /// </code>
-        /// 
+        ///
         /// Visual Pattern (9×8 sample, ■=dark, □=light):
         /// <code>
         /// ■□□■□□■□□
@@ -525,14 +626,14 @@ internal static partial class ModulePlacer
         /// ■□□■□□■□□
         /// ■□□■□□■□□
         /// </code>
-        /// 
+        ///
         /// Characteristics:
         /// <code>
         /// - Alternating vertical columns
         /// - Independent of y coordinate
         /// - Period: 3 columns (wider than Pattern 1)
         /// </code>
-        /// 
+        ///
         /// Example:
         /// <code>
         /// Col 0: 0%3==0 → true  ■
@@ -555,7 +656,7 @@ internal static partial class ModulePlacer
         /// <code>
         /// (x + y) % 3 == 0
         /// </code>
-        /// 
+        ///
         /// Visual Pattern (9×9 sample, ■=dark, □=light):
         /// <code>
         /// ■□□■□□■□□
@@ -568,33 +669,33 @@ internal static partial class ModulePlacer
         /// □□■□□■□□■
         /// □■□□■□□■□
         /// </code>
-        /// 
+        ///
         /// Mathematical Properties:
         /// <code>
         /// (a % 3) + (b % 3) can exceed 3
         /// Example: (2 % 3) + (2 % 3) = 2 + 2 = 4
         /// Therefore: Must apply modulo to sum: (2 + 2) % 3 = 1
         /// </code>
-        /// 
+        ///
         /// Optimization - Avoid Modulo:
         /// <code>
         /// rowMod3 ∈ {0, 1, 2}
         /// colMod3 ∈ {0, 1, 2}
         /// sum = rowMod3 + colMod3 ∈ {0, 1, 2, 3, 4}
-        /// 
+        ///
         /// sum % 3 == 0 ⟺ sum ∈ {0, 3}
-        /// 
+        ///
         /// Instead of: (rowMod3 + colMod3) % 3 == 0
         /// Use:        sum == 0 || sum == 3
         /// Benefit:    Eliminates modulo operation
         /// </code>
-        /// 
+        ///
         /// Diagonal Pattern:
         /// <code>
         /// Slope: -1/1 (45° diagonal)
         /// Period: 3 modules
         /// </code>
-        /// 
+        ///
         /// Example:
         /// <code>
         /// (0,0): 0+0=0 → true  ■
@@ -621,7 +722,7 @@ internal static partial class ModulePlacer
         /// <code>
         /// (⌊y/2⌋ + ⌊x/3⌋) % 2 == 0
         /// </code>
-        /// 
+        ///
         /// Visual Pattern (12×12 sample, ■=dark, □=light):
         /// <code>
         /// ■■■□□□■■■□□□
@@ -637,20 +738,20 @@ internal static partial class ModulePlacer
         /// □□□■■■□□□■■■
         /// □□□■■■□□□■■■
         /// </code>
-        /// 
+        ///
         /// Mathematical Optimization:
         /// <code>
         /// ⌊y/2⌋ = y >> 1     (for non-negative integers)
         /// ⌊x/3⌋ = x / 3      (integer division)
         /// (a + b) % 2 ≡ (a + b) &amp; 1  (bitwise optimization)
         /// </code>
-        /// 
+        ///
         /// Block Size:
         /// <code>
         /// Vertical blocks:   2 rows
         /// Horizontal blocks: 3 columns
         /// </code>
-        /// 
+        ///
         /// Example:
         /// <code>
         /// (0,0): (0/2 + 0/3)%2 = (0+0)%2 = 0 → true  ■
@@ -675,7 +776,7 @@ internal static partial class ModulePlacer
         /// <code>
         /// ((x·y) % 2) + ((x·y) % 3) == 0
         /// </code>
-        /// 
+        ///
         /// Visual Pattern (12×12 sample, ■=dark, □=light):
         /// <code>
         /// ■■■■■■■■■■■■
@@ -691,7 +792,7 @@ internal static partial class ModulePlacer
         /// ■■□□□□□□□□□□
         /// ■□■□■□□■□■□■
         /// </code>
-        /// 
+        ///
         /// Mathematical Properties:
         /// <code>
         /// ((x·y) % 2) + ((x·y) % 3) == 0
@@ -699,19 +800,19 @@ internal static partial class ModulePlacer
         /// ⟺ (x·y) % lcm(2,3) == 0
         /// ⟺ (x·y) % 6 == 0
         /// </code>
-        /// 
+        ///
         /// Optimization - Avoid Multiplication:
         /// <code>
         /// (x·y) % 2 == 0  ⟺  (x % 2 == 0) OR (y % 2 == 0)  (either is even)
         /// (x·y) % 3 == 0  ⟺  (x % 3 == 0) OR (y % 3 == 0)  (either is divisible by 3)
-        /// 
+        ///
         /// Therefore:
         /// ((x·y) % 2) + ((x·y) % 3) == 0
         /// ⟺ (rowMod2 == 0 OR colMod2 == 0) AND (rowMod3 == 0 OR colMod3 == 0)
-        /// 
+        ///
         /// Benefit: Eliminates multiplication and modulo operations entirely
         /// </code>
-        /// 
+        ///
         /// Example:
         /// <code>
         /// # Basic
@@ -719,7 +820,7 @@ internal static partial class ModulePlacer
         /// (2,3): 6%2 + 6%3 = 0+0 = 0 → true  ■
         /// (1,1): 1%2 + 1%3 = 1+1 = 2 → false □
         /// (2,2): 4%2 + 4%3 = 0+1 = 1 → false □
-        /// 
+        ///
         /// # Optimized:
         /// (0,0): (0==0 OR 0==0) AND (0==0 OR 0==0) → true  ■
         /// (2,3): (0==0 OR 1==0) AND (2==0 OR 0==0) → true  ■
@@ -743,7 +844,7 @@ internal static partial class ModulePlacer
         /// <code>
         /// (((x·y) % 2) + ((x·y) % 3)) % 2 == 0
         /// </code>
-        /// 
+        ///
         /// Visual Pattern (12×12 sample, ■=dark, □=light):
         /// <code>
         /// ■■■■■■■■■■■■
@@ -759,22 +860,22 @@ internal static partial class ModulePlacer
         /// ■■□□■■□□■■■■
         /// ■□■□■□□■□■□■
         /// </code>
-        /// 
+        ///
         /// Mathematical Properties:
         /// <code>
         /// Similar to Pattern 5, but checks parity of sum
         /// Sum can be: 0, 1, 2, or 3
         /// Pattern is dark when sum is even (0 or 2)
         /// </code>
-        /// 
+        ///
         /// Optimization - Avoid Multiplication and Modulo:
         /// <code>
         /// Break down into two components:
-        /// 
+        ///
         /// 1. (x·y) % 2 parity:
         ///    - Product is odd only when both x and y are odd
         ///    - rowMod2 &amp; colMod2  (bitwise AND gives 1 only if both are 1)
-        /// 
+        ///
         /// 2. (x·y) % 3 parity (using 3×3 lookup table):
         ///    - rowMod3 ∈ {0,1,2}, colMod3 ∈ {0,1,2}
         ///    - Product table:
@@ -784,13 +885,13 @@ internal static partial class ModulePlacer
         ///      2   0  2  4  (all even → parity 0)
         ///    - Parity is odd (1) only when: (1,1) or (2,2)
         ///    - Condition: rowMod3 != 0 AND rowMod3 == colMod3
-        /// 
+        ///
         /// Final result:
         ///    ((p2) + (p3)) % 2 == 0  ⟺  p2 ^ p3 == 0  (XOR for parity)
-        /// 
+        ///
         /// Benefit: Eliminates multiplication and modulo operations entirely
         /// </code>
-        /// 
+        ///
         /// Example:
         /// <code>
         /// # Basic formula:
@@ -798,7 +899,7 @@ internal static partial class ModulePlacer
         /// (1,1): (1%2 + 1%3)%2 = (1+1)%2 = 0 → true  ■
         /// (2,1): (2%2 + 2%3)%2 = (0+2)%2 = 0 → true  ■
         /// (1,2): (2%2 + 2%3)%2 = (0+2)%2 = 0 → true  ■
-        /// 
+        ///
         /// # Optimized:
         /// (0,0): p2=0 &amp; 0=0, p3=(0!=0 &amp;&amp; 0==0)=0 → 0^0=0 → true  ■
         /// (1,1): p2=1 &amp; 1=1, p3=(1!=0 &amp;&amp; 1==1)=1 → 1^1=0 → true  ■
@@ -835,7 +936,7 @@ internal static partial class ModulePlacer
         /// <code>
         /// (((x+y) % 2) + ((x·y) % 3)) % 2 == 0
         /// </code>
-        /// 
+        ///
         /// Visual Pattern (12×12 sample, ■=dark, □=light):
         /// <code>
         /// ■□■□■□■□■□■□
@@ -851,7 +952,7 @@ internal static partial class ModulePlacer
         /// ■□■■□■■□■■□■
         /// □■■■■■□■■■■□
         /// </code>
-        /// 
+        ///
         /// Hybrid Pattern:
         /// <code>
         /// Combines two components:
@@ -859,16 +960,16 @@ internal static partial class ModulePlacer
         /// 2. Product grid: (x·y) % 3
         /// Result is dark when their sum is even
         /// </code>
-        /// 
+        ///
         /// Optimization Strategy:
         /// <code>
         /// (x+y) % 2: Use pre-calculated rowMod2 + colMod2
         /// (x·y) % 3: Calculate at runtime (cannot pre-calculate)
-        /// 
+        ///
         /// Mathematical property: (a%2) + (b%2) ∈ {0, 1, 2}
         /// Final check: ((sum) + (product%3)) &amp; 1 == 0
         /// </code>
-        /// 
+        ///
         /// Example:
         /// <code>
         /// (0,0): ((0+0)%2 + 0%3)%2 = (0+0)%2 = 0 → true  ■

--- a/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/ModulePlacer.cs
@@ -47,12 +47,18 @@ internal static partial class ModulePlacer
         // Ref-based access below elides per-module bounds checks, so validate the
         // whole traversal range here. size >= 7 keeps the strip column x >= 1
         // (real QR sizes are 21..177), so b-1 never goes negative.
+        // The module count is computed in long: an int size*size would overflow
+        // for size >= 46341 and could wrap below the actual span lengths, letting
+        // the unchecked writes run out of bounds. With long, any size whose square
+        // exceeds int range can never satisfy the length checks and throws here;
+        // for every size that passes, the int index arithmetic below is exact.
         if (size < 7)
             throw new ArgumentOutOfRangeException(nameof(size), $"size must be >= 7, got {size}");
-        if (buffer.Length < size * size)
-            throw new ArgumentException($"buffer too small: required {size * size}, got {buffer.Length}", nameof(buffer));
-        if (blockedMask.Length < (size * size + 7) / 8)
-            throw new ArgumentException($"blockedMask too small: required {(size * size + 7) / 8}, got {blockedMask.Length}", nameof(blockedMask));
+        var totalModules = (long)size * size;
+        if (buffer.Length < totalModules)
+            throw new ArgumentException($"buffer too small: required {totalModules}, got {buffer.Length}", nameof(buffer));
+        if (blockedMask.Length < (totalModules + 7) / 8)
+            throw new ArgumentException($"blockedMask too small: required {(totalModules + 7) / 8}, got {blockedMask.Length}", nameof(blockedMask));
 
         var up = true;
 

--- a/tests/SkiaSharp.QrCode.Tests/ModulePlacerPlaceDataWordsParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/ModulePlacerPlaceDataWordsParityTest.cs
@@ -111,6 +111,23 @@ public class ModulePlacerPlaceDataWordsParityTest
             ModulePlacer.PlaceDataWords(buffer, 6, data, mask));
     }
 
+    [Theory]
+    [InlineData(46341)]      // smallest size whose square overflows int
+    [InlineData(65536)]      // size*size wraps to exactly 0 in int
+    [InlineData(int.MaxValue)]
+    public void PlaceDataWords_SizeSquareOverflowsInt_Throws(int size)
+    {
+        // size*size computed in int would wrap (to a small or negative value)
+        // and slip past the length validation, letting the unchecked writes run
+        // out of bounds. The validation must reject these instead.
+        var buffer = new byte[64];
+        var mask = new byte[64];
+        var data = new byte[8];
+
+        Assert.Throws<ArgumentException>(() =>
+            ModulePlacer.PlaceDataWords(buffer, size, data, mask));
+    }
+
     /// <summary>
     /// Builds the matrix state right before data placement the same way
     /// QRCodeGenerator.WriteQRMatrix does: all function patterns placed via

--- a/tests/SkiaSharp.QrCode.Tests/ModulePlacerPlaceDataWordsParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/ModulePlacerPlaceDataWordsParityTest.cs
@@ -1,0 +1,194 @@
+using SkiaSharp.QrCode.Internals;
+using Xunit;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// Verifies that the accumulator-based PlaceDataWords (sequential 64-bit stream
+/// reader + column-pair fast path + ref access) produces a byte-identical
+/// matrix to a naive per-module reference implementation of ISO/IEC 18004
+/// Section 7.7.3 (symbol character placement).
+/// The reference walks the zigzag one module at a time and extracts each data
+/// bit with an indexed byte load, deliberately independent from the production
+/// bit tricks.
+/// </summary>
+public class ModulePlacerPlaceDataWordsParityTest
+{
+    // Versions covering all structural cases:
+    // 1 (no alignment patterns), 2/5/6 (alignment, no version info),
+    // 7/10 (version info), 11/12/13, 20/40 (large matrices, multiple
+    // alignment rows).
+    public static TheoryData<int> Versions => [1, 2, 5, 6, 7, 10, 11, 12, 13, 20, 40];
+
+    [Theory]
+    [MemberData(nameof(Versions))]
+    public void PlaceDataWords_MatchesPerModuleReference(int version)
+    {
+        var (pristine, blockedMask, size, freeModules) = BuildFixture(version);
+
+        // Stream lengths covering every consumption path:
+        // floor(capacity)  = real-world shape (0-7 remainder modules left empty)
+        // ceil(capacity)   = stream outlives the free modules
+        // 5 bytes          = stream exhausts early (early-return path)
+        // 0 bytes          = nothing placed
+        int[] dataLengths = [freeModules / 8, (freeModules + 7) / 8, 5, 0];
+
+        foreach (var dataLength in dataLengths)
+        {
+            for (var seed = 0; seed < 3; seed++)
+            {
+                var data = new byte[dataLength];
+                new Random(seed).NextBytes(data);
+
+                var expected = (byte[])pristine.Clone();
+                ReferencePlaceDataWords(expected, size, data, blockedMask);
+
+                var actual = (byte[])pristine.Clone();
+                ModulePlacer.PlaceDataWords(actual, size, data, blockedMask);
+
+                Assert.Equal(expected, actual);
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Versions))]
+    public void PlaceDataWords_AllZeroAndAllOneData_MatchesReference(int version)
+    {
+        // Degenerate streams exercise the fast path with constant accumulator
+        // contents (every 2-bit consume identical).
+        var (pristine, blockedMask, size, freeModules) = BuildFixture(version);
+
+        foreach (var fill in new byte[] { 0x00, 0xFF })
+        {
+            var data = new byte[freeModules / 8];
+            data.AsSpan().Fill(fill);
+
+            var expected = (byte[])pristine.Clone();
+            ReferencePlaceDataWords(expected, size, data, blockedMask);
+
+            var actual = (byte[])pristine.Clone();
+            ModulePlacer.PlaceDataWords(actual, size, data, blockedMask);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void PlaceDataWords_UndersizedBuffer_Throws()
+    {
+        var (_, blockedMask, size, _) = BuildFixture(1);
+        var data = new byte[8];
+
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var small = new byte[size * size - 1];
+            ModulePlacer.PlaceDataWords(small, size, data, blockedMask);
+        });
+    }
+
+    [Fact]
+    public void PlaceDataWords_UndersizedBlockedMask_Throws()
+    {
+        var (pristine, blockedMask, size, _) = BuildFixture(1);
+        var data = new byte[8];
+
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var smallMask = blockedMask.AsSpan(0, blockedMask.Length - 1);
+            ModulePlacer.PlaceDataWords(pristine, size, data, smallMask);
+        });
+    }
+
+    [Fact]
+    public void PlaceDataWords_TooSmallSize_Throws()
+    {
+        var buffer = new byte[36];
+        var mask = new byte[5];
+        var data = new byte[4];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ModulePlacer.PlaceDataWords(buffer, 6, data, mask));
+    }
+
+    /// <summary>
+    /// Builds the matrix state right before data placement the same way
+    /// QRCodeGenerator.WriteQRMatrix does: all function patterns placed via
+    /// ModulePlacer and the blocked bitmask built.
+    /// </summary>
+    private static (byte[] Buffer, byte[] BlockedMask, int Size, int FreeModules) BuildFixture(int version)
+    {
+        var size = 21 + (version - 1) * 4;
+        var buffer = new byte[size * size];
+
+        var blockedModules = new Rectangle[128];
+        var blockedCount = 0;
+        var alignmentPatternLocations = GetAlignmentPatternPositions(version);
+
+        ModulePlacer.PlaceFinderPatterns(buffer, size, blockedModules, ref blockedCount);
+        ModulePlacer.ReserveSeparatorAreas(size, blockedModules, ref blockedCount);
+        ModulePlacer.PlaceAlignmentPatterns(buffer, size, alignmentPatternLocations, blockedModules, ref blockedCount);
+        ModulePlacer.PlaceTimingPatterns(buffer, size, blockedModules, ref blockedCount);
+        ModulePlacer.PlaceDarkModule(buffer, size, version, blockedModules, ref blockedCount);
+        ModulePlacer.ReserveVersionAreas(size, version, blockedModules, ref blockedCount);
+
+        var blockedMask = new byte[(size * size + 7) / 8];
+        QRCodeGenerator.BuildBlockedMask(blockedMask, size, blockedModules.AsSpan(0, blockedCount));
+
+        var freeModules = 0;
+        for (var i = 0; i < size * size; i++)
+        {
+            if ((blockedMask[i >> 3] & (1 << (i & 7))) == 0) freeModules++;
+        }
+
+        return (buffer, blockedMask, size, freeModules);
+    }
+
+    private static List<Point> GetAlignmentPatternPositions(int version)
+    {
+        var table = QRCodeConstants.AlignmentPatternTable;
+        for (var i = 0; i < table.Count; i++)
+        {
+            if (table[i].Version == version)
+                return table[i].PatternPositions;
+        }
+        throw new InvalidOperationException($"Alignment pattern positions not found for version {version}");
+    }
+
+    // ---------------------------------
+    // Naive per-module reference
+    // ---------------------------------
+
+    /// <summary>Plain ISO/IEC 18004 Section 7.7.3 zigzag placement, one module and one indexed bit load at a time.</summary>
+    private static void ReferencePlaceDataWords(byte[] buffer, int size, byte[] interleavedData, byte[] blockedMask)
+    {
+        var bitPos = 0;
+        var totalBits = interleavedData.Length * 8;
+        var up = true;
+
+        for (var x = size - 1; x >= 0; x -= 2)
+        {
+            if (x == 6)
+                x--;
+
+            for (var yMod = 1; yMod <= size; yMod++)
+            {
+                var y = up ? size - yMod : yMod - 1;
+
+                for (var xOffset = 0; xOffset < 2; xOffset++)
+                {
+                    var bitIndex = y * size + (x - xOffset);
+
+                    if ((blockedMask[bitIndex >> 3] & (1 << (bitIndex & 7))) == 0 && bitPos < totalBits)
+                    {
+                        var bit = (interleavedData[bitPos >> 3] & (1 << (7 - (bitPos & 7)))) != 0;
+                        buffer[bitIndex] = bit ? (byte)1 : (byte)0;
+                        bitPos++;
+                    }
+                }
+            }
+
+            up = !up;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Rewrites `ModulePlacer.PlaceDataWords` (byte-span overload) with a bit-packed read path: a sequential 64-bit MSB-aligned accumulator for the data stream, a column-pair fast path driven by a 2-bit blocked-mask window, early return on stream exhaustion, and ref-based access with one-time up-front range validation. **~2x faster at every QR version, zero allocations, byte-identical output.**

## Intent

`PlaceDataWords` was the largest remaining hot spot after the ECC / MaskCode / QRCodeData optimizations, accounting for ~12–18% of end-to-end generation time (32.5 μs of 175.7 μs at version 40). The previous implementation paid per module: an indexed data byte load + variable shift, a blocked-mask lookup, a remaining-bits compare, and a data-dependent branch.

The rewrite exploits two structural facts:

- Data bits are consumed strictly sequentially, so the next up-to-64 bits can live MSB-aligned in a register (refilled 8 bytes at a time) instead of being re-extracted per bit.
- The two modules of a zigzag strip row sit at adjacent bit indices (`b`, `b-1`) in the blocked mask, and ~90% of rows have both free — one 2-bit window read + one 2-bit consume handles the pair.

Each step was validated in an isolated micro-benchmark loop (baseline-faithful copy, one hypothesis per variant, byte-identical correctness gate, JIT disassembly review). Refuted alternatives (branchless-only, 16-bit mask window, merged 16-bit stores, rect-derived segment loop) are measured and rejected.

## Expected behavior

- No functional change: output is byte-identical to the previous implementation. Verified by new parity tests against a naive per-module ISO/IEC 18004 §7.7.3 reference (`ModulePlacerPlaceDataWordsParityTest`) across versions 1–40, stream lengths (full / overfull / short / empty), random and degenerate all-0/all-1 streams.
- New up-front argument validation (`size >= 7`, buffer/mask length) throws `ArgumentException` / `ArgumentOutOfRangeException` for invalid inputs that previously failed via span bounds checks; this makes the ref-based access provably in-bounds. Internal API, single caller (`WriteQRMatrix`) unaffected.
- The deprecated string-based overload is unchanged.

## Benchmarks

Kernel (BenchmarkDotNet, 15 iterations, .NET 10, Ryzen 9 7950X3D):

| Scenario | Before | After | Ratio |
|---|---:|---:|---:|
| v1 (21×21) | 373.5 ns | 178.0 ns | 0.51 |
| v10 (57×57) | 3,552 ns | 1,532 ns | 0.46 |
| v40 (177×177) | 35,357 ns | 16,933 ns | 0.49 |

End-to-end (`QrCodeEndToEnd`, public `CreateQrCode` API):

| Scenario | Before | After | Δ |
|---|---:|---:|---:|
| Short_M | 2.91 μs | 2.73 μs | -6% |
| Url_M | 7.78 μs | 6.56 μs | -16% |
| Long_L (v40) | 175.7 μs | 153.3 μs | -13% |
| Long_H (v40) | 161.9 μs | 144.6 μs | -11% |

Allocations unchanged in all scenarios.