### PR TITLE
feat: Rewrite BitWriter around an MSB-first ulong accumulator with bulk 32/64-bit stores, and update QRBinaryEncoder to use the faster write, flush, and pad paths.

### DIFF
--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BitWriter.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/BitWriter.cs
@@ -1,17 +1,28 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace SkiaSharp.QrCode.Internals.BinaryEncoders;
 
 /// <summary>
-/// Writes bit to a byte buffer with precise bit-level control.
+/// Writes bits to a byte buffer with precise bit-level control (MSB-first).
 /// Used for QR code data encoding.
 /// </summary>
+/// <remarks>
+/// Bits are staged in a 64-bit accumulator and stored as 32-bit big-endian words
+/// once available, so up to 31 bits stay pending between writes. Buffer contents
+/// are only guaranteed after <see cref="Flush"/> (called by <see cref="GetData"/>
+/// and <see cref="WritePadBytes"/>); <see cref="BitPosition"/> and
+/// <see cref="ByteCount"/> are always valid.
+/// The caller guarantees the buffer is large enough for all writes; exceeding it
+/// surfaces as an out-of-range exception from the underlying span access.
+/// </remarks>
 internal ref struct BitWriter
 {
     private Span<byte> _buffer;
     private int _bytePosition;
-    private byte _accumulator;
-    private int _accumulatorBits;
+    private ulong _accumulator;   // pending bits stored at the top (MSB-first)
+    private int _accumulatorBits; // 0..31 between writes
 
     /// <summary>
     /// Current bit position in the buffer.
@@ -24,7 +35,7 @@ internal ref struct BitWriter
     /// <remarks>
     /// If written 9 bits, this will be 2
     /// </remarks>
-    public int ByteCount => _bytePosition + (_accumulatorBits > 0 ? 1 : 0);
+    public int ByteCount => _bytePosition + (_accumulatorBits + 7) / 8;
 
     public BitWriter(Span<byte> buffer)
     {
@@ -32,97 +43,100 @@ internal ref struct BitWriter
         _bytePosition = 0;
         _accumulator = 0;
         _accumulatorBits = 0;
-        buffer.Clear(); // 0 initialization
+        // No upfront clear: every byte in [0, ByteCount) is stored by
+        // Write/Flush/WritePadBytes, so zero-initialization is redundant.
     }
 
     /// <summary>
-    /// Writes specified number of bits from value (LSB first)
+    /// Writes specified number of bits from value (MSB of the value range first).
     /// </summary>
-    /// <param name="value"></param>
-    /// <param name="bitCount"></param>
+    /// <param name="value">Value whose low <paramref name="bitCount"/> bits are written.</param>
+    /// <param name="bitCount">Number of bits to write (1-32).</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(int value, int bitCount)
     {
-        // --------------------------------------------
-        // if Write(0b101, 3) & bit position is 0
-        // --------------------------------------------
-        // step 1: (i = 2), (bit = (0b101 >> 2) & 1 => 1), (byteIndex = 0), (bitIndex = 7 - (0 % 8) => 7), (_buffer[0] after write => 10000000), (_bitPosition = 1)
-        // step 2: (i = 1), (bit = (0b101 >> 1) & 1 => 0), (byteIndex = 0), (bitIndex = 7 - (1 % 8) => 6), (_buffer[0] after write => 10000000), (_bitPosition = 2)
-        // step 3: (i = 0), (bit = (0b101 >> 0) & 1 => 1), (byteIndex = 0), (bitIndex = 7 - (2 % 8) => 5), (_buffer[0] after write => 10100000), (_bitPosition = 3)
-        // Result: _buffer[0] = 0b10100000
-        // --------------------------------------------
+        Debug.Assert(bitCount >= 1 && bitCount <= 32, "bitCount must be between 1 and 32");
 
-        if (bitCount < 1 || bitCount > 32)
-            throw new ArgumentOutOfRangeException(nameof(bitCount), "bitCount must be between 1 and 32");
+        // stage: place the value's low bitCount bits directly below the pending bits
+        // headroom: _accumulatorBits <= 31, bitCount <= 32 -> at most 63 bits pending
+        var v = (ulong)(uint)value & ((1UL << bitCount) - 1);
+        _accumulator |= v << (64 - _accumulatorBits - bitCount);
+        _accumulatorBits += bitCount;
 
-        if (BitPosition + bitCount > _buffer.Length * 8)
-            throw new InvalidOperationException($"Buffer overflow: trying to write {bitCount} bits at position {BitPosition}, buffer size: {_buffer.Length * 8} bits");
-
-        // 16 bits over, split into two writes
-        if (bitCount > 16)
+        // store a full 32-bit word once available
+        if (_accumulatorBits >= 32)
         {
-            var highBits = bitCount - 16;
-            Write(value >> 16, highBits);
-            Write(value & 0xFFFF, 16);
-            return;
+            BinaryPrimitives.WriteUInt32BigEndian(_buffer.Slice(_bytePosition), (uint)(_accumulator >> 32));
+            _bytePosition += 4;
+            _accumulator <<= 32;
+            _accumulatorBits -= 32;
         }
+    }
 
-        // 8 bits over and accumulator is empty, split into two writes
-        if (bitCount > 8 && _accumulatorBits == 0)
-        {
-            var highBits = bitCount - 8;
-            WriteInternal(value >> 8, highBits);
-            WriteInternal(value & 0xFF, 8);
-        }
-        else
-        {
-            WriteInternal(value, bitCount);
-        }
+    /// <summary>
+    /// Writes 64 bits at once (bulk path for byte-mode data).
+    /// </summary>
+    /// <param name="value">Big-endian bit sequence: the MSB is written first.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Write64(ulong value)
+    {
+        // merge pending bits with the head of the value and store 8 bytes;
+        // the displaced tail bits stay pending (count unchanged)
+        var combined = _accumulator | (value >> _accumulatorBits);
+        BinaryPrimitives.WriteUInt64BigEndian(_buffer.Slice(_bytePosition), combined);
+        _bytePosition += 8;
+        _accumulator = _accumulatorBits == 0 ? 0UL : value << (64 - _accumulatorBits);
+    }
 
-        // if there are remaining bits in the accumulator, flush them to the buffer
+    /// <summary>
+    /// Stores all pending bits to the buffer. Full bytes advance the position;
+    /// a trailing partial byte is stored (low bits zero) without advancing.
+    /// Idempotent; writing may continue afterwards.
+    /// </summary>
+    public void Flush()
+    {
+        while (_accumulatorBits >= 8)
+        {
+            _buffer[_bytePosition++] = (byte)(_accumulator >> 56);
+            _accumulator <<= 8;
+            _accumulatorBits -= 8;
+        }
         if (_accumulatorBits > 0)
         {
-            _buffer[_bytePosition] = _accumulator;
+            _buffer[_bytePosition] = (byte)(_accumulator >> 56);
         }
     }
 
     /// <summary>
-    /// Internal write logic that assumes bitCount <= 16 and fits in the buffer
+    /// Writes alternating pad bytes (0xEC, 0x11, ...) directly to the buffer.
+    /// Requires the current position to be byte-aligned.
     /// </summary>
-    /// <param name="value"></param>
-    /// <param name="bitCount"></param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void WriteInternal(int value, int bitCount)
+    public void WritePadBytes(int count)
     {
-        var remainingBits = bitCount;
-        while (remainingBits > 0)
+        // drain pending full bytes so _bytePosition is the true write position
+        while (_accumulatorBits >= 8)
         {
-            // decide how many bits to write in this iteration
-            var bitsToWrite = Math.Min(remainingBits, 8 - _accumulatorBits);
-
-            // extract the bits to write (from MSB)
-            var shift = remainingBits - bitsToWrite;
-            var mask = (1 << bitsToWrite) - 1;
-            var bits = (value >> shift) & mask;
-
-            // add to accumulator
-            _accumulator |= (byte)(bits << (8 - _accumulatorBits - bitsToWrite));
-            _accumulatorBits += bitsToWrite;
-            remainingBits -= bitsToWrite;
-
-            // if accumulator is full, write to buffer
-            if (_accumulatorBits == 8)
-            {
-                _buffer[_bytePosition++] = _accumulator;
-                _accumulator = 0;
-                _accumulatorBits = 0;
-            }
+            _buffer[_bytePosition++] = (byte)(_accumulator >> 56);
+            _accumulator <<= 8;
+            _accumulatorBits -= 8;
         }
+        Debug.Assert(_accumulatorBits == 0, "Pad fill requires byte alignment");
+
+        var span = _buffer.Slice(_bytePosition, count);
+        for (var i = 0; i < span.Length; i++)
+        {
+            span[i] = (i & 1) == 0 ? (byte)0xEC : (byte)0x11;
+        }
+        _bytePosition += count;
     }
 
     /// <summary>
-    /// Gets the written data as a read-only span
+    /// Gets the written data as a read-only span (flushes pending bits first).
     /// </summary>
     /// <returns></returns>
-    public ReadOnlySpan<byte> GetData() => _buffer[..ByteCount];
+    public ReadOnlySpan<byte> GetData()
+    {
+        Flush();
+        return _buffer.Slice(0, ByteCount);
+    }
 }

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/QRBinaryEncoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/QRBinaryEncoder.cs
@@ -72,12 +72,17 @@ internal ref struct QRBinaryEncoder
         var currentBits = _writer.BitPosition;
         var remaining = targetBitCount - currentBits;
 
-        // 1. Terminator (up to 4 bits)
-        if (remaining > 0)
+        // Target already reached (or exceeded): nothing to pad. Only drain pending
+        // bits so callers can read the raw buffer; the position does not advance.
+        if (remaining <= 0)
         {
-            var terminatorBits = Math.Min(remaining, 4);
-            _writer.Write(0, terminatorBits);
+            _writer.Flush();
+            return;
         }
+
+        // 1. Terminator (up to 4 bits)
+        var terminatorBits = Math.Min(remaining, 4);
+        _writer.Write(0, terminatorBits);
 
         // 2. Byte boundary alignment (0-7 bits)
         var alignmentBits = (8 - _writer.BitPosition % 8) % 8;

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/QRBinaryEncoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/QRBinaryEncoder.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Text;
 
 namespace SkiaSharp.QrCode.Internals.BinaryEncoders;
@@ -85,12 +86,18 @@ internal ref struct QRBinaryEncoder
             _writer.Write(0, alignmentBits);
         }
 
-        // 3. Alternating pad bytes (0xEC, 0x11, 0xEC, 0x11, ...) until target length
-        var useEC = true;
-        while (_writer.BitPosition < targetBitCount)
+        // 3. Alternating pad bytes (0xEC, 0x11, 0xEC, 0x11, ...) until target length.
+        // The position is byte-aligned here, so the bytes are filled directly.
+        // Callers read the raw buffer after WritePadding, so both branches drain
+        // every pending bit to the buffer.
+        var padBytes = (targetBitCount - _writer.BitPosition) / 8;
+        if (padBytes > 0)
         {
-            _writer.Write(useEC ? 0xEC : 0x11, 8);
-            useEC = !useEC;
+            _writer.WritePadBytes(padBytes);
+        }
+        else
+        {
+            _writer.Flush();
         }
     }
 
@@ -106,10 +113,10 @@ internal ref struct QRBinaryEncoder
         switch (encoding)
         {
             case EncodingMode.Numeric:
-                EncodeNumeric(textSpan);
+                WriteNumericData(textSpan);
                 break;
             case EncodingMode.Alphanumeric:
-                EncodeAlphanumeric(textSpan);
+                WriteAlphanumericData(textSpan);
                 break;
             case EncodingMode.Byte:
                 EncodeByte(textSpan, eci, utf8Bom);
@@ -120,136 +127,26 @@ internal ref struct QRBinaryEncoder
     }
 
     /// <summary>
-    /// Writes numeric data from string 
+    /// Writes byte mode data based on ECI mode.
     /// </summary>
-    /// <param name="textSpan"></param>
-    private void EncodeNumeric(ReadOnlySpan<char> textSpan)
-    {
-        // Convert string to ASCII bytes (numeric chars are ASCII compatible)
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-        // ascii is 1 char = 1 byte, so length is same
-        if (textSpan.Length <= StackAllocThreshold)
-        {
-            Span<byte> asciiBytes = stackalloc byte[textSpan.Length];
-            var bytesWritten = Encoding.ASCII.GetBytes(textSpan, asciiBytes);
-            WriteNumericData(asciiBytes.Slice(0, bytesWritten));
-        }
-        else
-        {
-            var buffer = ArrayPool<byte>.Shared.Rent(textSpan.Length);
-            try
-            {
-                var bytesWritten = Encoding.ASCII.GetBytes(textSpan, buffer);
-                WriteNumericData(buffer.AsSpan(0, bytesWritten));
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
-        }
-#else
-        // Fallback for older frameworks without Span support
-        if (textSpan.Length <= StackAllocThreshold)
-        {
-            Span<byte> buffer = stackalloc byte[textSpan.Length];
-            for (int i = 0; i < textSpan.Length; i++)
-            {
-                buffer[i] = (byte)textSpan[i]; // direct cast since ASCII, avoids Span.ToString() allocation
-            }
-            WriteNumericData(buffer);
-        }
-        else
-        {
-            var rented = ArrayPool<byte>.Shared.Rent(textSpan.Length);
-            try
-            {
-                var buffer = rented.AsSpan(0, textSpan.Length);
-                for (int i = 0; i < textSpan.Length; i++)
-                {
-                    buffer[i] = (byte)textSpan[i];
-                }
-                WriteNumericData(buffer);
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(rented);
-            }
-        }
-#endif
-    }
-
-    /// <summary>
-    ///  Writes alphanumeric data from string
-    /// </summary>
-    /// <param name="textSpan"></param>
-    private void EncodeAlphanumeric(ReadOnlySpan<char> textSpan)
-    {
-        // Convert string to ASCII bytes (numeric chars are ASCII compatible)
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-        // ascii is 1 char = 1 byte, so length is same
-        if (textSpan.Length <= StackAllocThreshold)
-        {
-            Span<byte> asciiBytes = stackalloc byte[textSpan.Length];
-            var bytesWritten = Encoding.ASCII.GetBytes(textSpan, asciiBytes);
-            WriteAlphanumericData(asciiBytes.Slice(0, bytesWritten));
-        }
-        else
-        {
-            var buffer = ArrayPool<byte>.Shared.Rent(textSpan.Length);
-            try
-            {
-                var bytesWritten = Encoding.ASCII.GetBytes(textSpan, buffer);
-                WriteAlphanumericData(buffer.AsSpan(0, bytesWritten));
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
-        }
-#else
-        // Fallback for older frameworks without Span support
-        if (textSpan.Length <= StackAllocThreshold)
-        {
-            Span<byte> buffer = stackalloc byte[textSpan.Length];
-            for (int i = 0; i < textSpan.Length; i++)
-            {
-                buffer[i] = (byte)textSpan[i]; // direct cast since ASCII, avoids Span.ToString() allocation
-            }
-            WriteAlphanumericData(buffer);
-        }
-        else
-        {
-            var rented = ArrayPool<byte>.Shared.Rent(textSpan.Length);
-            try
-            {
-                var buffer = rented.AsSpan(0, textSpan.Length);
-                for (int i = 0; i < textSpan.Length; i++)
-                {
-                    buffer[i] = (byte)textSpan[i];
-                }
-                WriteAlphanumericData(buffer);
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(rented);
-            }
-        }
-#endif
-    }
-
-    /// <summary>
-    ///  Writes alphanumeric data from string
-    /// </summary>
-    /// <param name="textSpan"></param>
     private void EncodeByte(ReadOnlySpan<char> textSpan, EciMode eci, bool utf8Bom)
     {
-        // Determine encoding based on ECI mode
-        var maxByteCount = textSpan.Length * 4;
+        if (eci is EciMode.Default or EciMode.Iso8859_1)
+        {
+            // ISO-8859-1 is a pure narrowing cast for chars <= 0xFF (validated upstream by TextAnalyzer)
+            WriteLatin1Data(textSpan);
+            return;
+        }
 
+        if (eci != EciMode.Utf8)
+            throw new ArgumentOutOfRangeException(nameof(eci), "Unsupported ECI mode for Byte encoding");
+
+        // UTF-8: encode into a temporary buffer, then bulk-write
+        var maxByteCount = textSpan.Length * 4;
         if (maxByteCount <= StackAllocThreshold)
         {
             Span<byte> buffer = stackalloc byte[maxByteCount];
-            var length = GetByteData(textSpan, eci, utf8Bom, buffer);
+            var length = GetUtf8Data(textSpan, utf8Bom, buffer);
             WriteByteData(buffer.Slice(0, length));
         }
         else
@@ -257,7 +154,7 @@ internal ref struct QRBinaryEncoder
             var buffer = ArrayPool<byte>.Shared.Rent(maxByteCount);
             try
             {
-                var length = GetByteData(textSpan, eci, utf8Bom, buffer);
+                var length = GetUtf8Data(textSpan, utf8Bom, buffer);
                 WriteByteData(buffer.AsSpan(0, length));
             }
             finally
@@ -271,7 +168,7 @@ internal ref struct QRBinaryEncoder
     /// Writes numeric data (groups of 3 digits as 10 bits, 2 digits as 7 bits, 1 digit as 4 bits)
     /// </summary>
     /// <param name="digits"></param>
-    private void WriteNumericData(scoped ReadOnlySpan<byte> digits)
+    private void WriteNumericData(ReadOnlySpan<char> digits)
     {
         var i = 0;
         var length = digits.Length;
@@ -307,7 +204,7 @@ internal ref struct QRBinaryEncoder
     /// <remarks>
     /// Encoding: Groups of 2 chars → 11 bits, 1 char → 6 bits.
     /// </remarks>
-    private void WriteAlphanumericData(scoped ReadOnlySpan<byte> chars)
+    private void WriteAlphanumericData(ReadOnlySpan<char> chars)
     {
         var length = chars.Length;
         var i = 0;
@@ -318,8 +215,8 @@ internal ref struct QRBinaryEncoder
         // Process 2 characters at a time
         while (i + 1 < length)
         {
-            var value = QRCodeConstants.GetAlphanumericValue((char)chars[i]) * 45
-                + QRCodeConstants.GetAlphanumericValue((char)chars[i + 1]);
+            var value = QRCodeConstants.GetAlphanumericValue(chars[i]) * 45
+                + QRCodeConstants.GetAlphanumericValue(chars[i + 1]);
             _writer.Write(value, 11);
             i += 2;
         }
@@ -327,20 +224,76 @@ internal ref struct QRBinaryEncoder
         // Process remaining 1 character
         if (i < length)
         {
-            var value = QRCodeConstants.GetAlphanumericValue((char)chars[i]);
+            var value = QRCodeConstants.GetAlphanumericValue(chars[i]);
             _writer.Write(value, 6);
         }
     }
 
     /// <summary>
-    /// Writes byte data (each byte should be 8-bit)
+    /// Writes ISO-8859-1 (Latin-1) byte data directly from chars.
+    /// </summary>
+    /// <remarks>
+    /// Chars are pre-validated as ISO-8859-1 (&lt;= 0xFF), so encoding is a narrowing cast.
+    /// </remarks>
+    private void WriteLatin1Data(ReadOnlySpan<char> textSpan)
+    {
+#if NET5_0_OR_GREATER
+        // Encoding.Latin1 narrows chars with SIMD; then bulk-write 8 bytes per store
+        if (textSpan.Length <= StackAllocThreshold)
+        {
+            Span<byte> latin1 = stackalloc byte[textSpan.Length];
+            Encoding.Latin1.GetBytes(textSpan, latin1);
+            WriteByteData(latin1);
+        }
+        else
+        {
+            var buffer = ArrayPool<byte>.Shared.Rent(textSpan.Length);
+            try
+            {
+                var bytesWritten = Encoding.Latin1.GetBytes(textSpan, buffer);
+                WriteByteData(buffer.AsSpan(0, bytesWritten));
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+#else
+        // Scalar fallback: pack 8 narrowed chars into one big-endian ulong per store
+        var i = 0;
+        for (; i + 8 <= textSpan.Length; i += 8)
+        {
+            var v = ((ulong)(byte)textSpan[i] << 56)
+                | ((ulong)(byte)textSpan[i + 1] << 48)
+                | ((ulong)(byte)textSpan[i + 2] << 40)
+                | ((ulong)(byte)textSpan[i + 3] << 32)
+                | ((ulong)(byte)textSpan[i + 4] << 24)
+                | ((ulong)(byte)textSpan[i + 5] << 16)
+                | ((ulong)(byte)textSpan[i + 6] << 8)
+                | (byte)textSpan[i + 7];
+            _writer.Write64(v);
+        }
+        for (; i < textSpan.Length; i++)
+        {
+            _writer.Write((byte)textSpan[i], 8);
+        }
+#endif
+    }
+
+    /// <summary>
+    /// Writes byte data (each byte should be 8-bit), 8 bytes per store where possible.
     /// </summary>
     /// <param name="data"></param>
     private void WriteByteData(scoped ReadOnlySpan<byte> data)
     {
-        foreach (var b in data)
+        var i = 0;
+        for (; i + 8 <= data.Length; i += 8)
         {
-            _writer.Write(b, 8);
+            _writer.Write64(BinaryPrimitives.ReadUInt64BigEndian(data.Slice(i)));
+        }
+        for (; i < data.Length; i++)
+        {
+            _writer.Write(data[i], 8);
         }
     }
 
@@ -351,71 +304,47 @@ internal ref struct QRBinaryEncoder
     public ReadOnlySpan<byte> GetEncodedData() => _writer.GetData();
 
     /// <summary>
-    /// Gets byte data for Byte mode encoding.
+    /// Gets UTF-8 byte data (with optional BOM) for Byte mode encoding.
     /// </summary>
     /// <param name="textSpan">Text to encode.</param>
-    /// <param name="eciMode">ECI mode for character encoding.</param>
     /// <param name="utf8BOM">Whether to include UTF-8 BOM.</param>
     /// <param name="buffer">Buffer to use for encoding.</param>
-    /// <returns>Byte array representing the encoded text.</returns>
-    private static int GetByteData(ReadOnlySpan<char> textSpan, EciMode eciMode, bool utf8BOM, Span<byte> buffer)
+    /// <returns>Number of bytes written to the buffer.</returns>
+    private static int GetUtf8Data(ReadOnlySpan<char> textSpan, bool utf8BOM, Span<byte> buffer)
     {
-        return eciMode switch
-        {
-            EciMode.Default => EncodeISO88591(textSpan, buffer), // already validated as ISO-8859-1
-            EciMode.Iso8859_1 => EncodeISO88591(textSpan, buffer),
-            EciMode.Utf8 => EncodeUtf8(textSpan, utf8BOM, buffer),
-            _ => throw new ArgumentOutOfRangeException(nameof(eciMode), "Unsupported ECI mode for Byte encoding"),
-        };
-
-        static int EncodeISO88591(ReadOnlySpan<char> textSpan, Span<byte> buffer)
-        {
+        var offset = 0;
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-            return Encoding.GetEncoding("ISO-8859-1").GetBytes(textSpan, buffer);
+        if (utf8BOM)
+        {
+            var preamble = Encoding.UTF8.GetPreamble();
+            preamble.CopyTo(buffer);
+            offset += preamble.Length;
+
+            return offset + Encoding.UTF8.GetBytes(textSpan, buffer.Slice(offset));
+        }
+        else
+        {
+            return Encoding.UTF8.GetBytes(textSpan, buffer);
+        }
 #else
+        if (utf8BOM)
+        {
+            var preamble = Encoding.UTF8.GetPreamble();
+            preamble.CopyTo(buffer);
+            offset += preamble.Length;
+
             var input = textSpan.ToString();
-            ReadOnlySpan<byte> bytes = Encoding.GetEncoding("ISO-8859-1").GetBytes(input);
-            bytes.CopyTo(buffer);
-            return bytes.Length;
-#endif
+            ReadOnlySpan<byte> utf8bytes = Encoding.UTF8.GetBytes(input);
+            utf8bytes.CopyTo(buffer.Slice(offset));
+            return offset + utf8bytes.Length;
         }
-
-        static int EncodeUtf8(ReadOnlySpan<char> textSpan, bool utf8BOM, Span<byte> buffer)
+        else
         {
-            var offset = 0;
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-            if (utf8BOM)
-            {
-                var preamble = Encoding.UTF8.GetPreamble();
-                preamble.CopyTo(buffer);
-                offset += preamble.Length;
-
-                return offset + Encoding.UTF8.GetBytes(textSpan, buffer.Slice(offset));
-            }
-            else
-            {
-                return Encoding.UTF8.GetBytes(textSpan, buffer);
-            }
-#else
-            if (utf8BOM)
-            {
-                var preamble = Encoding.UTF8.GetPreamble();
-                preamble.CopyTo(buffer);
-                offset += preamble.Length;
-
-                var input = textSpan.ToString();
-                ReadOnlySpan<byte> utf8bytes = Encoding.UTF8.GetBytes(input);
-                utf8bytes.CopyTo(buffer.Slice(offset));
-                return offset + utf8bytes.Length;
-            }
-            else
-            {
-                var input = textSpan.ToString();
-                ReadOnlySpan<byte> utf8bytes = Encoding.UTF8.GetBytes(input);
-                utf8bytes.CopyTo(buffer);
-                return utf8bytes.Length;
-            }
-#endif
+            var input = textSpan.ToString();
+            ReadOnlySpan<byte> utf8bytes = Encoding.UTF8.GetBytes(input);
+            utf8bytes.CopyTo(buffer);
+            return utf8bytes.Length;
         }
+#endif
     }
 }

--- a/tests/SkiaSharp.QrCode.Tests/BitWriterUnitTests.cs
+++ b/tests/SkiaSharp.QrCode.Tests/BitWriterUnitTests.cs
@@ -12,8 +12,9 @@ public class BitWriterUnitTests
         var writer = new BitWriter(buffer);
 
         writer.Write(0b_10101010, 8);
+        var data = writer.GetData();
 
-        Assert.Equal(0xAA, buffer[0]);
+        Assert.Equal(0xAA, data[0]);
     }
 
     [Fact]
@@ -25,9 +26,10 @@ public class BitWriterUnitTests
         writer.Write(0b1111, 4);
         writer.Write(0b0000, 4);
         writer.Write(0b1010, 4);
+        var data = writer.GetData();
 
-        Assert.Equal(0xF0, buffer[0]);
-        Assert.Equal(0xA0, buffer[1]);
+        Assert.Equal(0xF0, data[0]);
+        Assert.Equal(0xA0, data[1]);
     }
 
     [Theory]
@@ -44,8 +46,9 @@ public class BitWriterUnitTests
         Span<byte> buffer = stackalloc byte[1];
         var writer = new BitWriter(buffer);
         writer.Write(value, bits);
+        var data = writer.GetData();
 
-        Assert.Equal(expected[0], buffer[0]);
+        Assert.Equal(expected[0], data[0]);
     }
 
     // Edge cases

--- a/tests/SkiaSharp.QrCode.Tests/QRBinaryEncoderUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRBinaryEncoderUnitTest.cs
@@ -343,10 +343,10 @@ public class QRBinaryEncoderUnitTest
         Assert.Equal(0xE0, data[15]);
     }
 
-    // Regression: WritePadding with a target below the current position must not
-    // throw and must keep the written data intact (alignment bits only).
+    // Regression: WritePadding with a target at or below the current position is a
+    // no-op aside from flushing - no throw, no position advance, data intact.
     [Fact]
-    public void WritePadding_TargetBelowPosition_KeepsData()
+    public void WritePadding_TargetBelowPosition_KeepsDataAndPosition()
     {
         Span<byte> buffer = stackalloc byte[8];
         var encoder = new QRBinaryEncoder(buffer);
@@ -360,6 +360,7 @@ public class QRBinaryEncoderUnitTest
         var after = encoder.GetEncodedData().ToArray();
 
         Assert.Equal(before, after);
+        Assert.Equal(35, encoder.BitPosition); // no alignment bits added
     }
 
     // helpers

--- a/tests/SkiaSharp.QrCode.Tests/QRBinaryEncoderUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRBinaryEncoderUnitTest.cs
@@ -19,8 +19,9 @@ public class QRBinaryEncoderUnitTest
         var encoder = new QRBinaryEncoder(buffer);
 
         encoder.WriteMode(encoding, eci);
+        var data = encoder.GetEncodedData();
 
-        Assert.Equal(expected, buffer[0]);
+        Assert.Equal(expected, data[0]);
     }
 
     [Theory]
@@ -32,9 +33,10 @@ public class QRBinaryEncoderUnitTest
         var encoder = new QRBinaryEncoder(buffer);
 
         encoder.WriteMode(EncodingMode.Byte, eci);
+        var data = encoder.GetEncodedData();
 
-        Assert.Equal(expected0, buffer[0]); // ECI mode + part of UTF-8
-        Assert.Equal(expected1, buffer[1]); // rest of UTF-8 + Byte mode
+        Assert.Equal(expected0, data[0]); // ECI mode + part of UTF-8
+        Assert.Equal(expected1, data[1]); // rest of UTF-8 + Byte mode
     }
 
     [Theory]
@@ -46,7 +48,7 @@ public class QRBinaryEncoderUnitTest
         var encoder = new QRBinaryEncoder(buffer);
 
         encoder.WriteMode(EncodingMode.Byte, eci);
-        var result = ToBinaryString(buffer, encoder.BitPosition);
+        var result = ToBinaryString(encoder.GetEncodedData(), encoder.BitPosition);
 
         // Assert: Total bit length is 16 (4 + 8 + 4)
         Assert.Equal(16, result.Length);
@@ -73,8 +75,9 @@ public class QRBinaryEncoderUnitTest
         var encoder = new QRBinaryEncoder(buffer);
 
         encoder.WriteCharacterCount(count, bitsLength);
+        var data = encoder.GetEncodedData();
 
-        var result = buffer[0] << 8 | buffer[1];
+        var result = data[0] << 8 | data[1];
         Assert.Equal(expectedFirstByte, result);
     }
 
@@ -293,6 +296,70 @@ public class QRBinaryEncoderUnitTest
         var afterPadding = encoder.GetEncodedData().ToArray();
 
         Assert.Equal(beforePadding, afterPadding);
+    }
+
+    // Full pipeline parity (mode + count + data + padding)
+
+    // ISO/IEC 18004 canonical example: "HELLO WORLD", alphanumeric, version 1-M
+    // (16 data codewords). Encoded stream is the well-known byte sequence.
+    [Fact]
+    public void EncodePipeline_HelloWorld_V1M_ProducesCanonicalCodewords()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var encoder = new QRBinaryEncoder(buffer);
+
+        encoder.WriteMode(EncodingMode.Alphanumeric, EciMode.Default);
+        encoder.WriteCharacterCount(11, 9); // version 1-9 alphanumeric: 9 bits
+        encoder.WriteData("HELLO WORLD", EncodingMode.Alphanumeric, EciMode.Default, false);
+        encoder.WritePadding(16 * 8);
+
+        var expected = new byte[]
+        {
+            0x20, 0x5B, 0x0B, 0x78, 0xD1, 0x72, 0xDC, 0x4D,
+            0x43, 0x40, 0xEC, 0x11, 0xEC, 0x11, 0xEC, 0x11,
+        };
+        Assert.Equal(16, encoder.ByteCount);
+        Assert.Equal(expected, encoder.GetEncodedData().ToArray());
+    }
+
+    // Exact capacity fit: 14 bytes data in version 1-M (16 data codewords)
+    // leaves room for the 4-bit terminator only - zero pad bytes.
+    [Fact]
+    public void EncodePipeline_ExactCapacityFit_NoPadBytes()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        var encoder = new QRBinaryEncoder(buffer);
+
+        encoder.WriteMode(EncodingMode.Byte, EciMode.Default);
+        encoder.WriteCharacterCount(14, 8); // version 1-9 byte: 8 bits
+        encoder.WriteData("ABCDEFGHIJKLMN", EncodingMode.Byte, EciMode.Default, false);
+        Assert.Equal(124, encoder.BitPosition); // 4 + 8 + 14*8
+        encoder.WritePadding(16 * 8);
+
+        Assert.Equal(128, encoder.BitPosition); // terminator only, no pad bytes
+        Assert.Equal(16, encoder.ByteCount);
+        var data = encoder.GetEncodedData();
+        // last byte = low nibble of 'N' (0x4E -> 1110) + 4-bit terminator (0000)
+        Assert.Equal(0xE0, data[15]);
+    }
+
+    // Regression: WritePadding with a target below the current position must not
+    // throw and must keep the written data intact (alignment bits only).
+    [Fact]
+    public void WritePadding_TargetBelowPosition_KeepsData()
+    {
+        Span<byte> buffer = stackalloc byte[8];
+        var encoder = new QRBinaryEncoder(buffer);
+
+        encoder.WriteMode(EncodingMode.Numeric, EciMode.Default); // 4 bits
+        encoder.WriteCharacterCount(1234, 14); // 14 bits
+        encoder.WriteData("12345", EncodingMode.Numeric, EciMode.Default, false); // 17 bits -> total 35
+
+        var before = encoder.GetEncodedData().ToArray();
+        encoder.WritePadding(32); // below current position (35 bits)
+        var after = encoder.GetEncodedData().ToArray();
+
+        Assert.Equal(before, after);
     }
 
     // helpers


### PR DESCRIPTION
## Summary

Rewrites the QR data-encoding kernel (`QRBinaryEncoder` + `BitWriter`) for speed:

- `BitWriter` now stages bits in a 64-bit MSB-first accumulator and flushes 32-bit big-endian words, instead of an 8-bit accumulator that re-stored a partial byte on every `Write`.
- Byte mode writes 8 input bytes per store (`Write64`): ISO-8859-1 input is narrowed with `Encoding.Latin1` (SIMD) on .NET 5+, with a scalar 8-byte pack fallback for netstandard.
- Numeric/alphanumeric modes read chars directly, dropping the char→ASCII temp-buffer pass.
- Pad bytes (0xEC/0x11) are filled directly into the buffer after byte alignment; the redundant upfront `buffer.Clear()` is removed.

## Intent

Encoding was the last unoptimized stage of the generation pipeline (ECC, masking, placement, and interleaving were tuned previously). The old writer capped progress at 8 bits per inner-loop iteration and byte mode paid one `Write` call per byte, which dominated for URL- and document-sized payloads.

## Expected behavior

- **No output change**: encoded codewords are byte-identical to the previous implementation. Verified across numeric (len % 3 = 0/1/2), alphanumeric (odd/even/full 45-char set), byte ASCII / ISO-8859-1 / UTF-8 (with and without BOM), empty input, exact-capacity fit, and v40-size payloads. Includes a new test asserting the ISO/IEC 18004 canonical "HELLO WORLD" v1-M codeword sequence.
- **Contract change (internal)**: `BitWriter` buffer contents are only guaranteed after `Flush()` / `GetData()`; `WritePadding` always drains, so `QRCodeGenerator` needs no changes. Tests that asserted raw buffer state mid-stream now read via `GetData()`.
- **Bug fix**: `WritePadding` with a target below the current bit position no longer risks a negative-length slice (previously reachable only in over-capacity edge cases).
- Zero allocations, as before.

## Benchmarks

Encoding kernel (Ryzen 9 7950X3D, .NET 10, 15 iterations):

| Scenario | Before | After | Speedup |
|---|---:|---:|---:|
| Alphanumeric 16 chars (v1-M) | 68.6 ns | 37.5 ns | 1.9x |
| Numeric 120 digits (v4-M) | 222.3 ns | 85.4 ns | 2.6x |
| Byte 87-char URL (v6-M) | 390.9 ns | 40.9 ns | 9.2x |
| Byte 2,900 chars (v40-L) | 9,960.6 ns | 530.8 ns | 18.8x |

End-to-end `QRCodeGenerator.CreateQrCode` (QrCodeEndToEnd, warmup 3 / iterations 10):

| Scenario | Before | After | Delta |
|---|---:|---:|---:|
| Short_M | 2.90 µs | 2.77 µs | -4.5% |
| Url_M | 6.47 µs | 6.26 µs | -3.1% |
| Long_L | 165.4 µs | 153.8 µs | -7.0% |
| Long_H | 155.4 µs | 150.2 µs | -3.3% |