### PR TITLE
feat: add 0alloc CreateQrCode API to use caller provided Span

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,34 @@ var qrData = QRCodeGenerator.CreateQrCode("content", ECCLevel.M, quietZoneSize: 
 // Access individual modules: bool isDark = qrData[row, col];
 ```
 
+#### Zero-Allocation Generation (Span destination)
+
+For high-throughput scenarios (e.g., per-request QR generation on a web server), you can generate the module matrix into a caller-provided buffer with zero heap allocation. Calculate the required size with `GetRequiredBufferSize`, allocate (or rent) the buffer yourself, and pass it as `Span<byte>`:
+
+```csharp
+// 1. Calculate required buffer size (no allocation)
+var calculated = QRCodeGenerator.GetRequiredBufferSize("content", ECCLevel.M, quietZoneSize: 4);
+
+// 2. Allocate the buffer yourself (pool it, reuse it, or stackalloc it)
+var buffer = ArrayPool<byte>.Shared.Rent(calculated.BufferSize);
+try
+{
+    // 3. Generate directly into the buffer; returns bytes written (= QrSize * QrSize)
+    var written = QRCodeGenerator.CreateQrCode("content", ECCLevel.M, buffer, quietZoneSize: 4);
+
+    // 4. Slice to the written region and consume
+    var matrix = buffer.AsSpan(0, written);
+    // One byte per module (0 = light, 1 = dark), row-major, quiet zone included:
+    var isDark = matrix[row * calculated.QrSize + col] != 0;
+}
+finally
+{
+    ArrayPool<byte>.Shared.Return(buffer);
+}
+```
+
+Buffer sizes are bounded: version 40 with the standard quiet zone needs 185 × 185 = 34,225 bytes, so a pooled or fixed buffer keeps memory usage constant regardless of request volume. The buffer region is cleared before writing, so dirty pooled buffers are fine; bytes beyond the written region are left untouched.
+
 ## Platform-Specific Considerations
 
 ### Linux Support

--- a/src/SkiaSharp.QrCode.Benchmark/SimpleEncode.cs
+++ b/src/SkiaSharp.QrCode.Benchmark/SimpleEncode.cs
@@ -10,6 +10,7 @@ public class SimpleEncode
     private string _textUrl = default!;
     private string _textUnicode = default!;
     private string _textWifi = default!;
+    private byte[] _spanDestination = default!;
     ZXing.BarcodeWriter<SKBitmap> _zxingWriter_ascii = default!;
     ZXing.BarcodeWriter<SKBitmap> _zxingWriter_utf8 = default!;
 
@@ -21,6 +22,11 @@ public class SimpleEncode
         _textUrl = "https://example.com/user/repo?foo=value&bar=piyo";
         _textUnicode = "FooBar你好世界こんにちはПривет мир🎉🎊🎈Zürich";
         _textWifi = "WIFI:S:foobar-wifi;T:WPA;P:test123;H:false;;";
+        // Shared destination for the span-based zero-allocation benchmarks,
+        // sized for the largest of the five payloads.
+        var maxBufferSize = new[] { _textNumber, _textAlphanumeric, _textUrl, _textUnicode, _textWifi }
+            .Max(text => SkiaSharp.QrCode.QRCodeGenerator.GetRequiredBufferSize(text.AsSpan(), ECCLevel.L).BufferSize);
+        _spanDestination = new byte[maxBufferSize];
         _zxingWriter_ascii = new()
         {
             Format = ZXing.BarcodeFormat.QR_CODE,
@@ -158,6 +164,43 @@ public class SimpleEncode
     public QRCodeData SkiaSharpQRCode_Wifi_Encode()
     {
         return SkiaSharp.QrCode.QRCodeGenerator.CreateQrCode(_textWifi.AsSpan(), ECCLevel.L);
+    }
+
+    // Span-destination (zero-allocation) variants
+
+    [Benchmark]
+    [BenchmarkCategory("SkiaSharp.QrCode")]
+    public int SkiaSharpQRCode_Number_EncodeSpan()
+    {
+        return SkiaSharp.QrCode.QRCodeGenerator.CreateQrCode(_textNumber.AsSpan(), ECCLevel.L, _spanDestination);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("SkiaSharp.QrCode")]
+    public int SkiaSharpQRCode_Alphanumeric_EncodeSpan()
+    {
+        return SkiaSharp.QrCode.QRCodeGenerator.CreateQrCode(_textAlphanumeric.AsSpan(), ECCLevel.L, _spanDestination);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("SkiaSharp.QrCode")]
+    public int SkiaSharpQRCode_Url_EncodeSpan()
+    {
+        return SkiaSharp.QrCode.QRCodeGenerator.CreateQrCode(_textUrl.AsSpan(), ECCLevel.L, _spanDestination);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("SkiaSharp.QrCode")]
+    public int SkiaSharpQRCode_Unicode_EncodeSpan()
+    {
+        return SkiaSharp.QrCode.QRCodeGenerator.CreateQrCode(_textUnicode.AsSpan(), ECCLevel.L, _spanDestination);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("SkiaSharp.QrCode")]
+    public int SkiaSharpQRCode_Wifi_EncodeSpan()
+    {
+        return SkiaSharp.QrCode.QRCodeGenerator.CreateQrCode(_textWifi.AsSpan(), ECCLevel.L, _spanDestination);
     }
 
     [Benchmark]

--- a/src/SkiaSharp.QrCode/Internals/ModulePlacer.Masking.cs
+++ b/src/SkiaSharp.QrCode/Internals/ModulePlacer.Masking.cs
@@ -262,7 +262,8 @@ internal static partial class ModulePlacer
     /// positions as PlaceFormat. Static data spans: no per-call table build, and
     /// no temporary array in unoptimized builds (stackalloc initializers allocate
     /// a heap copy there). Copy 2 coordinates are size-relative and computed
-    /// inline: bit i &lt; 8 sits at (8, size-1-i), bit i &gt;= 8 at (size-15+i, 8).
+    /// inline: bit i &lt; 8 sits at (x = size-1-i, y = 8), bit i &gt;= 8 at
+    /// (x = 8, y = size-15+i).
     /// </summary>
     private static ReadOnlySpan<byte> FormatXs1 => new byte[15] { 8, 8, 8, 8, 8, 8, 8, 8, 7, 5, 4, 3, 2, 1, 0 };
     private static ReadOnlySpan<byte> FormatYs1 => new byte[15] { 0, 1, 2, 3, 4, 5, 7, 8, 8, 8, 8, 8, 8, 8, 8 };

--- a/src/SkiaSharp.QrCode/Internals/ModulePlacer.Masking.cs
+++ b/src/SkiaSharp.QrCode/Internals/ModulePlacer.Masking.cs
@@ -257,19 +257,25 @@ internal static partial class ModulePlacer
         return PopCount(y5) + 2 * PopCount(starts);
     }
 
+    /// <summary>
+    /// Format-bit module coordinates around the top-left finder (copy 1), same
+    /// positions as PlaceFormat. Static data spans: no per-call table build, and
+    /// no temporary array in unoptimized builds (stackalloc initializers allocate
+    /// a heap copy there). Copy 2 coordinates are size-relative and computed
+    /// inline: bit i &lt; 8 sits at (8, size-1-i), bit i &gt;= 8 at (size-15+i, 8).
+    /// </summary>
+    private static ReadOnlySpan<byte> FormatXs1 => new byte[15] { 8, 8, 8, 8, 8, 8, 8, 8, 7, 5, 4, 3, 2, 1, 0 };
+    private static ReadOnlySpan<byte> FormatYs1 => new byte[15] { 0, 1, 2, 3, 4, 5, 7, 8, 8, 8, 8, 8, 8, 8, 8 };
+
     private static void PokeFormatBits64(Span<ulong> rows, int size, ushort formatBits)
     {
-        // Same positions as PlaceFormat, poked directly into packed rows.
-        Span<int> xs1 = stackalloc int[15] { 8, 8, 8, 8, 8, 8, 8, 8, 7, 5, 4, 3, 2, 1, 0 };
-        Span<int> ys1 = stackalloc int[15] { 0, 1, 2, 3, 4, 5, 7, 8, 8, 8, 8, 8, 8, 8, 8 };
-        Span<int> xs2 = stackalloc int[15] { size - 1, size - 2, size - 3, size - 4, size - 5, size - 6, size - 7, size - 8, 8, 8, 8, 8, 8, 8, 8 };
-        Span<int> ys2 = stackalloc int[15] { 8, 8, 8, 8, 8, 8, 8, 8, size - 7, size - 6, size - 5, size - 4, size - 3, size - 2, size - 1 };
-
         for (var i = 0; i < 15; i++)
         {
             var bit = (formatBits & (1 << i)) != 0;
-            rows[ys1[i]] = WithBit64(rows[ys1[i]], xs1[i], bit);
-            rows[ys2[i]] = WithBit64(rows[ys2[i]], xs2[i], bit);
+            var x2 = i < 8 ? size - 1 - i : 8;
+            var y2 = i < 8 ? 8 : size - 15 + i;
+            rows[FormatYs1[i]] = WithBit64(rows[FormatYs1[i]], FormatXs1[i], bit);
+            rows[y2] = WithBit64(rows[y2], x2, bit);
         }
     }
 
@@ -662,16 +668,14 @@ internal static partial class ModulePlacer
 
     private static void PokeFormatBits192(Span<Row192> rows, int size, ushort formatBits)
     {
-        Span<int> xs1 = stackalloc int[15] { 8, 8, 8, 8, 8, 8, 8, 8, 7, 5, 4, 3, 2, 1, 0 };
-        Span<int> ys1 = stackalloc int[15] { 0, 1, 2, 3, 4, 5, 7, 8, 8, 8, 8, 8, 8, 8, 8 };
-        Span<int> xs2 = stackalloc int[15] { size - 1, size - 2, size - 3, size - 4, size - 5, size - 6, size - 7, size - 8, 8, 8, 8, 8, 8, 8, 8 };
-        Span<int> ys2 = stackalloc int[15] { 8, 8, 8, 8, 8, 8, 8, 8, size - 7, size - 6, size - 5, size - 4, size - 3, size - 2, size - 1 };
-
+        // Same coordinate scheme as PokeFormatBits64 (see FormatXs1/FormatYs1).
         for (var i = 0; i < 15; i++)
         {
             var bit = (formatBits & (1 << i)) != 0;
-            rows[ys1[i]] = rows[ys1[i]].WithBit(xs1[i], bit);
-            rows[ys2[i]] = rows[ys2[i]].WithBit(xs2[i], bit);
+            var x2 = i < 8 ? size - 1 - i : 8;
+            var y2 = i < 8 ? 8 : size - 15 + i;
+            rows[FormatYs1[i]] = rows[FormatYs1[i]].WithBit(FormatXs1[i], bit);
+            rows[y2] = rows[y2].WithBit(x2, bit);
         }
     }
 

--- a/src/SkiaSharp.QrCode/QRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/QRCodeGenerator.cs
@@ -88,16 +88,9 @@ public static class QRCodeGenerator
         // Prepare configuration
         var config = PrepareConfiguration(textSpan, eccLevel, utf8BOM, eciMode, requestedVersion);
 
-        // Calculate buffer sizes
         var result = new QRCodeData(config.Version, quietZoneSize);
         var coreSize = result.GetCoreSize();
         var dataLength = coreSize * coreSize;
-
-        var dataCapacity = CalculateMaxBitStringLength(config.Version, config.EccLevel, config.Encoding);
-        var dataBufferSize = (dataCapacity + 7) / 8; // bits to bytes, rounded up
-        var totalBlocks = config.EccInfo.BlocksInGroup1 + config.EccInfo.BlocksInGroup2;
-        var eccBufferSize = totalBlocks * config.EccInfo.ECCPerBlock;
-        var interleavedSize = BinaryInterleaver.CalculateInterleavedSize(config.EccInfo, config.Version);
 
         // Allocate buffers
         byte[]? rentedWorkBuffer = null;
@@ -109,22 +102,7 @@ public static class QRCodeGenerator
             var workBuffer = rentedWorkBuffer.AsSpan(0, dataLength);
             workBuffer.Clear();
 
-            Span<byte> dataBuffer = stackalloc byte[dataBufferSize];
-            Span<byte> eccBuffer = stackalloc byte[eccBufferSize];
-            Span<byte> interleavedBuffer = stackalloc byte[interleavedSize];
-
-            // Encode data
-            var encodedLength = EncodeData(textSpan, config, dataBuffer);
-            var encodedData = dataBuffer.Slice(0, encodedLength);
-
-            // Calculate Error Correction
-            CalculateErrorCorrection(encodedData, config.EccInfo, eccBuffer);
-
-            // Interleave data
-            InterleaveCodewords(encodedData, eccBuffer, config.EccInfo, config.Version, interleavedBuffer);
-
-            // QR matrix in work buffer
-            WriteQRMatrix(workBuffer, coreSize, config.Version, interleavedBuffer, config.EccLevel);
+            WriteCoreModules(textSpan, config, workBuffer, coreSize);
 
             result.SetCoreData(workBuffer);
 
@@ -135,6 +113,146 @@ public static class QRCodeGenerator
             if (rentedWorkBuffer is not null)
                 ArrayPool<byte>.Shared.Return(rentedWorkBuffer, clearArray: false);
         }
+    }
+
+    /// <summary>
+    /// Creates a QR code from the provided plain text and writes the module matrix into the caller-provided buffer without heap allocation.
+    /// </summary>
+    /// <param name="plainText">The text to encode in the QR code.</param>
+    /// <param name="eccLevel">Error correction level (L: 7%, M: 15%, Q: 25%, H: 30%).</param>
+    /// <param name="destination">The buffer to write the QR code module matrix into. Must be at least <see cref="GetRequiredBufferSize"/> bytes.</param>
+    /// <param name="utf8BOM">Include UTF-8 BOM (Byte Order Mark) in encoded data. Ignore if data is not UTF-8.</param>
+    /// <param name="eciMode">ECI mode for character encoding.</param>
+    /// <param name="requestedVersion">Specific version to use (1-40), or -1 for automatic selection.</param>
+    /// <param name="quietZoneSize">Size of the quiet zone (white border) in modules.</param>
+    /// <returns>The number of bytes written to <paramref name="destination"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="destination"/> is smaller than the required buffer size.</exception>
+    public static int CreateQrCode(string plainText, ECCLevel eccLevel, Span<byte> destination, bool utf8BOM = false, EciMode eciMode = EciMode.Default, int requestedVersion = -1, int quietZoneSize = 4)
+    {
+        return CreateQrCode(plainText.AsSpan(), eccLevel, destination, utf8BOM, eciMode, requestedVersion, quietZoneSize);
+    }
+
+    /// <summary>
+    /// Creates a QR code from the provided plain text and writes the module matrix into the caller-provided buffer without heap allocation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Output format: one byte per module (0 = light, 1 = dark), flat row-major order, quiet zone included.
+    /// Module at (row, col) is <c>destination[row * qrSize + col]</c> where qrSize is
+    /// <see cref="QRCodeCalculatedSize.QrSize"/> returned by <see cref="GetRequiredBufferSize"/>.
+    /// </para>
+    /// <para>
+    /// Usage flow for allocation-free generation:
+    /// <code>
+    /// var calculated = QRCodeGenerator.GetRequiredBufferSize(text, ECCLevel.M);
+    /// var buffer = ArrayPool&lt;byte&gt;.Shared.Rent(calculated.BufferSize);
+    /// var written = QRCodeGenerator.CreateQrCode(text, ECCLevel.M, buffer);
+    /// var matrix = buffer.AsSpan(0, written);
+    /// // ... consume matrix ...
+    /// ArrayPool&lt;byte&gt;.Shared.Return(buffer);
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Only the first <see cref="QRCodeCalculatedSize.BufferSize"/> bytes of <paramref name="destination"/> are written
+    /// (cleared first, so a dirty pooled buffer is fine); any remaining bytes are left untouched.
+    /// </para>
+    /// </remarks>
+    /// <param name="textSpan">The text span to encode in the QR code.</param>
+    /// <param name="eccLevel">Error correction level (L: 7%, M: 15%, Q: 25%, H: 30%).</param>
+    /// <param name="destination">The buffer to write the QR code module matrix into. Must be at least <see cref="GetRequiredBufferSize"/> bytes.</param>
+    /// <param name="utf8BOM">Include UTF-8 BOM (Byte Order Mark) in encoded data. Ignore if data is not UTF-8.</param>
+    /// <param name="eciMode">ECI mode for character encoding.</param>
+    /// <param name="requestedVersion">Specific version to use (1-40), or -1 for automatic selection.</param>
+    /// <param name="quietZoneSize">Size of the quiet zone (white border) in modules.</param>
+    /// <returns>The number of bytes written to <paramref name="destination"/> (always qrSize × qrSize).</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="destination"/> is smaller than the required buffer size.</exception>
+    public static int CreateQrCode(ReadOnlySpan<char> textSpan, ECCLevel eccLevel, Span<byte> destination, bool utf8BOM = false, EciMode eciMode = EciMode.Default, int requestedVersion = -1, int quietZoneSize = 4)
+    {
+        if (requestedVersion != -1 && (requestedVersion < 1 || requestedVersion > 40))
+            throw new ArgumentOutOfRangeException(nameof(requestedVersion), $"Version must be 1-40 or -1(auto), but was {requestedVersion}");
+        if (quietZoneSize < 0)
+            throw new ArgumentOutOfRangeException(nameof(quietZoneSize), $"Quiet zone size must be non-negative, got {quietZoneSize}");
+
+        // Prepare configuration
+        var config = PrepareConfiguration(textSpan, eccLevel, utf8BOM, eciMode, requestedVersion);
+
+        var coreSize = QRCodeData.SizeFromVersion(config.Version);
+        var totalSize = coreSize + quietZoneSize * 2;
+        var requiredSize = totalSize * totalSize;
+        if (destination.Length < requiredSize)
+            throw new ArgumentException($"Destination buffer too small: {requiredSize} bytes required (version {config.Version}, {totalSize}x{totalSize} modules), got {destination.Length} bytes. Use {nameof(GetRequiredBufferSize)} to calculate the required size.", nameof(destination));
+
+        // Module placement and the quiet zone both assume zeroed memory.
+        var target = destination.Slice(0, requiredSize);
+        target.Clear();
+
+        if (quietZoneSize == 0)
+        {
+            WriteCoreModules(textSpan, config, target, coreSize);
+        }
+        else
+        {
+            // The placement pipeline requires a contiguous coreSize-stride matrix,
+            // so build the core in a rented buffer and center it in the destination.
+            byte[]? rentedWorkBuffer = null;
+            try
+            {
+                var dataLength = coreSize * coreSize;
+                rentedWorkBuffer = ArrayPool<byte>.Shared.Rent(dataLength);
+                var workBuffer = rentedWorkBuffer.AsSpan(0, dataLength);
+                workBuffer.Clear();
+
+                WriteCoreModules(textSpan, config, workBuffer, coreSize);
+
+                for (var row = 0; row < coreSize; row++)
+                {
+                    var destOffset = (row + quietZoneSize) * totalSize + quietZoneSize;
+                    workBuffer.Slice(row * coreSize, coreSize).CopyTo(target.Slice(destOffset, coreSize));
+                }
+            }
+            finally
+            {
+                if (rentedWorkBuffer is not null)
+                    ArrayPool<byte>.Shared.Return(rentedWorkBuffer, clearArray: false);
+            }
+        }
+
+        return requiredSize;
+    }
+
+    /// <summary>
+    /// Runs the encode → ECC → interleave → module placement pipeline and writes
+    /// the core module matrix (one byte per module, no quiet zone) into <paramref name="coreBuffer"/>.
+    /// </summary>
+    /// <param name="textSpan">The text span to encode.</param>
+    /// <param name="config">Prepared QR configuration.</param>
+    /// <param name="coreBuffer">Zeroed output buffer of coreSize × coreSize bytes.</param>
+    /// <param name="coreSize">Module count per side without quiet zone.</param>
+    private static void WriteCoreModules(ReadOnlySpan<char> textSpan, in QRConfiguration config, Span<byte> coreBuffer, int coreSize)
+    {
+        // Calculate buffer sizes
+        var dataCapacity = CalculateMaxBitStringLength(config.Version, config.EccLevel, config.Encoding);
+        var dataBufferSize = (dataCapacity + 7) / 8; // bits to bytes, rounded up
+        var totalBlocks = config.EccInfo.BlocksInGroup1 + config.EccInfo.BlocksInGroup2;
+        var eccBufferSize = totalBlocks * config.EccInfo.ECCPerBlock;
+        var interleavedSize = BinaryInterleaver.CalculateInterleavedSize(config.EccInfo, config.Version);
+
+        Span<byte> dataBuffer = stackalloc byte[dataBufferSize];
+        Span<byte> eccBuffer = stackalloc byte[eccBufferSize];
+        Span<byte> interleavedBuffer = stackalloc byte[interleavedSize];
+
+        // Encode data
+        var encodedLength = EncodeData(textSpan, config, dataBuffer);
+        var encodedData = dataBuffer.Slice(0, encodedLength);
+
+        // Calculate Error Correction
+        CalculateErrorCorrection(encodedData, config.EccInfo, eccBuffer);
+
+        // Interleave data
+        InterleaveCodewords(encodedData, eccBuffer, config.EccInfo, config.Version, interleavedBuffer);
+
+        // QR matrix in core buffer
+        WriteQRMatrix(coreBuffer, coreSize, config.Version, interleavedBuffer, config.EccLevel);
     }
 
     /// <summary>

--- a/src/SkiaSharp.QrCode/QRCodeGenerator.cs
+++ b/src/SkiaSharp.QrCode/QRCodeGenerator.cs
@@ -177,8 +177,7 @@ public static class QRCodeGenerator
         var config = PrepareConfiguration(textSpan, eccLevel, utf8BOM, eciMode, requestedVersion);
 
         var coreSize = QRCodeData.SizeFromVersion(config.Version);
-        var totalSize = coreSize + quietZoneSize * 2;
-        var requiredSize = totalSize * totalSize;
+        var (totalSize, requiredSize) = CalculateMatrixSize(coreSize, quietZoneSize);
         if (destination.Length < requiredSize)
             throw new ArgumentException($"Destination buffer too small: {requiredSize} bytes required (version {config.Version}, {totalSize}x{totalSize} modules), got {destination.Length} bytes. Use {nameof(GetRequiredBufferSize)} to calculate the required size.", nameof(destination));
 
@@ -267,6 +266,9 @@ public static class QRCodeGenerator
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the data is too large for version 40.</exception>
     public static QRCodeCalculatedSize GetRequiredBufferSize(ReadOnlySpan<char> text, ECCLevel eccLevel, bool utf8BOM = false, EciMode eciMode = EciMode.Default, int quietZoneSize = 4)
     {
+        if (quietZoneSize < 0)
+            throw new ArgumentOutOfRangeException(nameof(quietZoneSize), $"Quiet zone size must be non-negative, got {quietZoneSize}");
+
         var analysisResult = TextAnalyzer.Analyze(text, eciMode);
         var version = GetVersion(analysisResult.DataLength, analysisResult.EncodingMode, eccLevel, analysisResult.EciMode, utf8BOM);
 
@@ -274,10 +276,27 @@ public static class QRCodeGenerator
             throw new ArgumentOutOfRangeException(nameof(version), $"Version must be 1-40, but was {version}");
 
         var baseSize = QRCodeData.SizeFromVersion(version);
-        var totalSize = baseSize + quietZoneSize * 2; // for rendering with quiet zone
-        var bufferSize = totalSize * totalSize; // for buffer allocation
+        var (totalSize, bufferSize) = CalculateMatrixSize(baseSize, quietZoneSize);
 
         return new QRCodeCalculatedSize(bufferSize, totalSize, version);
+    }
+
+    /// <summary>
+    /// Computes the matrix side length (core + quiet zone) and the byte-per-module
+    /// buffer size, guarding against <see cref="int"/> overflow from oversized
+    /// quiet zones.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the buffer size would exceed <see cref="int.MaxValue"/>.</exception>
+    private static (int TotalSize, int BufferSize) CalculateMatrixSize(int coreSize, int quietZoneSize)
+    {
+        // long arithmetic: quietZoneSize is caller-controlled, and totalSize² can
+        // exceed int.MaxValue long before totalSize itself does. The first check
+        // also keeps the squaring below long.MaxValue.
+        var totalSize = coreSize + 2L * quietZoneSize;
+        if (totalSize > int.MaxValue || totalSize * totalSize > int.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(quietZoneSize), $"Quiet zone size {quietZoneSize} makes the matrix ({totalSize}x{totalSize} modules) exceed the maximum supported buffer size ({int.MaxValue} bytes).");
+
+        return ((int)totalSize, (int)(totalSize * totalSize));
     }
 
     // Pipelines

--- a/tests/SkiaSharp.QrCode.Tests/QRCodeGeneratorUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRCodeGeneratorUnitTest.cs
@@ -757,6 +757,26 @@ public class QRCodeGeneratorUnitTest
         Assert.Throws<ArgumentOutOfRangeException>(() => CreateQrCode("HELLO".AsSpan(), ECCLevel.L, buffer.AsSpan(), quietZoneSize: -1));
     }
 
+    [Theory]
+    [InlineData(40_000)]        // totalSize fits in int, but totalSize² overflows
+    [InlineData(int.MaxValue)]  // totalSize itself exceeds int.MaxValue
+    public void CreateQrCode_SpanDestination_OversizedQuietZone_Throws(int quietZoneSize)
+    {
+        var buffer = new byte[64 * 64];
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => CreateQrCode("HELLO".AsSpan(), ECCLevel.L, buffer.AsSpan(), quietZoneSize: quietZoneSize));
+        Assert.Equal("quietZoneSize", ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(40_000)]
+    [InlineData(int.MaxValue)]
+    public void GetRequiredBufferSize_InvalidQuietZone_Throws(int quietZoneSize)
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => GetRequiredBufferSize("HELLO".AsSpan(), ECCLevel.L, quietZoneSize: quietZoneSize));
+        Assert.Equal("quietZoneSize", ex.ParamName);
+    }
+
     // Helpers
 
     /// <summary>

--- a/tests/SkiaSharp.QrCode.Tests/QRCodeGeneratorUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRCodeGeneratorUnitTest.cs
@@ -590,6 +590,173 @@ public class QRCodeGeneratorUnitTest
         }
     }
 
+    // CreateQrCode (Span destination) Tests
+
+    [Theory]
+    [InlineData("HELLO WORLD", ECCLevel.L, 0)]
+    [InlineData("HELLO WORLD", ECCLevel.L, 4)]
+    [InlineData("https://example.com/foobar", ECCLevel.M, 4)]
+    [InlineData("0123456789012345678901234567890123456789", ECCLevel.Q, 4)]
+    [InlineData("こんにちは世界", ECCLevel.H, 4)]
+    [InlineData("", ECCLevel.L, 4)]
+    public void CreateQrCode_SpanDestination_MatchesQRCodeData(string text, ECCLevel eccLevel, int quietZoneSize)
+    {
+        var calculated = GetRequiredBufferSize(text.AsSpan(), eccLevel, quietZoneSize: quietZoneSize);
+        var buffer = new byte[calculated.BufferSize];
+
+        // Act
+        var written = CreateQrCode(text.AsSpan(), eccLevel, buffer.AsSpan(), quietZoneSize: quietZoneSize);
+
+        // Assert - written bytes match the size calculation API
+        Assert.Equal(calculated.BufferSize, written);
+
+        // Assert - every module matches the class-based API
+        var qrCode = CreateQrCode(text.AsSpan(), eccLevel, quietZoneSize: quietZoneSize);
+        Assert.Equal(calculated.QrSize, qrCode.Size);
+        for (var row = 0; row < qrCode.Size; row++)
+        {
+            for (var col = 0; col < qrCode.Size; col++)
+            {
+                Assert.Equal(qrCode[row, col], buffer[row * calculated.QrSize + col] != 0);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(7)]
+    [InlineData(40)]
+    public void CreateQrCode_SpanDestination_RequestedVersion_MatchesQRCodeData(int requestedVersion)
+    {
+        var text = "https://example.com/foobar";
+        var quietZoneSize = 4;
+        var qrCode = CreateQrCode(text.AsSpan(), ECCLevel.L, requestedVersion: requestedVersion, quietZoneSize: quietZoneSize);
+        var buffer = new byte[qrCode.Size * qrCode.Size];
+
+        // Act
+        var written = CreateQrCode(text.AsSpan(), ECCLevel.L, buffer.AsSpan(), requestedVersion: requestedVersion, quietZoneSize: quietZoneSize);
+
+        // Assert
+        Assert.Equal(qrCode.Size * qrCode.Size, written);
+        for (var row = 0; row < qrCode.Size; row++)
+        {
+            for (var col = 0; col < qrCode.Size; col++)
+            {
+                Assert.Equal(qrCode[row, col], buffer[row * qrCode.Size + col] != 0);
+            }
+        }
+    }
+
+    [Fact]
+    public void CreateQrCode_SpanDestination_BufferTooSmall_Throws()
+    {
+        var text = "https://example.com/foobar";
+        var calculated = GetRequiredBufferSize(text.AsSpan(), ECCLevel.L);
+        var buffer = new byte[calculated.BufferSize - 1];
+
+        var ex = Assert.Throws<ArgumentException>(() => CreateQrCode(text.AsSpan(), ECCLevel.L, buffer.AsSpan()));
+        Assert.Contains($"{calculated.BufferSize} bytes required", ex.Message);
+    }
+
+    [Fact]
+    public void CreateQrCode_SpanDestination_DirtyOversizedBuffer_WritesCleanOutputAndLeavesTailUntouched()
+    {
+        var text = "HELLO WORLD";
+        var quietZoneSize = 4;
+        var calculated = GetRequiredBufferSize(text.AsSpan(), ECCLevel.L, quietZoneSize: quietZoneSize);
+
+        // Simulate a dirty pooled buffer, larger than required
+        var buffer = new byte[calculated.BufferSize + 100];
+        buffer.AsSpan().Fill(0xFF);
+
+        // Act
+        var written = CreateQrCode(text.AsSpan(), ECCLevel.L, buffer.AsSpan(), quietZoneSize: quietZoneSize);
+
+        // Assert - written region contains only 0/1 and the quiet zone is light
+        Assert.Equal(calculated.BufferSize, written);
+        var qrSize = calculated.QrSize;
+        for (var row = 0; row < qrSize; row++)
+        {
+            for (var col = 0; col < qrSize; col++)
+            {
+                var module = buffer[row * qrSize + col];
+                Assert.True(module is 0 or 1, $"Module at ({row}, {col}) should be 0 or 1, got {module}");
+
+                var isQuietZone = row < quietZoneSize || row >= qrSize - quietZoneSize
+                    || col < quietZoneSize || col >= qrSize - quietZoneSize;
+                if (isQuietZone)
+                {
+                    Assert.Equal(0, module);
+                }
+            }
+        }
+
+        // Assert - bytes beyond the written region are untouched
+        for (var i = written; i < buffer.Length; i++)
+        {
+            Assert.Equal(0xFF, buffer[i]);
+        }
+    }
+
+    [Fact]
+    public void CreateQrCode_SpanDestination_StringOverload_MatchesSpanOverload()
+    {
+        var text = "https://example.com/foobar";
+        var calculated = GetRequiredBufferSize(text.AsSpan(), ECCLevel.M);
+        var bufferFromString = new byte[calculated.BufferSize];
+        var bufferFromSpan = new byte[calculated.BufferSize];
+
+        // Act
+        var writtenFromString = CreateQrCode(text, ECCLevel.M, bufferFromString.AsSpan());
+        var writtenFromSpan = CreateQrCode(text.AsSpan(), ECCLevel.M, bufferFromSpan.AsSpan());
+
+        // Assert
+        Assert.Equal(writtenFromSpan, writtenFromString);
+        Assert.Equal(bufferFromSpan, bufferFromString);
+    }
+
+#if !DEBUG
+    // Release-only: unoptimized (Debug) JIT allocates small temporaries inside the
+    // SIMD ECC kernel that the optimizing JIT eliminates; the zero-allocation
+    // guarantee applies to shipped (Release) binaries.
+    [Fact]
+    public void CreateQrCode_SpanDestination_DoesNotAllocate()
+    {
+        var text = "https://example.com/foobar";
+        var buffer = new byte[GetRequiredBufferSize(text.AsSpan(), ECCLevel.M).BufferSize];
+
+        // Warm up JIT, ArrayPool and lazily-built static tables
+        for (var i = 0; i < 3; i++)
+        {
+            GetRequiredBufferSize(text.AsSpan(), ECCLevel.M);
+            CreateQrCode(text.AsSpan(), ECCLevel.M, buffer.AsSpan());
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        GetRequiredBufferSize(text.AsSpan(), ECCLevel.M);
+        CreateQrCode(text.AsSpan(), ECCLevel.M, buffer.AsSpan());
+        var after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Equal(0, after - before);
+    }
+#endif
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(41)]
+    public void CreateQrCode_SpanDestination_InvalidVersion_Throws(int requestedVersion)
+    {
+        var buffer = new byte[64 * 64];
+        Assert.Throws<ArgumentOutOfRangeException>(() => CreateQrCode("HELLO".AsSpan(), ECCLevel.L, buffer.AsSpan(), requestedVersion: requestedVersion));
+    }
+
+    [Fact]
+    public void CreateQrCode_SpanDestination_NegativeQuietZone_Throws()
+    {
+        var buffer = new byte[64 * 64];
+        Assert.Throws<ArgumentOutOfRangeException>(() => CreateQrCode("HELLO".AsSpan(), ECCLevel.L, buffer.AsSpan(), quietZoneSize: -1));
+    }
+
     // Helpers
 
     /// <summary>


### PR DESCRIPTION
# feat: Add zero-allocation Span-based QR generation API

## Summary

Adds a `Span<byte>` destination overload to `QRCodeGenerator.CreateQrCode` that writes the module matrix directly into a caller-provided buffer and returns the number of bytes written. Combined with the existing `GetRequiredBufferSize`, QR generation now runs with **zero heap allocation**.

```csharp
var calc = QRCodeGenerator.GetRequiredBufferSize(text, ECCLevel.M, quietZoneSize: 4);
var buffer = ArrayPool<byte>.Shared.Rent(calc.BufferSize);
int written = QRCodeGenerator.CreateQrCode(text, ECCLevel.M, buffer, quietZoneSize: 4);
var matrix = buffer.AsSpan(0, written); // matrix[row * calc.QrSize + col] != 0 → dark
```

## Motivation

Per-request QR generation (e.g. web servers) previously allocated a `QRCodeData` instance per call. With a caller-owned buffer (pooled or reused), memory usage stays constant regardless of request volume — callers no longer need to think about allocation. Buffer size is bounded: version 40 with the standard quiet zone is 185 × 185 = 34,225 bytes.

## Expected behavior

- Output format: one byte per module (`0` = light, `1` = dark), flat row-major, quiet zone included — matching the existing `GetRequiredBufferSize` contract (`BufferSize = QrSize²`).
- Returns bytes written (always `QrSize²`); slice the buffer to that length.
- The written region is cleared first, so dirty pooled buffers are safe; bytes beyond it are left untouched.
- Throws `ArgumentException` when the destination is smaller than required; parameter validation matches the class-based overloads.
- Produces bit-identical matrices to the class-based `CreateQrCode` (verified module-by-module across versions 1–40, ECC levels, quiet zone 0/4).

## Implementation notes

- The encode → ECC → interleave → matrix pipeline is extracted into a shared `WriteCoreModules`; the class-based path is unchanged behaviorally.
- Fixed a Debug-only allocation found during verification: `stackalloc int[15] { ... }` initializers compile to a temporary heap array in unoptimized builds (2,304 B/call in `PokeFormatBits64/192`). Replaced with static `ReadOnlySpan<byte>` data-section tables + inline size-relative coordinates — this also removes the per-call table copies in Release.
- Zero-allocation regression test is gated `#if !DEBUG`: the MinOpts (Debug) JIT allocates ~72 B inside the SSSE3 ECC kernel, which is not addressable at the source level. The guarantee applies to shipped (Release) binaries.

## Benchmark

Measured with `GC.GetAllocatedBytesForCurrentThread` (Release, net10.0):

| Scenario | Allocated |
|---|---|
| `CreateQrCode` → `Span<byte>` (v2, qz=4) | **0 B** |
| `CreateQrCode` → `Span<byte>` (v28, qz=4) | **0 B** |
| `CreateQrCode` → `Span<byte>` (v28, qz=0) | **0 B** |
| `CreateQrCode` → `QRCodeData` (v2) | 144 B |
| `CreateQrCode` → `QRCodeData` (v28) | 2,152 B |

`SimpleEncode` gains `*_EncodeSpan` variants for all five payloads; BenchmarkDotNet results:

| Method                                          | Mean       | Error | Ratio | Gen0   | Allocated | Alloc Ratio |
|------------------------------------------------ |-----------:|------:|------:|-------:|----------:|------------:|
| NetCodecreteQrCodeGenerator_Number_Encode       |  10.080 us |    NA |  1.00 | 0.0763 |    4184 B |        1.00 |
| NetCodecreteQrCodeGenerator_Alphanumeric_Encode |  12.560 us |    NA |  1.25 | 0.0763 |    4504 B |        1.08 |
| NetCodecreteQrCodeGenerator_Url_Encode          |  13.418 us |    NA |  1.33 | 0.0916 |    5088 B |        1.22 |
| NetCodecreteQrCodeGenerator_Unicode_Encode      |  17.803 us |    NA |  1.77 | 0.1221 |    6440 B |        1.54 |
| NetCodecreteQrCodeGenerator_Wifi_Encode         |  12.437 us |    NA |  1.23 | 0.0916 |    5072 B |        1.21 |
|                                                 |            |       |       |        |           |             |
| QRCoder_Number_Encode                           |  45.399 us |    NA |  1.00 | 0.0610 |    4097 B |        1.00 |
| QRCoder_Alphanumeric_Encode                     |  70.377 us |    NA |  1.55 |      - |    4760 B |        1.16 |
| QRCoder_Url_Encode                              | 109.710 us |    NA |  2.42 |      - |    5400 B |        1.32 |
| QRCoder_Unicode_Encode                          | 182.164 us |    NA |  4.01 |      - |    6064 B |        1.48 |
| QRCoder_Wifi_Encode                             | 121.543 us |    NA |  2.68 |      - |    5392 B |        1.32 |
|                                                 |            |       |       |        |           |             |
| SkiaSharpQRCode_Number_Encode                   |   2.278 us |    NA |  1.00 |      - |     120 B |        1.00 |
| SkiaSharpQRCode_Alphanumeric_Encode             |   2.994 us |    NA |  1.31 |      - |     144 B |        1.20 |
| SkiaSharpQRCode_Url_Encode                      |   3.547 us |    NA |  1.56 |      - |     176 B |        1.47 |
| SkiaSharpQRCode_Unicode_Encode                  |   4.030 us |    NA |  1.77 |      - |     208 B |        1.73 |
| SkiaSharpQRCode_Wifi_Encode                     |   3.460 us |    NA |  1.52 |      - |     176 B |        1.47 |
| SkiaSharpQRCode_Number_EncodeSpan               |   2.324 us |    NA |  1.02 |      - |         - |        0.00 |
| SkiaSharpQRCode_Alphanumeric_EncodeSpan         |   3.594 us |    NA |  1.58 |      - |         - |        0.00 |
| SkiaSharpQRCode_Url_EncodeSpan                  |   4.237 us |    NA |  1.86 |      - |         - |        0.00 |
| SkiaSharpQRCode_Unicode_EncodeSpan              |   4.112 us |    NA |  1.80 |      - |         - |        0.00 |
| SkiaSharpQRCode_Wifi_EncodeSpan                 |   3.933 us |    NA |  1.73 |      - |         - |        0.00 |
|                                                 |            |       |       |        |           |             |
| ZXing_Number_Encode                             |  32.482 us |    NA |  1.00 | 0.3052 |   16024 B |        1.00 |
| ZXing_Alphanumeric_Encode                       |  46.756 us |    NA |  1.44 | 0.6104 |   33456 B |        2.09 |
| ZXing_Url_Encode                                |  66.346 us |    NA |  2.04 | 1.3428 |   69184 B |        4.32 |
| ZXing_Unicode_Encode                            | 109.594 us |    NA |  3.37 | 2.4414 |  128584 B |        8.02 |
| ZXing_Wifi_Encode                               |  71.114 us |    NA |  2.19 | 1.3428 |   70088 B |        4.37 |

## Tests

- Module-level equality vs. the class-based API (incl. forced version 2/7/40, exercising both `MaskCode64`/`MaskCode192` paths)
- `bytesWritten` matches `GetRequiredBufferSize`
- Too-small buffer throws; dirty oversized buffer produces clean output and untouched tail
- 959 tests passing on net8.0/net10.0 × Debug/Release