### PR TITLE
feat: Faster interleaving via sequential writes, branchless column loops, and a single-block copy fast path.

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BinaryInterleaver.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BinaryInterleaver.cs
@@ -1,3 +1,6 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 namespace SkiaSharp.QrCode.Internals.BinaryEncoders;
 
 internal static class BinaryInterleaver
@@ -17,44 +20,102 @@ internal static class BinaryInterleaver
         // 1. Data codewords are interleaved in round-robin order from all blocks
         // 2. ECC codewords are interleaved in round-robin order from all blocks
         // 3. Final sequence follows QR code specification for optimal error correction
+        //
+        // Writing the output sequentially makes the source access strided (block length);
+        // the reverse (sequential reads, strided writes) measured consistently slower in benchmarks.
+        //
+        // Image
+        // data:  [D1 D2 D3 | D4 D5 D6]
+        // ↑ stride=3, row0: D1, D4
+        // ↑ stride=3, row1: D2, D5
+        // ↑ stride=3, row2: D3, D6
+        // output: D1 D4 D2 D5 D3 D6 | (Same for ECC)
 
-        var outputIndex = 0;
-        var totalBlocks = eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2;
-        var maxCodewordCount = Math.Max(eccInfo.CodewordsInGroup1, eccInfo.CodewordsInGroup2);
+        var g1Blocks = eccInfo.BlocksInGroup1;
+        var g1Cw = eccInfo.CodewordsInGroup1;
+        var g2Blocks = eccInfo.BlocksInGroup2;
+        var g2Cw = g2Blocks > 0 ? eccInfo.CodewordsInGroup2 : 0;
+        var group2Offset = g1Blocks * g1Cw;
+        var totalBlocks = g1Blocks + g2Blocks;
+        var eccPerBlock = eccInfo.ECCPerBlock;
 
-        // Interleave data codewords
-        for (var i = 0; i < maxCodewordCount; i++)
+        // Upfront validation so the ref arithmetic below cannot leave the buffers
+        var dataLen = group2Offset + g2Blocks * g2Cw;
+        var eccLen = totalBlocks * eccPerBlock;
+        if (data.Length < dataLen)
+            throw new ArgumentException($"Data buffer too small: required {dataLen}, got {data.Length}", nameof(data));
+        if (ecc.Length < eccLen)
+            throw new ArgumentException($"ECC buffer too small: required {eccLen}, got {ecc.Length}", nameof(ecc));
+        if (output.Length < dataLen + eccLen)
+            throw new ArgumentException($"Output buffer too small: required {dataLen + eccLen}, got {output.Length}", nameof(output));
+
+        // Single block: interleaving is the identity permutation (versions 1-2 at most
+        // ECC levels, v5L, ...) — two sequential copies, ~5x faster than the loop
+        if (totalBlocks == 1)
         {
-            // Group 1 blocks
-            for (var blockIndex = 0; blockIndex < eccInfo.BlocksInGroup1; blockIndex++)
-            {
-                if (i < eccInfo.CodewordsInGroup1)
-                {
-                    var dataIndex = blockIndex * eccInfo.CodewordsInGroup1 + i;
-                    output[outputIndex++] = data[dataIndex];
-                }
-            }
+            data.Slice(0, dataLen).CopyTo(output);
+            ecc.Slice(0, eccLen).CopyTo(output.Slice(dataLen));
+            return;
+        }
 
-            // Group 2 blocks
-            var group2Offset = eccInfo.BlocksInGroup1 * eccInfo.CodewordsInGroup1;
-            for (var blockIndex = 0; blockIndex < eccInfo.BlocksInGroup2; blockIndex++)
+        ref var src = ref MemoryMarshal.GetReference(data);
+        ref var dst = ref MemoryMarshal.GetReference(output);
+
+        // Rows where every block contributes: group 1 blocks then group 2 blocks,
+        // walking each column with an additive stride (the block length)
+        var common = g2Blocks > 0 ? Math.Min(g1Cw, g2Cw) : g1Cw;
+        var i = 0;
+        for (; i < common; i++)
+        {
+            var idx = i;
+            for (var b = 0; b < g1Blocks; b++)
             {
-                if (i < eccInfo.CodewordsInGroup2)
-                {
-                    var dataOffset = group2Offset + blockIndex * eccInfo.CodewordsInGroup2 + i;
-                    output[outputIndex++] = data[dataOffset];
-                }
+                dst = Unsafe.Add(ref src, idx);
+                dst = ref Unsafe.Add(ref dst, 1);
+                idx += g1Cw;
+            }
+            idx = group2Offset + i;
+            for (var b = 0; b < g2Blocks; b++)
+            {
+                dst = Unsafe.Add(ref src, idx);
+                dst = ref Unsafe.Add(ref dst, 1);
+                idx += g2Cw;
             }
         }
 
-        // Interleave ECC codewords
-        for (var i = 0; i < eccInfo.ECCPerBlock; i++)
+        // Tail rows: only the group with longer blocks still has codewords
+        // (in real QR patterns g2Cw == g1Cw + 1, so at most one row remains)
+        for (; i < g1Cw; i++)
         {
-            for (var blockIndex = 0; blockIndex < totalBlocks; blockIndex++)
+            var idx = i;
+            for (var b = 0; b < g1Blocks; b++)
             {
-                var eccOffset = blockIndex * eccInfo.ECCPerBlock;
-                output[outputIndex] = ecc[eccOffset + i];
-                outputIndex++;
+                dst = Unsafe.Add(ref src, idx);
+                dst = ref Unsafe.Add(ref dst, 1);
+                idx += g1Cw;
+            }
+        }
+        for (var t = common; t < g2Cw; t++)
+        {
+            var idx = group2Offset + t;
+            for (var b = 0; b < g2Blocks; b++)
+            {
+                dst = Unsafe.Add(ref src, idx);
+                dst = ref Unsafe.Add(ref dst, 1);
+                idx += g2Cw;
+            }
+        }
+
+        // Interleave ECC codewords: all blocks have exactly eccPerBlock codewords
+        ref var eccSrc = ref MemoryMarshal.GetReference(ecc);
+        for (var e = 0; e < eccPerBlock; e++)
+        {
+            var idx = e;
+            for (var b = 0; b < totalBlocks; b++)
+            {
+                dst = Unsafe.Add(ref eccSrc, idx);
+                dst = ref Unsafe.Add(ref dst, 1);
+                idx += eccPerBlock;
             }
         }
 
@@ -95,7 +156,7 @@ internal static class BinaryInterleaver
         // eccInfo = {
         //     Version = 5,
         //     ErrorCorrectionLevel = Q,
-        //     TotalDataCodewords = 80,       // Data capacity
+        //     TotalDataCodewords = 62,       // Data capacity
         //     ECCPerBlock = 18,              // ECC Word count per block
         //     BlocksInGroup1 = 2,            // Group 1 block count
         //     CodewordsInGroup1 = 15,        // Group 1 data word count per block
@@ -104,11 +165,11 @@ internal static class BinaryInterleaver
         // };
         //
         // // Calculation:
-        // var dataCodewordsBits = 80 = 80 bytes
-        // var eccCodewordsBits = 18 * (2 + 2) = 72 bytes
-        // var remainderBits = GetRemainderBits(5) = 0 bits  // Version 5 has no module remainder bits
+        // var dataCodewordsBits = 62 * 8 = 496 bits
+        // var eccCodewordsBits = 18 * (2 + 2) * 8 = 576 bits
+        // var remainderBits = GetRemainderBits(5) = 7 bits
         //
-        // Total = 80 + 72 + 0 = 152 bytes
+        // Total = (496 + 576 + 7 + 7) / 8 = 135 bytes
         // -----------------------------------------------------
 
         var totalDataBytes = eccInfo.TotalDataCodewords;

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BinaryInterleaver.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BinaryInterleaver.cs
@@ -49,6 +49,13 @@ internal static class BinaryInterleaver
         if (output.Length < dataLen + eccLen)
             throw new ArgumentException($"Output buffer too small: required {dataLen + eccLen}, got {output.Length}", nameof(output));
 
+        // Zero the remainder-bits tail (at most 1 byte for CalculateInterleavedSize-sized
+        // buffers) so the output is deterministic even if the caller passes an
+        // uninitialized buffer (SkipLocalsInit stackalloc, pooled arrays). The remainder
+        // bits are consumed by ModulePlacer.PlaceDataWords and must be 0 per ISO/IEC 18004.
+        if (output.Length > dataLen + eccLen)
+            output.Slice(dataLen + eccLen).Clear();
+
         // Single block: interleaving is the identity permutation (versions 1-2 at most
         // ECC levels, v5L, ...) — two sequential copies, ~5x faster than the loop
         if (totalBlocks == 1)
@@ -119,7 +126,7 @@ internal static class BinaryInterleaver
             }
         }
 
-        // Remainder bits are already zeroed in the output buffer. No need to explicitly write remainder bits.
+        // Remainder bits were zeroed upfront (tail Clear after validation).
     }
 
     /// <summary>

--- a/tests/SkiaSharp.QrCode.Tests/BinaryInterleaverParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/BinaryInterleaverParityTest.cs
@@ -1,0 +1,164 @@
+using SkiaSharp.QrCode.Internals;
+using SkiaSharp.QrCode.Internals.BinaryEncoders;
+using Xunit;
+using static SkiaSharp.QrCode.Internals.QRCodeConstants;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// Verifies that the optimized InterleaveCodewords (single-block identity fast path +
+/// ref-arithmetic transpose with additive strides) produces byte-identical output to
+/// a naive per-element reference implementation of ISO/IEC 18004 Section 7.6
+/// (codeword interleaving). The reference walks rows with per-element index
+/// multiplication and range conditions, deliberately independent from the production
+/// pointer arithmetic.
+/// </summary>
+public class BinaryInterleaverParityTest
+{
+    public static TheoryData<int, ECCLevel> AllVersionLevelCombinations()
+    {
+        var data = new TheoryData<int, ECCLevel>();
+        for (var version = 1; version <= 40; version++)
+        {
+            foreach (var level in new[] { ECCLevel.L, ECCLevel.M, ECCLevel.Q, ECCLevel.H })
+            {
+                data.Add(version, level);
+            }
+        }
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(AllVersionLevelCombinations))]
+    public void InterleaveCodewords_MatchesReference_AllVersionsAndLevels(int version, ECCLevel level)
+    {
+        var eccInfo = GetEccInfo(version, level);
+        AssertMatchesReference(version, eccInfo);
+    }
+
+    [Fact]
+    public void InterleaveCodewords_MatchesReference_NonStandardPatterns()
+    {
+        // Patterns outside the real capacity table exercise the general path's
+        // structural edges: equal block lengths across groups, single blocks per
+        // group, group 2 only.
+        (int Version, ECCInfo EccInfo)[] patterns =
+        [
+            (1, new ECCInfo(1, ECCLevel.M, 6, 2, 2, 3, 0, 0)),   // group 1 only, 2 blocks
+            (5, new ECCInfo(5, ECCLevel.H, 7, 2, 1, 3, 1, 4)),   // 1+1 blocks, cw2 = cw1 + 1
+            (5, new ECCInfo(5, ECCLevel.H, 12, 2, 2, 3, 2, 3)),  // cw2 == cw1 (no tail row)
+            (5, new ECCInfo(5, ECCLevel.H, 8, 2, 0, 0, 2, 4)),   // group 2 only
+        ];
+
+        foreach (var (version, eccInfo) in patterns)
+        {
+            AssertMatchesReference(version, eccInfo);
+        }
+    }
+
+    [Fact]
+    public void InterleaveCodewords_UndersizedDataBuffer_Throws()
+    {
+        var eccInfo = GetEccInfo(5, ECCLevel.Q);
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var data = new byte[eccInfo.TotalDataCodewords - 1];
+            var ecc = new byte[(eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2) * eccInfo.ECCPerBlock];
+            var output = new byte[BinaryInterleaver.CalculateInterleavedSize(eccInfo, 5)];
+            BinaryInterleaver.InterleaveCodewords(data, ecc, output, 5, eccInfo);
+        });
+    }
+
+    [Fact]
+    public void InterleaveCodewords_UndersizedEccBuffer_Throws()
+    {
+        var eccInfo = GetEccInfo(5, ECCLevel.Q);
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var data = new byte[eccInfo.TotalDataCodewords];
+            var ecc = new byte[(eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2) * eccInfo.ECCPerBlock - 1];
+            var output = new byte[BinaryInterleaver.CalculateInterleavedSize(eccInfo, 5)];
+            BinaryInterleaver.InterleaveCodewords(data, ecc, output, 5, eccInfo);
+        });
+    }
+
+    [Fact]
+    public void InterleaveCodewords_UndersizedOutputBuffer_Throws()
+    {
+        var eccInfo = GetEccInfo(5, ECCLevel.Q);
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var data = new byte[eccInfo.TotalDataCodewords];
+            var ecc = new byte[(eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2) * eccInfo.ECCPerBlock];
+            var output = new byte[data.Length + ecc.Length - 1];
+            BinaryInterleaver.InterleaveCodewords(data, ecc, output, 5, eccInfo);
+        });
+    }
+
+    private static void AssertMatchesReference(int version, in ECCInfo eccInfo)
+    {
+        var dataLen = eccInfo.BlocksInGroup1 * eccInfo.CodewordsInGroup1
+                    + eccInfo.BlocksInGroup2 * eccInfo.CodewordsInGroup2;
+        var eccLen = (eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2) * eccInfo.ECCPerBlock;
+        var outputSize = BinaryInterleaver.CalculateInterleavedSize(eccInfo, version);
+
+        for (var seed = 0; seed < 3; seed++)
+        {
+            var data = new byte[dataLen];
+            var ecc = new byte[eccLen];
+            new Random(seed).NextBytes(data);
+            new Random(seed + 100).NextBytes(ecc);
+
+            var expected = new byte[outputSize];
+            ReferenceInterleaveCodewords(data, ecc, expected, eccInfo);
+
+            var actual = new byte[outputSize];
+            BinaryInterleaver.InterleaveCodewords(data, ecc, actual, version, eccInfo);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    /// <summary>
+    /// Naive reference: round-robin over rows with per-element index multiplication
+    /// and per-element range conditions (the pre-optimization implementation shape).
+    /// </summary>
+    private static void ReferenceInterleaveCodewords(ReadOnlySpan<byte> data, ReadOnlySpan<byte> ecc, Span<byte> output, in ECCInfo eccInfo)
+    {
+        var outputIndex = 0;
+        var totalBlocks = eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2;
+        var maxCodewordCount = Math.Max(eccInfo.CodewordsInGroup1, eccInfo.CodewordsInGroup2);
+
+        for (var i = 0; i < maxCodewordCount; i++)
+        {
+            for (var blockIndex = 0; blockIndex < eccInfo.BlocksInGroup1; blockIndex++)
+            {
+                if (i < eccInfo.CodewordsInGroup1)
+                {
+                    var dataIndex = blockIndex * eccInfo.CodewordsInGroup1 + i;
+                    output[outputIndex++] = data[dataIndex];
+                }
+            }
+
+            var group2Offset = eccInfo.BlocksInGroup1 * eccInfo.CodewordsInGroup1;
+            for (var blockIndex = 0; blockIndex < eccInfo.BlocksInGroup2; blockIndex++)
+            {
+                if (i < eccInfo.CodewordsInGroup2)
+                {
+                    var dataOffset = group2Offset + blockIndex * eccInfo.CodewordsInGroup2 + i;
+                    output[outputIndex++] = data[dataOffset];
+                }
+            }
+        }
+
+        for (var i = 0; i < eccInfo.ECCPerBlock; i++)
+        {
+            for (var blockIndex = 0; blockIndex < totalBlocks; blockIndex++)
+            {
+                var eccOffset = blockIndex * eccInfo.ECCPerBlock;
+                output[outputIndex] = ecc[eccOffset + i];
+                outputIndex++;
+            }
+        }
+    }
+}

--- a/tests/SkiaSharp.QrCode.Tests/BinaryInterleaverParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/BinaryInterleaverParityTest.cs
@@ -56,6 +56,36 @@ public class BinaryInterleaverParityTest
         }
     }
 
+    [Theory]
+    [InlineData(5, ECCLevel.Q)]  // multi-block (2+2), version with 7 remainder bits
+    [InlineData(5, ECCLevel.L)]  // single-block fast path, 7 remainder bits
+    [InlineData(1, ECCLevel.L)]  // single-block fast path, 0 remainder bits (no tail)
+    public void InterleaveCodewords_DirtyOutputBuffer_RemainderTailIsZeroed(int version, ECCLevel level)
+    {
+        // The remainder-bits byte is placed into the matrix by PlaceDataWords and must
+        // be 0 per ISO/IEC 18004 — the function must not rely on the caller handing
+        // over a pre-zeroed buffer (SkipLocalsInit stackalloc, pooled arrays).
+        var eccInfo = GetEccInfo(version, level);
+        var dataLen = eccInfo.TotalDataCodewords;
+        var eccLen = (eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2) * eccInfo.ECCPerBlock;
+        var outputSize = BinaryInterleaver.CalculateInterleavedSize(eccInfo, version);
+
+        var data = new byte[dataLen];
+        var ecc = new byte[eccLen];
+        new Random(1).NextBytes(data);
+        new Random(101).NextBytes(ecc);
+
+        var output = new byte[outputSize];
+        output.AsSpan().Fill(0xFF); // dirty buffer
+
+        BinaryInterleaver.InterleaveCodewords(data, ecc, output, version, eccInfo);
+
+        for (var i = dataLen + eccLen; i < outputSize; i++)
+        {
+            Assert.Equal(0, output[i]);
+        }
+    }
+
     [Fact]
     public void InterleaveCodewords_UndersizedDataBuffer_Throws()
     {


### PR DESCRIPTION
## Summary

Optimize `BinaryInterleaver.InterleaveCodewords` (QR codeword interleaving): add an identity-copy fast path for single-block versions and replace the per-element indexed loops with a bounds-check-free transpose using upfront range validation, ref arithmetic, and additive strides. Also fixes an incorrect v5-Q example in the `CalculateInterleavedSize` doc comment (62 data codewords / 135 bytes, not 80 / 152).

## Intent

The previous implementation paid, per element: a bounds check on both source and destination, an index multiplication, and per-row-invariant `if (i < CodewordsInGroupN)` branches evaluated inside the block loop. For single-block versions (v1–v2 at most ECC levels, v5-L, ...) interleaving is the identity permutation, yet the full round-robin loop still ran.

Variant search was done with BenchmarkDotNet (15 iterations + JIT disassembly) over real ECC block patterns. Notable refuted hypotheses, so they don't get retried later:

- Inverted loop order (sequential reads / strided writes) — consistently slower than sequential writes / strided reads.
- Wide-load chunking (one 64/32-bit load per 8/4 codewords, scattered byte stores) — no reliable win; the workload is L1-resident and the scattered stores cancel the saved loads.

## Expected behavior

No functional change — output is byte-identical to the previous implementation. Verified by a new parity test (`BinaryInterleaverParityTest`) comparing against a naive reference across all 160 version/ECC-level patterns × 3 seeds, plus non-standard block-shape edge cases.

One intentional hardening: undersized `data`/`ecc`/`output` buffers now throw `ArgumentException` with a clear message upfront (previously `IndexOutOfRangeException` mid-write), guarding the ref arithmetic.

## Benchmarks

Kernel (micro-benchmark, AMD Ryzen 9 7950X3D, .NET 10, 15 iterations):

| Scenario | Blocks | Before | After | Speedup |
|---|---|---:|---:|---:|
| v1-M | 1 | 24.0 ns | 4.7 ns | **~5.1x** |
| v5-Q | 2+2 | 82.4 ns | 41.7 ns | ~2.0x |
| v40-L | 19+6 | 1,975 ns | 859 ns | ~2.3x |
| v40-H | 20+61 | 1,902 ns | 953 ns | ~2.0x |

Allocations: 0 B before and after.

End-to-end (`QrCodeEndToEnd`, coarse 1-iteration config):

| Scenario | Before | After |
|---|---:|---:|
| Short_M | 2.75 µs | 2.67 µs |
| Url_M | 6.34 µs | 6.26 µs |
| Long_L | 152.0 µs | 152.1 µs |
| Long_H | 142.1 µs | 143.0 µs |

Interleaving is ~1.3% of end-to-end generation time, so the E2E impact is small (slight gain on small QR codes, noise-level on large ones); the win is at the kernel level.