### PR TITLE
feat: add NEON (macOS, ARM64) improvement for EccBinaryEncoder

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,10 +10,26 @@ on:
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            rid: linux-x64
+          - os: ubuntu-24.04-arm
+            rid: linux-arm64
+          - os: windows-2025
+            rid: win-x64
+          - os: windows-11-arm
+            rid: win-arm64
+          - os: macos-26
+            rid: osx-arm64
+          - os: macos-26-intel
+            rid: osx-x64
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -22,25 +38,38 @@ jobs:
         with:
           restore-wasm-workload: true
       - name: Build
-        run: dotnet build -c Release
+        run: dotnet build -c Release -r ${{ matrix.rid }}
       - name: Test
-        run: dotnet test -c Release --logger GitHubActions --logger "console;verbosity=normal"
+        run: dotnet test -c Release -r ${{ matrix.rid }} --logger GitHubActions --logger "console;verbosity=normal"
 
   run:
     needs: [build]
-    strategy:
-      matrix:
-        include:
-          - runs-on: ubuntu-24.04
-            ext: ""
-          - runs-on: windows-2025
-            ext: .exe
-          - runs-on: macos-15
-            ext: ""
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     permissions:
       contents: read
-    runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            rid: linux-x64
+            ext: ""
+          - os: ubuntu-24.04-arm
+            rid: linux-arm64
+            ext: ""
+          - os: windows-2025
+            rid: win-x64
+            ext: ".exe"
+          - os: windows-11-arm
+            rid: win-arm64
+            ext: ".exe"
+          - os: macos-26
+            rid: osx-arm64
+            ext: ""
+          - os: macos-26-intel
+            rid: osx-x64
+            ext: ""
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -50,17 +79,17 @@ jobs:
           dotnet-version: 10.0.x
       # ConsoleApp
       - name: Run ConsoleApp
-        run: dotnet run --c Release
+        run: dotnet run -c Release -r ${{ matrix.rid }}
         working-directory: ./samples/ConsoleApp
       # SimpleGenerate
       - name: Run SimpleGenerate
-        run: dotnet run -c Release
+        run: dotnet run -c Release -r ${{ matrix.rid }}
         working-directory: ./samples/SimpleGenerate
       # NativeAOT
       - name: Run ConsoleAppNativeAOT
         shell: bash
         run: |
-          dotnet publish ./samples/ConsoleAppNativeAOT/ConsoleAppNativeAOT.csproj -c Release -o ./publish/
+          dotnet publish ./samples/ConsoleAppNativeAOT/ConsoleAppNativeAOT.csproj -c Release -r ${{ matrix.rid }} -o ./publish/
           cd ./publish/
           ls -l
           chmod +x ConsoleAppNativeAOT${{ matrix.ext }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,9 +38,9 @@ jobs:
         with:
           restore-wasm-workload: true
       - name: Build
-        run: dotnet build -c Release -r ${{ matrix.rid }}
+        run: dotnet build -c Release
       - name: Test
-        run: dotnet test -c Release -r ${{ matrix.rid }} --logger GitHubActions --logger "console;verbosity=normal"
+        run: dotnet test -c Release --logger GitHubActions --logger "console;verbosity=normal"
 
   run:
     needs: [build]

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.Simd.Arm.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.Simd.Arm.cs
@@ -1,0 +1,254 @@
+#if NET8_0_OR_GREATER
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+
+namespace SkiaSharp.QrCode.Internals.BinaryEncoders;
+
+/// <summary>
+/// Vectorized Reed-Solomon kernel for ARM64 (Apple Silicon / Graviton). Selected at
+/// runtime by <see cref="EccBinaryEncoder.CalculateECC"/>; produces byte-identical
+/// output to <see cref="EccBinaryEncoder.CalculateEccScalar"/>.
+/// </summary>
+/// <remarks>
+/// Faithful port of the SSSE3 kernel (see EccBinaryEncoder.Simd.cs for the shared
+/// architecture notes). Instruction mapping:
+///
+/// - PSHUFB → TBL (<see cref="AdvSimd.Arm64.VectorTableLookup(Vector128{byte}, Vector128{byte})"/>).
+///   Both zero out-of-range lanes; the nibble indices here are always 0-15, so the
+///   semantic difference (PSHUFB keys on bit 7, TBL on index ≥ 16) is never exercised.
+/// - PSRLDQ (byte shift right) → EXT (<see cref="AdvSimd.ExtractVector128(Vector128{byte}, Vector128{byte}, byte)"/>
+///   with a zero upper operand).
+/// - PALIGNR(hi, lo, n) → EXT(lo, hi, n) — ARM's operand order is (lower, upper, index).
+///
+/// The factor tables (nibble-split multiply, quad factors T, composed T∘U) are
+/// ISA-independent and shared with the x86 kernels. GFNI has no NEON equivalent
+/// (SVE2's GF ops have no .NET API and no Apple hardware), so the TBL nibble-split
+/// kernel is the ARM64 ceiling for now.
+/// </remarks>
+internal static partial class EccBinaryEncoder
+{
+    /// <summary>
+    /// Entry point for the NEON kernel. Caller guarantees AdvSimd.Arm64.IsSupported
+    /// and eccCount ≤ 32 (QR maximum is 30).
+    /// </summary>
+    internal static void CalculateEccAdvSimd(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        if (eccCount <= 16)
+        {
+            AdvSimdCore128(data, ecc, eccCount);
+        }
+        else
+        {
+            AdvSimdCoreDual128(data, ecc, eccCount);
+        }
+    }
+
+    private static void AdvSimdCore128(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        var nib = GetNibbleTables(eccCount);
+        ref var nibRef = ref MemoryMarshal.GetArrayDataReference(nib);
+        ref var mulBase = ref MemoryMarshal.GetArrayDataReference(GetNibbleMulTable());
+        ref var qf = ref MemoryMarshal.GetArrayDataReference(GetQuadFactorTables(eccCount));
+        ref var tu = ref MemoryMarshal.GetArrayDataReference(GetComposedTUTables(eccCount));
+        ref var dataRef = ref MemoryMarshal.GetReference(data);
+
+        var genLo = Vector128.LoadUnsafe(ref nibRef, NibGenLoA);
+        var genHi = Vector128.LoadUnsafe(ref nibRef, NibGenHiA);
+        var genS1Lo = Vector128.LoadUnsafe(ref nibRef, NibGenS1LoA);
+        var genS1Hi = Vector128.LoadUnsafe(ref nibRef, NibGenS1HiA);
+        var genS2Lo = Vector128.LoadUnsafe(ref nibRef, NibGenS2LoA);
+        var genS2Hi = Vector128.LoadUnsafe(ref nibRef, NibGenS2HiA);
+        var genS3Lo = Vector128.LoadUnsafe(ref nibRef, NibGenS3LoA);
+        var genS3Hi = Vector128.LoadUnsafe(ref nibRef, NibGenS3HiA);
+        var zero = Vector128<byte>.Zero;
+
+        var reg = Vector128<byte>.Zero; // remainder register, ecc[0] = byte 0
+
+        var i = 0;
+        if (data.Length >= 4)
+        {
+            // First quad's factors come straight from the data (register is zero).
+            var d0 = Unsafe.ReadUnaligned<uint>(ref dataRef);
+            var f = QuadLookup(ref qf, d0);
+
+            for (i = 4; i + 3 < data.Length; i += 4)
+            {
+                // Next quad's input from the PRE-update register (software pipelining):
+                // x_next = d_next ^ reg[4..7] ^ U(f), and by GF(2)-linearity
+                // T(x_next) = T(d_next ^ reg[4..7]) ^ (T∘U)(f).
+                var z = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref dataRef, i)) ^ reg.AsUInt32().GetElement(1);
+                var y = QuadLookup(ref qf, z);
+
+                ref var t0 = ref Unsafe.Add(ref mulBase, (nint)((f & 0xFF) * 32));
+                ref var t1 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 8) & 0xFF) * 32));
+                ref var t2 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 16) & 0xFF) * 32));
+                ref var t3 = ref Unsafe.Add(ref mulBase, (nint)((f >> 24) * 32));
+
+                // reg = (reg >> 4 bytes) ^ (gen>>3)·f0 ^ (gen>>2)·f1 ^ (gen>>1)·f2 ^ gen·f3
+                reg = AdvSimd.ExtractVector128(reg, zero, 4)
+                    ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t0), genS3Lo) ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t0, 16), genS3Hi)
+                    ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t1), genS2Lo) ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t1, 16), genS2Hi)
+                    ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t2), genS1Lo) ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t2, 16), genS1Hi)
+                    ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t3), genLo) ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t3, 16), genHi);
+
+                f = QuadLookup(ref tu, f) ^ y;
+            }
+
+            // Final full quad (its factors were prepared by the last loop iteration).
+            {
+                ref var t0 = ref Unsafe.Add(ref mulBase, (nint)((f & 0xFF) * 32));
+                ref var t1 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 8) & 0xFF) * 32));
+                ref var t2 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 16) & 0xFF) * 32));
+                ref var t3 = ref Unsafe.Add(ref mulBase, (nint)((f >> 24) * 32));
+
+                reg = AdvSimd.ExtractVector128(reg, zero, 4)
+                    ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t0), genS3Lo) ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t0, 16), genS3Hi)
+                    ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t1), genS2Lo) ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t1, 16), genS2Hi)
+                    ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t2), genS1Lo) ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t2, 16), genS1Hi)
+                    ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t3), genLo) ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t3, 16), genHi);
+            }
+        }
+
+        // 0..3 trailing bytes, single-step
+        for (; i < data.Length; i++)
+        {
+            var f = (uint)(Unsafe.Add(ref dataRef, i) ^ reg.ToScalar());
+            ref var t = ref Unsafe.Add(ref mulBase, (nint)(f * 32));
+            reg = AdvSimd.ExtractVector128(reg, zero, 1)
+                ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t), genLo)
+                ^ AdvSimd.Arm64.VectorTableLookup(Vector128.LoadUnsafe(ref t, 16), genHi);
+        }
+
+        Span<byte> tmp = stackalloc byte[16];
+        reg.StoreUnsafe(ref MemoryMarshal.GetReference(tmp));
+        tmp.Slice(0, eccCount).CopyTo(ecc);
+    }
+
+    private static void AdvSimdCoreDual128(ReadOnlySpan<byte> data, Span<byte> ecc, int eccCount)
+    {
+        var nib = GetNibbleTables(eccCount);
+        ref var nibRef = ref MemoryMarshal.GetArrayDataReference(nib);
+        ref var mulBase = ref MemoryMarshal.GetArrayDataReference(GetNibbleMulTable());
+        ref var qf = ref MemoryMarshal.GetArrayDataReference(GetQuadFactorTables(eccCount));
+        ref var tu = ref MemoryMarshal.GetArrayDataReference(GetComposedTUTables(eccCount));
+        ref var dataRef = ref MemoryMarshal.GetReference(data);
+
+        var genLoA = Vector128.LoadUnsafe(ref nibRef, NibGenLoA);
+        var genHiA = Vector128.LoadUnsafe(ref nibRef, NibGenHiA);
+        var genLoB = Vector128.LoadUnsafe(ref nibRef, NibGenLoB);
+        var genHiB = Vector128.LoadUnsafe(ref nibRef, NibGenHiB);
+        var genS1LoA = Vector128.LoadUnsafe(ref nibRef, NibGenS1LoA);
+        var genS1HiA = Vector128.LoadUnsafe(ref nibRef, NibGenS1HiA);
+        var genS1LoB = Vector128.LoadUnsafe(ref nibRef, NibGenS1LoB);
+        var genS1HiB = Vector128.LoadUnsafe(ref nibRef, NibGenS1HiB);
+        var genS2LoA = Vector128.LoadUnsafe(ref nibRef, NibGenS2LoA);
+        var genS2HiA = Vector128.LoadUnsafe(ref nibRef, NibGenS2HiA);
+        var genS2LoB = Vector128.LoadUnsafe(ref nibRef, NibGenS2LoB);
+        var genS2HiB = Vector128.LoadUnsafe(ref nibRef, NibGenS2HiB);
+        var genS3LoA = Vector128.LoadUnsafe(ref nibRef, NibGenS3LoA);
+        var genS3HiA = Vector128.LoadUnsafe(ref nibRef, NibGenS3HiA);
+        var genS3LoB = Vector128.LoadUnsafe(ref nibRef, NibGenS3LoB);
+        var genS3HiB = Vector128.LoadUnsafe(ref nibRef, NibGenS3HiB);
+        var zero = Vector128<byte>.Zero;
+
+        // Remainder register as two 128-bit halves: lo = ecc[0..15], hi = ecc[16..31].
+        var lo = Vector128<byte>.Zero;
+        var hi = Vector128<byte>.Zero;
+
+        var i = 0;
+        if (data.Length >= 4)
+        {
+            var d0 = Unsafe.ReadUnaligned<uint>(ref dataRef);
+            var f = QuadLookup(ref qf, d0);
+
+            for (i = 4; i + 3 < data.Length; i += 4)
+            {
+                var z = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref dataRef, i)) ^ lo.AsUInt32().GetElement(1);
+                var y = QuadLookup(ref qf, z);
+
+                ref var t0 = ref Unsafe.Add(ref mulBase, (nint)((f & 0xFF) * 32));
+                ref var t1 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 8) & 0xFF) * 32));
+                ref var t2 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 16) & 0xFF) * 32));
+                ref var t3 = ref Unsafe.Add(ref mulBase, (nint)((f >> 24) * 32));
+
+                var tblLo0 = Vector128.LoadUnsafe(ref t0);
+                var tblHi0 = Vector128.LoadUnsafe(ref t0, 16);
+                var tblLo1 = Vector128.LoadUnsafe(ref t1);
+                var tblHi1 = Vector128.LoadUnsafe(ref t1, 16);
+                var tblLo2 = Vector128.LoadUnsafe(ref t2);
+                var tblHi2 = Vector128.LoadUnsafe(ref t2, 16);
+                var tblLo3 = Vector128.LoadUnsafe(ref t3);
+                var tblHi3 = Vector128.LoadUnsafe(ref t3, 16);
+
+                // Shift the 32-byte register left by 4 array positions:
+                // newLo = lo[4..15] ++ hi[0..3], newHi = hi[4..15] ++ 0000.
+                var newLo = AdvSimd.ExtractVector128(lo, hi, 4);
+                var newHi = AdvSimd.ExtractVector128(hi, zero, 4);
+
+                lo = newLo
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo0, genS3LoA) ^ AdvSimd.Arm64.VectorTableLookup(tblHi0, genS3HiA)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo1, genS2LoA) ^ AdvSimd.Arm64.VectorTableLookup(tblHi1, genS2HiA)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo2, genS1LoA) ^ AdvSimd.Arm64.VectorTableLookup(tblHi2, genS1HiA)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo3, genLoA) ^ AdvSimd.Arm64.VectorTableLookup(tblHi3, genHiA);
+                hi = newHi
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo0, genS3LoB) ^ AdvSimd.Arm64.VectorTableLookup(tblHi0, genS3HiB)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo1, genS2LoB) ^ AdvSimd.Arm64.VectorTableLookup(tblHi1, genS2HiB)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo2, genS1LoB) ^ AdvSimd.Arm64.VectorTableLookup(tblHi2, genS1HiB)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo3, genLoB) ^ AdvSimd.Arm64.VectorTableLookup(tblHi3, genHiB);
+
+                f = QuadLookup(ref tu, f) ^ y;
+            }
+
+            // Final full quad
+            {
+                ref var t0 = ref Unsafe.Add(ref mulBase, (nint)((f & 0xFF) * 32));
+                ref var t1 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 8) & 0xFF) * 32));
+                ref var t2 = ref Unsafe.Add(ref mulBase, (nint)(((f >> 16) & 0xFF) * 32));
+                ref var t3 = ref Unsafe.Add(ref mulBase, (nint)((f >> 24) * 32));
+
+                var tblLo0 = Vector128.LoadUnsafe(ref t0);
+                var tblHi0 = Vector128.LoadUnsafe(ref t0, 16);
+                var tblLo1 = Vector128.LoadUnsafe(ref t1);
+                var tblHi1 = Vector128.LoadUnsafe(ref t1, 16);
+                var tblLo2 = Vector128.LoadUnsafe(ref t2);
+                var tblHi2 = Vector128.LoadUnsafe(ref t2, 16);
+                var tblLo3 = Vector128.LoadUnsafe(ref t3);
+                var tblHi3 = Vector128.LoadUnsafe(ref t3, 16);
+
+                var newLo = AdvSimd.ExtractVector128(lo, hi, 4);
+                var newHi = AdvSimd.ExtractVector128(hi, zero, 4);
+
+                lo = newLo
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo0, genS3LoA) ^ AdvSimd.Arm64.VectorTableLookup(tblHi0, genS3HiA)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo1, genS2LoA) ^ AdvSimd.Arm64.VectorTableLookup(tblHi1, genS2HiA)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo2, genS1LoA) ^ AdvSimd.Arm64.VectorTableLookup(tblHi2, genS1HiA)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo3, genLoA) ^ AdvSimd.Arm64.VectorTableLookup(tblHi3, genHiA);
+                hi = newHi
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo0, genS3LoB) ^ AdvSimd.Arm64.VectorTableLookup(tblHi0, genS3HiB)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo1, genS2LoB) ^ AdvSimd.Arm64.VectorTableLookup(tblHi1, genS2HiB)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo2, genS1LoB) ^ AdvSimd.Arm64.VectorTableLookup(tblHi2, genS1HiB)
+                    ^ AdvSimd.Arm64.VectorTableLookup(tblLo3, genLoB) ^ AdvSimd.Arm64.VectorTableLookup(tblHi3, genHiB);
+            }
+        }
+
+        for (; i < data.Length; i++)
+        {
+            var f = (uint)(Unsafe.Add(ref dataRef, i) ^ lo.ToScalar());
+            ref var t = ref Unsafe.Add(ref mulBase, (nint)(f * 32));
+            var tblLo = Vector128.LoadUnsafe(ref t);
+            var tblHi = Vector128.LoadUnsafe(ref t, 16);
+            var newLo = AdvSimd.ExtractVector128(lo, hi, 1);
+            var newHi = AdvSimd.ExtractVector128(hi, zero, 1);
+            lo = newLo ^ AdvSimd.Arm64.VectorTableLookup(tblLo, genLoA) ^ AdvSimd.Arm64.VectorTableLookup(tblHi, genHiA);
+            hi = newHi ^ AdvSimd.Arm64.VectorTableLookup(tblLo, genLoB) ^ AdvSimd.Arm64.VectorTableLookup(tblHi, genHiB);
+        }
+
+        Span<byte> tmp = stackalloc byte[32];
+        lo.StoreUnsafe(ref MemoryMarshal.GetReference(tmp));
+        hi.StoreUnsafe(ref MemoryMarshal.GetReference(tmp), 16);
+        tmp.Slice(0, eccCount).CopyTo(ecc);
+    }
+}
+#endif // NET8_0_OR_GREATER

--- a/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/BinaryEncoders/EccBinaryEncoder.cs
@@ -9,8 +9,9 @@ namespace SkiaSharp.QrCode.Internals.BinaryEncoders;
 /// <remarks>
 /// This encoder implements the Reed-Solomon error correction algorithm as specified in ISO/IEC 18004 Section 8.5.
 /// The public entry point dispatches to the fastest kernel the runtime supports:
-/// GFNI (net10.0+, ~64x over the naive form), SSSE3 (net8.0+, ~52x), or a portable
-/// scalar kernel (~4.4x) used on netstandard, ARM64, and pre-SSSE3 x86.
+/// GFNI (net10.0+, ~64x over the naive form), SSSE3 (net8.0+, ~52x), NEON
+/// (net8.0+ ARM64, ~21-36x), or a portable scalar kernel (~4.4x) used on
+/// netstandard and pre-SSSE3 x86.
 /// All kernels produce byte-identical output; see the kernel parity tests.
 /// </remarks>
 internal static partial class EccBinaryEncoder
@@ -49,17 +50,25 @@ internal static partial class EccBinaryEncoder
         // QR codes use at most 30 ECC codewords per block, so the vectorized kernels
         // (which keep the remainder register in one or two vector registers) cover
         // every real input; the <= 32 guard is a safety net for non-QR callers.
-        if (eccCount <= 32 && System.Runtime.Intrinsics.X86.Ssse3.IsSupported)
+        if (eccCount <= 32)
         {
-            CalculateEccSimd(data, ecc, eccCount);
-            return;
+            if (System.Runtime.Intrinsics.X86.Ssse3.IsSupported)
+            {
+                CalculateEccSimd(data, ecc, eccCount);
+                return;
+            }
+            if (System.Runtime.Intrinsics.Arm.AdvSimd.Arm64.IsSupported)
+            {
+                CalculateEccAdvSimd(data, ecc, eccCount);
+                return;
+            }
         }
 #endif
         CalculateEccScalar(data, ecc, eccCount);
     }
 
     /// <summary>
-    /// Portable scalar kernel. Runs on every target (netstandard2.0+, ARM64, old x86).
+    /// Portable scalar kernel. Runs on every target (netstandard2.0+, old x86, pre-NEON ARM).
     /// </summary>
     /// <remarks>
     /// Two optimizations over the naive polynomial division, both measured (~4.4x combined):

--- a/tests/SkiaSharp.QrCode.Tests/EccBinaryEncoderKernelParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/EccBinaryEncoderKernelParityTest.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace SkiaSharp.QrCode.Tests;
 
 /// <summary>
-/// Verifies that every ECC kernel (scalar, SSSE3, GFNI) produces byte-identical
+/// Verifies that every ECC kernel (scalar, SSSE3, GFNI, NEON) produces byte-identical
 /// output to a naive reference implementation of ISO/IEC 18004 Section 8.5
 /// polynomial division. CalculateECC dispatches by hardware capability, so these
 /// tests exercise each kernel directly in addition to the public entry point.
@@ -73,6 +73,24 @@ public class EccBinaryEncoderKernelParityTest
 
             var actual = new byte[eccCount];
             EccBinaryEncoder.CalculateEccSsse3(data, actual, eccCount);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Combos))]
+    public void AdvSimdKernel_MatchesNaiveReference(int dataLength, int eccCount)
+    {
+        Assert.SkipUnless(System.Runtime.Intrinsics.Arm.AdvSimd.Arm64.IsSupported, "AdvSimd (ARM64 NEON) not supported on this machine");
+
+        foreach (var data in EnumerateInputs(dataLength))
+        {
+            var expected = new byte[eccCount];
+            NaiveReferenceECC(data, expected, eccCount);
+
+            var actual = new byte[eccCount];
+            EccBinaryEncoder.CalculateEccAdvSimd(data, actual, eccCount);
 
             Assert.Equal(expected, actual);
         }

--- a/tests/SkiaSharp.QrCode.Tests/SkiaImageSizeTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/SkiaImageSizeTest.cs
@@ -24,7 +24,9 @@ public class SkiaImageSizeTest
         Assert.Equal(100, b.Size.Width);
         Assert.Equal(40000, b.BytesSize);
         Assert.Equal(SKAlphaType.Premul, b.AlphaType);
-        Assert.Equal(SKColorType.Bgra8888, b.ColorType);
+        // The default color type is platform-dependent (Bgra8888 on Windows/Linux,
+        // Rgba8888 on macOS), so compare against SkiaSharp's platform default.
+        Assert.Equal(SKImageInfo.PlatformColorType, b.ColorType);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Add an ARM64 NEON kernel for Reed-Solomon ECC calculation (`EccBinaryEncoder`). ARM64 (Apple Silicon / AWS Graviton) previously fell back to the scalar kernel while x64 had SSSE3/GFNI vectorized kernels — this was the largest remaining performance gap between platforms.

## Intent

The SSSE3 kernel architecture (register-resident remainder, PSHUFB nibble-split GF(256) multiply, quad-linearized factors with composed T∘U software pipelining) ports to NEON almost mechanically:

| x64 | ARM64 NEON |
|---|---|
| `Ssse3.Shuffle` (PSHUFB) | `AdvSimd.Arm64.VectorTableLookup` (TBL) |
| `Sse2.ShiftRightLogical128BitLane` (PSRLDQ) | `AdvSimd.ExtractVector128(reg, zero, n)` (EXT) |
| `Ssse3.AlignRight(hi, lo, n)` (PALIGNR) | `AdvSimd.ExtractVector128(lo, hi, n)` (EXT) |

The nibble indices are always 0–15, so the PSHUFB/TBL out-of-range semantics difference is never exercised. All factor tables (nibble-split multiply, quad factors, composed T∘U) are ISA-independent and shared with the x86 kernels. GFNI has no NEON equivalent, so the TBL nibble-split kernel is the ARM64 ceiling for now.

The quad-pipelined design matters more on ARM than on x64: vector→GPR transfers are expensive on Apple Silicon, and this design issues only one transfer per 4 data bytes, read from the pre-update register (a full iteration of slack off the critical chain). A simpler per-byte TBL kernel was measured ~3x slower.

## Expected behavior

- No functional change: all kernels produce byte-identical output, verified by the extended kernel parity tests (`AdvSimdKernel_MatchesNaiveReference`, 9 shapes × 5 input patterns against a naive ISO/IEC 18004 §8.5 reference).
- Dispatch order in `CalculateECC`: SSSE3/GFNI (x86) → **NEON (new, `AdvSimd.Arm64.IsSupported`, net8.0+)** → scalar fallback (netstandard, pre-NEON hardware).
- netstandard2.0/2.1 targets are unaffected (kernel is `#if NET8_0_OR_GREATER`).

## Benchmarks

Kernel-level, Apple M2, .NET 10.0.9 (0 B allocated in all cases):

| Scenario | Scalar (before) | NEON (after) | Speedup |
|---|---:|---:|---:|
| v1M block (16 B data, 10 ecc) | 111.4 ns | 22.9 ns | **4.9x** |
| v40L block (119 B data, 30 ecc) | 1,584.9 ns | 193.9 ns | **8.2x** |

Relative to the naive form this is ~21–36x (scalar is ~4.4x), closing most of the gap to x64 SSSE3 (~52x) without a GFNI-class instruction.

End-to-end (`QrCodeEndToEnd` in `src/SkiaSharp.QrCode.Benchmark`, public `CreateQrCode` API, Apple M2):

| Scenario | Before | After | Delta |
|---|---:|---:|---:|
| Short_M (version ~1–2) | 4.98 µs | 4.90 µs | within noise |
| Url_M (version ~4–5) | 11.08 µs | 10.50 µs | −5% |
| Long_L (version 40, largest blocks) | 253.8 µs | 218.8 µs | **−14%** |
| Long_H (version 40, max ECC share) | 223.2 µs | 214.1 µs | −4% |

E2E gains are smaller than kernel-level because matrix construction and masking dominate total encode time.