### PR TITLE
feat: add WASM Playground

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,8 +95,30 @@ jobs:
           chmod +x ConsoleAppNativeAOT${{ matrix.ext }}
           ./ConsoleAppNativeAOT${{ matrix.ext }}
 
+  # Playground native relink (SkiaSharp + Emscripten) only happens on publish, so the
+  # matrix `dotnet build` above stays managed-only. Verify the publish path on one leg.
+  # AOT is disabled here for speed; the Deploy Playground workflow publishes with full AOT.
+  build-playground:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: guitarrapc/actions/.github/actions/setup-dotnet@9122a18b0dea07585a242b9eb6ed7886f8587c49 # v1.0.1
+        with:
+          dotnet-version: 10.0
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+      # No -r browser-wasm: it would propagate to the multi-targeted library reference
+      # and require the wasm-tools-net8 workload; the WebAssembly SDK defaults the RID anyway.
+      - name: Publish Playground (browser-wasm Release, no AOT)
+        run: dotnet publish src/SkiaSharp.QrCode.Playground/SkiaSharp.QrCode.Playground.csproj -c Release -p:RunAOTCompilation=false -p:PlaygroundSoftFingerprint=true -o publish/playground/
+
   build-complete:
-    needs: [build, run]
+    needs: [build, run, build-playground]
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,55 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  build-playground:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: guitarrapc/actions/.github/actions/setup-dotnet@9122a18b0dea07585a242b9eb6ed7886f8587c49 # v1.0.1
+        with:
+          dotnet-version: 10.0
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+      # Version flows into the in-page version badge (AssemblyInformationalVersion).
+      # No -r browser-wasm: the WebAssembly SDK defaults to it, and passing it as a global
+      # property would force the multi-targeted library reference to need wasm-tools-net8.
+      - name: Publish Playground (browser-wasm Release)
+        env:
+          GIT_TAG: ${{ inputs.version || github.ref_name }}
+        run: |
+          dotnet publish src/SkiaSharp.QrCode.Playground/SkiaSharp.QrCode.Playground.csproj -c Release -p:PlaygroundSoftFingerprint=true -p:Version="${GIT_TAG}" -o publish/
+      - name: Add .nojekyll
+        run: touch publish/wwwroot/.nojekyll
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: publish/wwwroot
+
+  # GitHub Pages deploy of the Playground; tag pushes only, same as create-release.
+  # Depends on build-dotnet so a broken release build also blocks the pages deploy.
+  # To redeploy a tag, re-run its release workflow run.
+  deploy-playground:
+    if: ${{ github.event_name == 'push' }}
+    needs: [build-playground, build-dotnet]
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    permissions:
+      pages: write
+      id-token: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
   create-release:
     if: ${{ github.event_name == 'push' }}
     needs: [build-dotnet]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="NativeCompressions" Version="0.6.1" />
     <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="4.148.0" />
     <PackageVersion Include="SkiaSharp.NativeAssets.NanoServer" Version="4.148.0" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="4.148.0" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="4.148.0" />
     <PackageVersion Include="SkiaSharp.Views.Blazor" Version="4.148.0" />
     <!-- Supply chain -->

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ You can create professional-looking QR codes like this with just a few lines of 
 
 See [samples/ConsoleApp](samples/ConsoleApp) for code examples generating these styles.
 
+## Playground
+
+Try SkiaSharp.QrCode in your browser — no install required: **[SkiaSharp.QrCode Playground](https://guitarrapc.github.io/SkiaSharp.QrCode/)**
+
+The playground runs the actual library compiled to WebAssembly (GitHub Pages, fully static). Tune gradients, module shapes, finder patterns and logos in realtime, then download the PNG or share your settings as a permalink. Source lives in [src/SkiaSharp.QrCode.Playground](src/SkiaSharp.QrCode.Playground); it is deployed to GitHub Pages by [release.yaml](.github/workflows/release.yaml) as part of every release.
+
 ## Overview
 
 SkiaSharp.QrCode is a modern, high-performance QR code generation library built on SkiaSharp. SkiaSharp.QrCode allocates memory only for the actual QR code data, with zero additional allocations during processing.

--- a/SkiaSharp.QrCode.slnx
+++ b/SkiaSharp.QrCode.slnx
@@ -13,6 +13,7 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/SkiaSharp.QrCode.Benchmark/SkiaSharp.QrCode.Benchmark.csproj" />
+    <Project Path="src/SkiaSharp.QrCode.Playground/SkiaSharp.QrCode.Playground.csproj" />
     <Project Path="src/SkiaSharp.QrCode/SkiaSharp.QrCode.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/src/SkiaSharp.QrCode.Playground/Program.cs
+++ b/src/SkiaSharp.QrCode.Playground/Program.cs
@@ -1,2 +1,7 @@
+using System.Runtime.Versioning;
+
+// Browser-only assembly: satisfies CA1416 for [JSExport]/[JSImport] call sites.
+[assembly: SupportedOSPlatform("browser")]
+
 // WASM host starts the Mono runtime once; QrInterop is exported to JavaScript.
 Console.WriteLine("SkiaSharp.QrCode Playground WASM runtime initialized.");

--- a/src/SkiaSharp.QrCode.Playground/Program.cs
+++ b/src/SkiaSharp.QrCode.Playground/Program.cs
@@ -1,0 +1,2 @@
+// WASM host starts the Mono runtime once; QrInterop is exported to JavaScript.
+Console.WriteLine("SkiaSharp.QrCode Playground WASM runtime initialized.");

--- a/src/SkiaSharp.QrCode.Playground/QrInterop.cs
+++ b/src/SkiaSharp.QrCode.Playground/QrInterop.cs
@@ -1,0 +1,302 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.InteropServices.JavaScript;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SkiaSharp.QrCode.Image;
+
+namespace SkiaSharp.QrCode.Playground;
+
+/// <summary>
+/// Browser-callable QR generation API. Invoked by the host script after <c>runMain()</c> completes.
+/// <para>
+/// CRITICAL: Every <c>[JSExport]</c> method MUST catch all exceptions internally.
+/// An unhandled exception propagating through the interop boundary causes the Mono WASM
+/// runtime to abort (exit code 1). Once aborted, the runtime cannot be restarted without
+/// a full page reload, and all subsequent calls fail with
+/// "Assert failed: .NET runtime already exited with 1".
+/// </para>
+/// </summary>
+public static partial class QrInterop
+{
+    private static SKBitmap? s_defaultLogo;
+    private static byte[]? s_customLogoBytes;
+    private static SKBitmap? s_customLogoBitmap;
+    private static string s_lastMeta = "{}";
+
+    /// <summary>User-facing build version. Exposed to the page script after WASM starts.</summary>
+    [JSExport]
+    public static string GetProductVersion()
+    {
+        try
+        {
+            var assembly = typeof(QrInterop).Assembly;
+            var info = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            if (string.IsNullOrEmpty(info))
+                return assembly.GetName().Version?.ToString(3) ?? "unknown";
+
+            // Strip SourceLink metadata (e.g. "1.2.3+abcdef0")
+            var plus = info.IndexOf('+');
+            return plus > 0 ? info[..plus] : info;
+        }
+        catch
+        {
+            return "unknown";
+        }
+    }
+
+    /// <summary>
+    /// Stats of the most recent successful <see cref="Generate"/> call as a JSON string:
+    /// <c>{"qrVersion":N,"matrixSize":N,"totalMs":N,"bytes":N}</c>.
+    /// </summary>
+    [JSExport]
+    public static string GetLastMeta() => s_lastMeta;
+
+    /// <summary>
+    /// Generates a QR code PNG from JSON options (see <see cref="QrRequest"/>).
+    /// Returns PNG bytes on success (first byte 0x89), or UTF-8 JSON
+    /// <c>{"error":"..."}</c> on failure (first byte 0x7B) — the JS side
+    /// distinguishes the two by the first byte.
+    /// </summary>
+    /// <param name="optionsJson">Serialized <see cref="QrRequest"/> (camelCase).</param>
+    /// <param name="customLogo">Uploaded logo image bytes; empty unless logo mode is "custom".</param>
+    [JSExport]
+    public static byte[] Generate(string optionsJson, byte[] customLogo)
+    {
+        try
+        {
+            var request = JsonSerializer.Deserialize(optionsJson, PlaygroundJsonContext.Default.QrRequest)
+                ?? throw new InvalidOperationException("Options JSON deserialized to null.");
+            return GenerateCore(request, customLogo);
+        }
+        catch (Exception ex)
+        {
+            return SerializeError(ex);
+        }
+    }
+
+    private static byte[] GenerateCore(QrRequest request, byte[] customLogo)
+    {
+        if (string.IsNullOrWhiteSpace(request.Content))
+            throw new ArgumentException("Content is empty.");
+
+        var stopwatch = Stopwatch.StartNew();
+        var data = QRCodeGenerator.CreateQrCode(
+            request.Content.AsSpan(),
+            ParseEcc(request.Ecc),
+            requestedVersion: request.Version,
+            quietZoneSize: Math.Clamp(request.QuietZone, 0, 10));
+
+        var size = Math.Clamp(request.Size, 64, 2048);
+        var bytes = new QRCodeImageBuilder(data)
+            .WithSize(size, size)
+            .WithColors(
+                ParseColor(request.Foreground, SKColors.Black),
+                ParseColor(request.Background, SKColors.White))
+            .WithModuleShape(CreateModuleShape(request), Math.Clamp(request.ModuleSizePercent, 0.5f, 1.0f))
+            .WithFinderPatternShape(CreateFinderShape(request.FinderShape))
+            .WithGradient(CreateGradient(request.Gradient))
+            .WithIcon(CreateIcon(request.Logo, customLogo))
+            .ToByteArray();
+        stopwatch.Stop();
+
+        s_lastMeta = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{{\"qrVersion\":{data.Version},\"matrixSize\":{data.Size},\"totalMs\":{stopwatch.Elapsed.TotalMilliseconds:F1},\"bytes\":{bytes.Length}}}");
+        return bytes;
+    }
+
+    private static ECCLevel ParseEcc(string ecc) => ecc.ToUpperInvariant() switch
+    {
+        "L" => ECCLevel.L,
+        "M" => ECCLevel.M,
+        "Q" => ECCLevel.Q,
+        "H" => ECCLevel.H,
+        _ => throw new ArgumentException($"Unknown ECC level '{ecc}'. Use L, M, Q or H."),
+    };
+
+    private static SKColor ParseColor(string value, SKColor fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+        if (value.Equals("transparent", StringComparison.OrdinalIgnoreCase))
+            return SKColors.Transparent;
+        if (SKColor.TryParse(value, out var color))
+            return color;
+        throw new ArgumentException($"Could not parse color '{value}'. Use #RRGGBB or 'transparent'.");
+    }
+
+    private static ModuleShape? CreateModuleShape(QrRequest request) => request.ModuleShape switch
+    {
+        "circle" => CircleModuleShape.Default,
+        "rounded" => new RoundedRectangleModuleShape(Math.Clamp(request.ModuleCornerRadius, 0f, 1f)),
+        _ => null, // rectangle (default)
+    };
+
+    private static FinderPatternShape? CreateFinderShape(string finderShape) => finderShape switch
+    {
+        "rectangle" => RectangleFinderPatternShape.Default,
+        "circle" => CircleFinderPatternShape.Default,
+        "rounded" => RoundedRectangleFinderPatternShape.Default,
+        "roundedCircle" => RoundedRectangleCircleFinderPatternShape.Default,
+        _ => null, // auto: standard pattern, or module shape when one is set
+    };
+
+    private static GradientOptions? CreateGradient(GradientDto? gradient)
+    {
+        if (gradient is null || !gradient.Enabled || gradient.Colors.Length < 2)
+            return null;
+
+        var direction = Enum.TryParse<GradientDirection>(gradient.Direction, ignoreCase: true, out var parsed)
+            ? parsed
+            : GradientDirection.TopLeftToBottomRight;
+        if (direction == GradientDirection.None)
+            return null;
+
+        var colors = new SKColor[gradient.Colors.Length];
+        for (var i = 0; i < colors.Length; i++)
+        {
+            colors[i] = ParseColor(gradient.Colors[i], SKColors.Black);
+        }
+        return new GradientOptions(colors, direction);
+    }
+
+    private static IconData? CreateIcon(LogoDto? logo, byte[] customLogo)
+    {
+        if (logo is null)
+            return null;
+
+        var bitmap = logo.Mode switch
+        {
+            "default" => s_defaultLogo ??= CreateDefaultLogo(),
+            "custom" => DecodeCustomLogo(customLogo),
+            _ => null, // none
+        };
+        if (bitmap is null)
+            return null;
+
+        return IconData.FromImage(
+            bitmap,
+            iconSizePercent: Math.Clamp(logo.SizePercent, 1, 40),
+            iconBorderWidth: Math.Clamp(logo.BorderWidth, 0, 64));
+    }
+
+    /// <summary>
+    /// Decodes the uploaded logo, caching the bitmap keyed by content so slider-driven
+    /// realtime regeneration does not re-decode the same image on every call.
+    /// </summary>
+    private static SKBitmap? DecodeCustomLogo(byte[] bytes)
+    {
+        if (bytes.Length == 0)
+            return null;
+        if (s_customLogoBitmap is not null && s_customLogoBytes is not null && bytes.AsSpan().SequenceEqual(s_customLogoBytes))
+            return s_customLogoBitmap;
+
+        var bitmap = SKBitmap.Decode(bytes)
+            ?? throw new ArgumentException("Could not decode the uploaded logo image. Use PNG, JPEG or WebP.");
+        s_customLogoBitmap?.Dispose();
+        s_customLogoBytes = bytes;
+        s_customLogoBitmap = bitmap;
+        return bitmap;
+    }
+
+    /// <summary>
+    /// Draws the built-in logo: an Instagram-style camera glyph on a warm-to-purple
+    /// gradient rounded square. Rendered with SkiaSharp itself, so no binary asset is shipped.
+    /// </summary>
+    private static SKBitmap CreateDefaultLogo()
+    {
+        const int S = 256;
+        var bitmap = new SKBitmap(new SKImageInfo(S, S, SKImageInfo.PlatformColorType, SKAlphaType.Premul));
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Transparent);
+
+        // Gradient rounded square (bottom-left warm to top-right purple).
+        using var background = new SKPaint { IsAntialias = true };
+        background.Shader = SKShader.CreateLinearGradient(
+            new SKPoint(0, S),
+            new SKPoint(S, 0),
+            [SKColor.Parse("#FA7E1E"), SKColor.Parse("#D62976"), SKColor.Parse("#962FBF")],
+            null,
+            SKShaderTileMode.Clamp);
+        canvas.DrawRoundRect(SKRect.Create(0, 0, S, S), S * 0.22f, S * 0.22f, background);
+
+        // White camera outline: body, lens, flash dot.
+        using var stroke = new SKPaint
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = S * 0.055f,
+            Color = SKColors.White,
+            StrokeCap = SKStrokeCap.Round,
+        };
+        var inset = S * 0.19f;
+        canvas.DrawRoundRect(SKRect.Create(inset, inset, S - 2 * inset, S - 2 * inset), S * 0.12f, S * 0.12f, stroke);
+        canvas.DrawCircle(S / 2f, S / 2f, S * 0.15f, stroke);
+        using var dot = new SKPaint { IsAntialias = true, Color = SKColors.White };
+        canvas.DrawCircle(S * 0.685f, S * 0.315f, S * 0.033f, dot);
+
+        return bitmap;
+    }
+
+    private static byte[] SerializeError(Exception ex)
+    {
+        var message = ex.GetBaseException().Message;
+        return JsonSerializer.SerializeToUtf8Bytes(new ErrorPayload(message), PlaygroundJsonContext.Default.ErrorPayload);
+    }
+}
+
+/// <summary>QR generation options passed from the page script as camelCase JSON.</summary>
+public sealed record QrRequest
+{
+    public string Content { get; init; } = "";
+    /// <summary>Error correction level: L, M, Q or H.</summary>
+    public string Ecc { get; init; } = "M";
+    /// <summary>Output image size in pixels (square).</summary>
+    public int Size { get; init; } = 512;
+    /// <summary>Quiet zone in modules (0-10).</summary>
+    public int QuietZone { get; init; } = 4;
+    /// <summary>QR version 1-40, or -1 for automatic selection.</summary>
+    public int Version { get; init; } = -1;
+    /// <summary>Module shape: rectangle, circle or rounded.</summary>
+    public string ModuleShape { get; init; } = "rectangle";
+    /// <summary>Module size as a fraction of the cell (0.5-1.0).</summary>
+    public float ModuleSizePercent { get; init; } = 1.0f;
+    /// <summary>Corner radius fraction for rounded modules (0.0-1.0).</summary>
+    public float ModuleCornerRadius { get; init; } = 0.3f;
+    /// <summary>Finder pattern shape: auto, rectangle, circle, rounded or roundedCircle.</summary>
+    public string FinderShape { get; init; } = "auto";
+    /// <summary>Module color as #RRGGBB.</summary>
+    public string Foreground { get; init; } = "#000000";
+    /// <summary>Background color as #RRGGBB or 'transparent'.</summary>
+    public string Background { get; init; } = "#FFFFFF";
+    public GradientDto? Gradient { get; init; }
+    public LogoDto? Logo { get; init; }
+}
+
+public sealed record GradientDto
+{
+    public bool Enabled { get; init; }
+    /// <summary>Gradient stops as #RRGGBB (2 or more).</summary>
+    public string[] Colors { get; init; } = [];
+    /// <summary>A <see cref="GradientDirection"/> member name.</summary>
+    public string Direction { get; init; } = "TopLeftToBottomRight";
+}
+
+public sealed record LogoDto
+{
+    /// <summary>Logo mode: none, default (built-in camera glyph) or custom (uploaded image).</summary>
+    public string Mode { get; init; } = "none";
+    /// <summary>Logo size as a percentage of the QR side length (1-40).</summary>
+    public int SizePercent { get; init; } = 16;
+    /// <summary>Border padding around the logo in pixels (0-64).</summary>
+    public int BorderWidth { get; init; } = 6;
+}
+
+public sealed record ErrorPayload(string Error);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(QrRequest))]
+[JsonSerializable(typeof(ErrorPayload))]
+internal sealed partial class PlaygroundJsonContext : JsonSerializerContext;

--- a/src/SkiaSharp.QrCode.Playground/QrInterop.cs
+++ b/src/SkiaSharp.QrCode.Playground/QrInterop.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
@@ -88,8 +89,20 @@ public static partial class QrInterop
             requestedVersion: request.Version,
             quietZoneSize: Math.Clamp(request.QuietZone, 0, 10));
 
+        var bytes = CreateBuilder(request, data, customLogo).ToByteArray();
+        stopwatch.Stop();
+
+        s_lastMeta = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{{\"qrVersion\":{data.Version},\"matrixSize\":{data.Size},\"totalMs\":{stopwatch.Elapsed.TotalMilliseconds:F1},\"bytes\":{bytes.Length}}}");
+        return bytes;
+    }
+
+    /// <summary>Builds the image builder from request options; shared by preview and benchmark rendering.</summary>
+    private static QRCodeImageBuilder CreateBuilder(QrRequest request, QRCodeData data, byte[] customLogo)
+    {
         var size = Math.Clamp(request.Size, 64, 2048);
-        var bytes = new QRCodeImageBuilder(data)
+        return new QRCodeImageBuilder(data)
             .WithSize(size, size)
             .WithColors(
                 ParseColor(request.Foreground, SKColors.Black),
@@ -97,14 +110,122 @@ public static partial class QrInterop
             .WithModuleShape(CreateModuleShape(request), Math.Clamp(request.ModuleSizePercent, 0.5f, 1.0f))
             .WithFinderPatternShape(CreateFinderShape(request.FinderShape))
             .WithGradient(CreateGradient(request.Gradient))
-            .WithIcon(CreateIcon(request.Logo, customLogo))
-            .ToByteArray();
+            .WithIcon(CreateIcon(request.Logo, customLogo));
+    }
+
+    /// <summary>
+    /// Runs one benchmark batch and returns stats as a JSON string:
+    /// <c>{"count":N,"elapsedMs":N,"qrVersion":N,"matrixSize":N,"bytesTotal":N}</c>,
+    /// or <c>{"error":"..."}</c> on failure. The page script chains batches so the UI
+    /// stays responsive and can show progress / cancel.
+    /// <para>
+    /// Content is made unique per iteration by appending <c>" #&lt;index+1&gt;"</c>.
+    /// Mode <c>encode</c> exercises the allocation-free
+    /// <see cref="QRCodeGenerator.CreateQrCode(ReadOnlySpan{char}, ECCLevel, Span{byte}, bool, EciMode, int, int)"/>
+    /// overload only; mode <c>render</c> runs the full pipeline (encode + Skia render + PNG encode)
+    /// with the current visual options.
+    /// </para>
+    /// </summary>
+    /// <param name="optionsJson">Serialized <see cref="QrRequest"/> (camelCase).</param>
+    /// <param name="mode">"encode" or "render".</param>
+    /// <param name="startIndex">Global index of the first iteration in this batch.</param>
+    /// <param name="count">Iterations to run in this batch.</param>
+    /// <param name="customLogo">Uploaded logo bytes for render mode; empty otherwise.</param>
+    [JSExport]
+    public static string BenchmarkBatch(string optionsJson, string mode, int startIndex, int count, byte[] customLogo)
+    {
+        try
+        {
+            var request = JsonSerializer.Deserialize(optionsJson, PlaygroundJsonContext.Default.QrRequest)
+                ?? throw new InvalidOperationException("Options JSON deserialized to null.");
+            if (string.IsNullOrWhiteSpace(request.Content))
+                throw new ArgumentException("Content is empty.");
+            if (count is <= 0 or > 1_000_000)
+                throw new ArgumentOutOfRangeException(nameof(count), "Batch count must be between 1 and 1,000,000.");
+
+            return mode switch
+            {
+                "encode" => BenchmarkEncode(request, startIndex, count),
+                "render" => BenchmarkRender(request, startIndex, count, customLogo),
+                _ => throw new ArgumentException($"Unknown benchmark mode '{mode}'. Use 'encode' or 'render'."),
+            };
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new ErrorPayload(ex.GetBaseException().Message), PlaygroundJsonContext.Default.ErrorPayload);
+        }
+    }
+
+    /// <summary>
+    /// Tight loop over the zero-allocation span API. The per-iteration text is composed in a
+    /// pooled char buffer (no string allocation) and the module matrix is written into a
+    /// pooled byte buffer sized for QR version 40, so the loop itself allocates nothing.
+    /// </summary>
+    private static string BenchmarkEncode(QrRequest request, int startIndex, int count)
+    {
+        var ecc = ParseEcc(request.Ecc);
+        var quietZone = Math.Clamp(request.QuietZone, 0, 10);
+        var prefixLength = request.Content.Length;
+
+        // " #" + int.MaxValue digits
+        var textBuffer = ArrayPool<char>.Shared.Rent(prefixLength + 2 + 11);
+        // Version 40 with quiet zone is the largest possible matrix.
+        var maxSide = 177 + 2 * quietZone;
+        var moduleBuffer = ArrayPool<byte>.Shared.Rent(maxSide * maxSide);
+        try
+        {
+            request.Content.AsSpan().CopyTo(textBuffer);
+            textBuffer[prefixLength] = ' ';
+            textBuffer[prefixLength + 1] = '#';
+
+            long bytesTotal = 0;
+            var written = 0;
+            var stopwatch = Stopwatch.StartNew();
+            for (var i = 0; i < count; i++)
+            {
+                (startIndex + i + 1).TryFormat(textBuffer.AsSpan(prefixLength + 2), out var digits);
+                var text = textBuffer.AsSpan(0, prefixLength + 2 + digits);
+                written = QRCodeGenerator.CreateQrCode(text, ecc, moduleBuffer, requestedVersion: request.Version, quietZoneSize: quietZone);
+                bytesTotal += written;
+            }
+            stopwatch.Stop();
+
+            var matrixSize = (int)Math.Sqrt(written);
+            var qrVersion = (matrixSize - 2 * quietZone - 17) / 4;
+            return string.Create(
+                CultureInfo.InvariantCulture,
+                $"{{\"count\":{count},\"elapsedMs\":{stopwatch.Elapsed.TotalMilliseconds:F2},\"qrVersion\":{qrVersion},\"matrixSize\":{matrixSize},\"bytesTotal\":{bytesTotal}}}");
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(moduleBuffer, clearArray: false);
+            ArrayPool<char>.Shared.Return(textBuffer, clearArray: false);
+        }
+    }
+
+    /// <summary>Full pipeline per iteration: encode, Skia render with current options, PNG encode.</summary>
+    private static string BenchmarkRender(QrRequest request, int startIndex, int count, byte[] customLogo)
+    {
+        var ecc = ParseEcc(request.Ecc);
+        var quietZone = Math.Clamp(request.QuietZone, 0, 10);
+
+        long bytesTotal = 0;
+        var qrVersion = 0;
+        var matrixSize = 0;
+        var stopwatch = Stopwatch.StartNew();
+        for (var i = 0; i < count; i++)
+        {
+            var text = string.Create(CultureInfo.InvariantCulture, $"{request.Content} #{startIndex + i + 1}");
+            var data = QRCodeGenerator.CreateQrCode(text.AsSpan(), ecc, requestedVersion: request.Version, quietZoneSize: quietZone);
+            qrVersion = data.Version;
+            matrixSize = data.Size;
+            bytesTotal += CreateBuilder(request, data, customLogo).ToByteArray().Length;
+        }
         stopwatch.Stop();
 
-        s_lastMeta = string.Create(
+        return string.Create(
             CultureInfo.InvariantCulture,
-            $"{{\"qrVersion\":{data.Version},\"matrixSize\":{data.Size},\"totalMs\":{stopwatch.Elapsed.TotalMilliseconds:F1},\"bytes\":{bytes.Length}}}");
-        return bytes;
+            $"{{\"count\":{count},\"elapsedMs\":{stopwatch.Elapsed.TotalMilliseconds:F2},\"qrVersion\":{qrVersion},\"matrixSize\":{matrixSize},\"bytesTotal\":{bytesTotal}}}");
     }
 
     private static ECCLevel ParseEcc(string ecc) => ecc.ToUpperInvariant() switch

--- a/src/SkiaSharp.QrCode.Playground/README.md
+++ b/src/SkiaSharp.QrCode.Playground/README.md
@@ -27,6 +27,10 @@ dotnet serve -d publish/playground/wwwroot   # or: python -m http.server -d publ
 `-p:PlaygroundSoftFingerprint=true` emits both fingerprinted and plain filenames so the page
 works on hosts without import-map rewriting (GitHub Pages, plain static servers).
 
+Publish to a **clean output directory** (delete it between publishes). Re-publishing into the
+same `-o` directory leaves the previous build's fingerprinted files behind, and the
+`_CopyDotnetJsFallback` target then fails with MSB3094 because two `dotnet.*.js` entry files match.
+
 The production build adds AOT + full trimming:
 
 ```bash
@@ -44,6 +48,18 @@ The `build-playground` / `deploy-playground` jobs in
 `github-pages` environment as part of every release tag push (`X.Y.Z`). To redeploy a tag,
 re-run its release workflow run. GitHub Pages must be configured with
 **Source: GitHub Actions** in the repository settings.
+
+## Performance benchmark
+
+The "Performance benchmark" panel generates many unique codes sequentially (content suffixed
+with `#1`, `#2`, …) to demo library throughput under load, in two modes:
+
+- **Encode only** — the zero-allocation `CreateQrCode(text, ecc, Span<byte>)` overload in a
+  tight loop (pooled text/module buffers, no per-iteration allocation).
+- **Full pipeline** — encode + Skia render + PNG encode with the current visual settings.
+
+The page script chains `BenchmarkBatch` calls sized to ~150ms of wall clock, so progress
+renders and Cancel stays responsive while everything runs single-threaded on the WASM runtime.
 
 ## Share links
 

--- a/src/SkiaSharp.QrCode.Playground/README.md
+++ b/src/SkiaSharp.QrCode.Playground/README.md
@@ -1,0 +1,52 @@
+# SkiaSharp.QrCode.Playground
+
+Browser playground for SkiaSharp.QrCode, published to GitHub Pages: https://guitarrapc.github.io/SkiaSharp.QrCode/
+
+A static `Microsoft.NET.Sdk.WebAssembly` app (no Blazor, no server). The page script loads the
+.NET runtime via `_framework/dotnet.js` and calls `[JSExport]` methods on `QrInterop` to render
+QR codes with the real SkiaSharp native library compiled to WebAssembly.
+
+## Local development
+
+The SkiaSharp native library is linked into `dotnet.native.wasm` **only on publish**
+(see the `_IsPublishing` condition in the csproj). This keeps solution builds fast and free of
+the Emscripten toolchain, but it means `dotnet run`/`dotnet build` outputs cannot render —
+always go through `dotnet publish`:
+
+```bash
+# once
+dotnet workload install wasm-tools
+
+# fast inner loop (no AOT, no trimming)
+dotnet publish src/SkiaSharp.QrCode.Playground/SkiaSharp.QrCode.Playground.csproj -c Debug -p:PlaygroundSoftFingerprint=true -o publish/playground
+
+# serve the static output (any static file server works)
+dotnet serve -d publish/playground/wwwroot   # or: python -m http.server -d publish/playground/wwwroot
+```
+
+`-p:PlaygroundSoftFingerprint=true` emits both fingerprinted and plain filenames so the page
+works on hosts without import-map rewriting (GitHub Pages, plain static servers).
+
+The production build adds AOT + full trimming:
+
+```bash
+dotnet publish src/SkiaSharp.QrCode.Playground/SkiaSharp.QrCode.Playground.csproj -c Release -p:PlaygroundSoftFingerprint=true -o publish/playground
+```
+
+Do not pass `-r browser-wasm`: the WebAssembly SDK already defaults to it, and as a CLI global
+property it propagates to the multi-targeted library reference, which would then demand the
+`wasm-tools-net8` workload.
+
+## Deploy
+
+The `build-playground` / `deploy-playground` jobs in
+[.github/workflows/release.yaml](../../.github/workflows/release.yaml) publish to the
+`github-pages` environment as part of every release tag push (`X.Y.Z`). To redeploy a tag,
+re-run its release workflow run. GitHub Pages must be configured with
+**Source: GitHub Actions** in the repository settings.
+
+## Share links
+
+The Share button stores the full playground state (compressed with `CompressionStream`,
+base64url) in the URL hash — nothing is sent to a server. Uploaded logo images are excluded
+from share links; the link falls back to the built-in logo.

--- a/src/SkiaSharp.QrCode.Playground/SkiaSharp.QrCode.Playground.csproj
+++ b/src/SkiaSharp.QrCode.Playground/SkiaSharp.QrCode.Playground.csproj
@@ -1,0 +1,74 @@
+<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>SkiaSharp.QrCode.Playground</RootNamespace>
+    <AssemblyName>SkiaSharp.QrCode.Playground</AssemblyName>
+    <!-- Required by the [JSExport] source generator (SYSLIB1075) -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <InvariantTimezone>true</InvariantTimezone>
+    <!-- Keep readable exception messages; they are surfaced in the UI as generation errors -->
+    <UseSystemResourceKeys>false</UseSystemResourceKeys>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Pre-allocate 64MB at startup to reduce early memory.grow fragmentation -->
+    <EmccInitialHeapSize>67108864</EmccInitialHeapSize>
+    <!-- Allow up to 1GB; Debug builds (no trim, no AOT) plus large canvases can exceed 512MB -->
+    <EmccMaximumHeapSize>1073741824</EmccMaximumHeapSize>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <RunAOTCompilation>true</RunAOTCompilation>
+    <WasmEnableWebcil>true</WasmEnableWebcil>
+  </PropertyGroup>
+
+  <!--
+    Static-host deploy (GitHub Pages): use -p:PlaygroundSoftFingerprint=true so the SDK
+    emits BOTH fingerprinted AND non-fingerprinted files.  This keeps href="style.css" and
+    import './_framework/dotnet.js' resolvable without server-side rewrites or import maps.
+    Default (!) keeps only fingerprinted files (suited for hosts that handle import maps).
+  -->
+  <PropertyGroup Condition="'$(PlaygroundSoftFingerprint)' == 'true'">
+    <PlaygroundFingerprintSuffix>?</PlaygroundFingerprintSuffix>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(PlaygroundSoftFingerprint)' != 'true'">
+    <PlaygroundFingerprintSuffix>!</PlaygroundFingerprintSuffix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- This app only runs in the browser; silences CA1416 for [JSExport] on plain net10.0 TFM -->
+    <SupportedPlatform Include="browser" />
+    <ProjectReference Include="..\SkiaSharp.QrCode\SkiaSharp.QrCode.csproj" />
+    <StaticWebAssetFingerprintPattern Include="JS" Pattern="*.js" Expression="#[.{fingerprint}]$(PlaygroundFingerprintSuffix)" />
+    <StaticWebAssetFingerprintPattern Include="CSS" Pattern="*.css" Expression="#[.{fingerprint}]$(PlaygroundFingerprintSuffix)" />
+  </ItemGroup>
+
+  <!--
+    libSkiaSharp.a is linked into dotnet.native.wasm only when publishing: the native relink
+    requires the wasm-tools workload (Emscripten) and takes minutes. Solution builds stay
+    managed-only so CI matrix legs do not need a native toolchain. Run the app locally via
+    `dotnet publish` (Debug is fast: no AOT, no trimming), then serve the published wwwroot.
+  -->
+  <ItemGroup Condition="'$(_IsPublishing)' == 'true'">
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
+  </ItemGroup>
+
+  <!--
+    Static-host fallback: copy the fingerprinted dotnet entry JS to _framework/dotnet.js so that
+    the ES module import in main.js resolves without an import map (GitHub Pages has no rewrite rules).
+  -->
+  <Target Name="_CopyDotnetJsFallback" AfterTargets="Publish" Condition="'$(PlaygroundSoftFingerprint)' == 'true'">
+    <ItemGroup>
+      <_DotnetEntryJs Include="$(PublishDir)wwwroot/_framework/dotnet.*.js"
+                      Exclude="$(PublishDir)wwwroot/_framework/dotnet.native.*.js;$(PublishDir)wwwroot/_framework/dotnet.runtime.*.js" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_DotnetEntryJs)" DestinationFiles="$(PublishDir)wwwroot/_framework/dotnet.js" />
+  </Target>
+
+</Project>

--- a/src/SkiaSharp.QrCode.Playground/SkiaSharp.QrCode.Playground.csproj
+++ b/src/SkiaSharp.QrCode.Playground/SkiaSharp.QrCode.Playground.csproj
@@ -42,8 +42,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- This app only runs in the browser; silences CA1416 for [JSExport] on plain net10.0 TFM -->
-    <SupportedPlatform Include="browser" />
     <ProjectReference Include="..\SkiaSharp.QrCode\SkiaSharp.QrCode.csproj" />
     <StaticWebAssetFingerprintPattern Include="JS" Pattern="*.js" Expression="#[.{fingerprint}]$(PlaygroundFingerprintSuffix)" />
     <StaticWebAssetFingerprintPattern Include="CSS" Pattern="*.css" Expression="#[.{fingerprint}]$(PlaygroundFingerprintSuffix)" />

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/favicon.svg
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/favicon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0" stop-color="#FA7E1E"/>
+      <stop offset="0.55" stop-color="#D62976"/>
+      <stop offset="1" stop-color="#962FBF"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#g)"/>
+  <g fill="#fff">
+    <rect x="12" y="12" width="16" height="16" rx="3"/>
+    <rect x="17" y="17" width="6" height="6" rx="1.5" fill="url(#g)"/>
+    <rect x="36" y="12" width="16" height="16" rx="3"/>
+    <rect x="41" y="17" width="6" height="6" rx="1.5" fill="url(#g)"/>
+    <rect x="12" y="36" width="16" height="16" rx="3"/>
+    <rect x="17" y="41" width="6" height="6" rx="1.5" fill="url(#g)"/>
+    <rect x="36" y="36" width="7" height="7" rx="2"/>
+    <rect x="45" y="36" width="7" height="7" rx="2"/>
+    <rect x="36" y="45" width="7" height="7" rx="2"/>
+    <rect x="45" y="45" width="7" height="7" rx="2"/>
+  </g>
+</svg>

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/index.html
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/index.html
@@ -212,6 +212,40 @@
           </div>
           <p class="field__hint">A logo covers part of the code — use error correction H and verify the result scans.</p>
         </details>
+
+        <details class="panel">
+          <summary>Performance benchmark</summary>
+          <div class="panel__grid">
+            <label class="field">
+              <span class="field__label">Mode</span>
+              <select id="bench-mode-select"
+                title="Encode only exercises the zero-allocation span API; full pipeline also renders and PNG-encodes with the current visual settings">
+                <option value="encode">Encode only — zero-allocation API</option>
+                <option value="render">Full pipeline — encode + render + PNG</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="field__label">Iterations</span>
+              <select id="bench-count-select">
+                <option value="100">100</option>
+                <option value="1000" selected>1,000</option>
+                <option value="10000">10,000</option>
+                <option value="100000">100,000</option>
+              </select>
+            </label>
+          </div>
+          <div class="bench-actions">
+            <button type="button" id="bench-run-btn" class="action-btn" disabled>Run benchmark</button>
+            <button type="button" id="bench-cancel-btn" class="small-btn" hidden>Cancel</button>
+          </div>
+          <progress id="bench-progress" value="0" max="100" hidden></progress>
+          <div id="bench-result" class="qr-stats" aria-live="polite"></div>
+          <p class="field__hint">
+            Generates unique codes sequentially (content is suffixed with #1, #2, …) using the current
+            settings, single-threaded on the WASM runtime in this tab. Native .NET throughput is much
+            higher — see the repository benchmarks.
+          </p>
+        </details>
       </div>
 
       <div class="preview-column">

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/index.html
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/index.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>SkiaSharp.QrCode Playground</title>
+  <meta name="description" content="Generate beautiful QR codes with SkiaSharp.QrCode — entirely in your browser via WebAssembly">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="SkiaSharp.QrCode Playground | Try in your browser">
+  <meta name="twitter:description" content="Generate beautiful QR codes with gradients, shapes and logos — entirely in your browser">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://guitarrapc.github.io/SkiaSharp.QrCode/">
+  <meta property="og:title" content="SkiaSharp.QrCode Playground | Try in your browser">
+  <meta property="og:description" content="Generate beautiful QR codes with gradients, shapes and logos — entirely in your browser">
+  <meta property="og:site_name" content="SkiaSharp.QrCode Playground">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" id="meta-color-scheme" content="light dark" />
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+  <script>
+    (function () {
+      var key = 'skqr-playground-color-mode';
+      var root = document.documentElement;
+      var meta = document.getElementById('meta-color-scheme');
+      function syncMeta(mode) {
+        if (!meta) return;
+        if (mode === 'light') meta.setAttribute('content', 'light');
+        else if (mode === 'dark') meta.setAttribute('content', 'dark');
+        else meta.setAttribute('content', 'light dark');
+      }
+      try {
+        var v = localStorage.getItem(key);
+        if (v === 'light') {
+          root.setAttribute('data-theme', 'light');
+          syncMeta('light');
+        } else if (v === 'dark') {
+          root.setAttribute('data-theme', 'dark');
+          syncMeta('dark');
+        } else {
+          root.removeAttribute('data-theme');
+          syncMeta('system');
+        }
+      } catch (e) { /* ignore */ }
+    })();
+  </script>
+  <link rel="stylesheet" href="style#[.{fingerprint}].css">
+</head>
+
+<body>
+  <nav id="header-bar">
+    <header>
+      <div class="site-title-row">
+        <h1>
+          <a href="https://github.com/guitarrapc/SkiaSharp.QrCode" aria-label="SkiaSharp.QrCode on GitHub"><span
+              class="site-logo" aria-hidden="true"></span></a>
+          SkiaSharp.QrCode Playground
+        </h1>
+        <a id="playground-version" class="version-badge" hidden target="_blank" rel="noopener noreferrer"
+          href="https://github.com/guitarrapc/SkiaSharp.QrCode/releases"
+          aria-label="Playground build version — GitHub releases"></a>
+      </div>
+      <p class="tagline">QR codes with gradients, shapes and logos — rendered by Skia in your browser</p>
+    </header>
+  </nav>
+  <div id="toast-stack" class="toast-stack" aria-live="polite" aria-relevant="additions"></div>
+  <main>
+    <section id="playground">
+      <div class="controls-column">
+        <div class="panel">
+          <label class="field">
+            <span class="field__label">Content</span>
+            <textarea id="content" rows="3" spellcheck="false"
+              placeholder="Text or URL to encode">https://github.com/guitarrapc/SkiaSharp.QrCode</textarea>
+          </label>
+          <label class="field">
+            <span class="field__label">Style preset</span>
+            <select id="preset-select">
+              <option value="instagram" selected>Instagram gradient + logo</option>
+              <option value="classic">Classic black &amp; white</option>
+              <option value="midnight">Midnight neon</option>
+              <option value="ocean">Ocean</option>
+              <option value="sunset">Sunset</option>
+              <option value="custom" hidden>(custom)</option>
+            </select>
+          </label>
+        </div>
+
+        <details class="panel" open>
+          <summary>QR parameters</summary>
+          <div class="panel__grid">
+            <label class="field">
+              <span class="field__label">Error correction</span>
+              <select id="ecc-select" title="Higher levels survive more damage or overlay — H is recommended with a logo">
+                <option value="L">L — 7%</option>
+                <option value="M">M — 15%</option>
+                <option value="Q">Q — 25%</option>
+                <option value="H">H — 30%</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="field__label">Version</span>
+              <select id="version-select" title="QR symbol version (matrix size). Auto picks the smallest that fits."></select>
+            </label>
+            <label class="field">
+              <span class="field__label">Image size <output id="size-out">512</output> px</span>
+              <input type="range" id="size-range" min="128" max="1024" step="32" value="512" />
+            </label>
+            <label class="field">
+              <span class="field__label">Quiet zone <output id="quiet-out">4</output> modules</span>
+              <input type="range" id="quiet-range" min="0" max="10" step="1" value="4" />
+            </label>
+          </div>
+        </details>
+
+        <details class="panel" open>
+          <summary>Shape</summary>
+          <div class="panel__grid">
+            <label class="field">
+              <span class="field__label">Module shape</span>
+              <select id="module-shape-select">
+                <option value="rectangle">Rectangle</option>
+                <option value="circle">Circle</option>
+                <option value="rounded">Rounded rectangle</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="field__label">Finder pattern</span>
+              <select id="finder-select" title="The three large squares in the corners">
+                <option value="auto">Auto (follow module shape)</option>
+                <option value="rectangle">Rectangle</option>
+                <option value="circle">Circle</option>
+                <option value="rounded">Rounded rectangle</option>
+                <option value="roundedCircle">Rounded + circle center</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="field__label">Module size <output id="module-size-out">100</output>%</span>
+              <input type="range" id="module-size-range" min="50" max="100" step="1" value="100"
+                title="Below 100% leaves gaps between modules. Values under 80% may hurt readability." />
+            </label>
+            <label class="field" id="corner-row">
+              <span class="field__label">Corner radius <output id="corner-out">30</output>%</span>
+              <input type="range" id="corner-range" min="0" max="100" step="5" value="30" />
+            </label>
+          </div>
+        </details>
+
+        <details class="panel" open>
+          <summary>Color</summary>
+          <div class="panel__grid">
+            <label class="field field--inline" id="fg-row">
+              <span class="field__label">Modules</span>
+              <input type="color" id="fg-color" value="#000000" />
+            </label>
+            <label class="field field--inline">
+              <span class="field__label">Background</span>
+              <input type="color" id="bg-color" value="#ffffff" />
+            </label>
+            <label class="field field--inline field--checkbox">
+              <input type="checkbox" id="bg-transparent" />
+              <span class="field__label">Transparent background</span>
+            </label>
+            <label class="field field--inline field--checkbox">
+              <input type="checkbox" id="gradient-toggle" />
+              <span class="field__label">Gradient modules</span>
+            </label>
+          </div>
+          <div id="gradient-panel" hidden>
+            <div class="field">
+              <span class="field__label">Gradient stops</span>
+              <div id="gradient-colors" class="gradient-colors"></div>
+              <button type="button" id="gradient-add-btn" class="small-btn">+ Add color</button>
+            </div>
+            <label class="field">
+              <span class="field__label">Direction</span>
+              <select id="gradient-direction">
+                <option value="LeftToRight">Left → Right</option>
+                <option value="RightToLeft">Right → Left</option>
+                <option value="TopToBottom">Top → Bottom</option>
+                <option value="BottomToTop">Bottom → Top</option>
+                <option value="TopLeftToBottomRight">Top-left → Bottom-right</option>
+                <option value="TopRightToBottomLeft">Top-right → Bottom-left</option>
+                <option value="BottomLeftToTopRight">Bottom-left → Top-right</option>
+                <option value="BottomRightToTopLeft">Bottom-right → Top-left</option>
+              </select>
+            </label>
+          </div>
+        </details>
+
+        <details class="panel" open>
+          <summary>Logo</summary>
+          <div class="panel__grid">
+            <label class="field">
+              <span class="field__label">Logo</span>
+              <select id="logo-mode-select">
+                <option value="none">None</option>
+                <option value="default">Built-in camera glyph</option>
+                <option value="custom">Upload image…</option>
+              </select>
+            </label>
+            <label class="field" id="logo-file-row" hidden>
+              <span class="field__label">Image file</span>
+              <input type="file" id="logo-file" accept="image/png,image/jpeg,image/webp" />
+            </label>
+            <label class="field">
+              <span class="field__label">Logo size <output id="logo-size-out">18</output>%</span>
+              <input type="range" id="logo-size-range" min="5" max="35" step="1" value="18" />
+            </label>
+            <label class="field">
+              <span class="field__label">Logo border <output id="logo-border-out">6</output> px</span>
+              <input type="range" id="logo-border-range" min="0" max="24" step="1" value="6" />
+            </label>
+          </div>
+          <p class="field__hint">A logo covers part of the code — use error correction H and verify the result scans.</p>
+        </details>
+      </div>
+
+      <div class="preview-column">
+        <div class="panel preview-panel">
+          <div id="loading" class="notification">Loading WebAssembly binary...</div>
+          <div class="preview-frame">
+            <img id="qr-preview" alt="Generated QR code" hidden />
+          </div>
+          <div id="generate-error" class="generate-error" hidden></div>
+          <div id="qr-stats" class="qr-stats"></div>
+          <div class="preview-actions">
+            <button type="button" id="download-btn" class="action-btn" disabled>Download PNG</button>
+            <button type="button" id="copy-image-btn" class="action-btn" disabled>Copy image</button>
+            <button type="button" id="permalink-btn" class="action-btn action-btn--primary" disabled
+              title="Share — copy a link with all settings encoded in the URL">Share link</button>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+  <section class="playground-about" aria-labelledby="about-playground-heading">
+    <h2 id="about-playground-heading">About the playground</h2>
+    <div class="playground-about__body">
+      <p>
+        This playground is a static page: after the WASM runtime loads,
+        <a href="https://github.com/guitarrapc/SkiaSharp.QrCode" target="_blank"
+          rel="noopener noreferrer">SkiaSharp.QrCode</a> encodes and renders every QR code
+        <strong>in your browser</strong>. Nothing you type is uploaded to a server.
+      </p>
+      <ul>
+        <li>Rendering uses the real SkiaSharp (Skia) native library compiled to WebAssembly — the output is
+          pixel-identical to what the NuGet package produces on .NET.</li>
+        <li><strong>Share link</strong> stores your settings compressed in the URL hash. Uploaded logo images are not
+          included in share links.</li>
+        <li>Decorated codes (gradients, shapes, logos) trade error margin for looks — always test-scan before printing.</li>
+      </ul>
+      <p>
+        The source code is available on <a href="https://github.com/guitarrapc/SkiaSharp.QrCode" target="_blank"
+          rel="noopener noreferrer">GitHub</a>.
+      </p>
+    </div>
+  </section>
+  <footer>
+    <p class="footer-copy-row">
+      <a class="repo-mark" href="https://github.com/guitarrapc/SkiaSharp.QrCode" target="_blank"
+        rel="noopener noreferrer" aria-label="SkiaSharp.QrCode on GitHub">
+        <svg class="repo-mark__icon" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"
+            d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.235-22.23-5.42-22.23-24.251 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.251 1.75 1.52 3.318 4.491 3.318 9.022 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" />
+        </svg>
+      </a>
+      <span class="footer-copy-sep" aria-hidden="true">|</span>
+      <span class="footer-copy-text">© 2026 <a href="https://github.com/guitarrapc">guitarrapc</a>. The source
+        code and website content are licensed <a
+          href="https://github.com/guitarrapc/SkiaSharp.QrCode/blob/main/LICENSE">MIT</a>.</span>
+      <span class="footer-copy-sep" aria-hidden="true">|</span>
+      <button type="button" id="theme-cycle-btn" class="theme-cycle-btn toolbar-icon-btn" data-theme-mode="system"
+        title="Cycle color theme: System → Light → Dark"
+        aria-label="Color theme: System. Click to cycle: System, Light, Dark.">
+        <svg class="theme-cycle-btn__svg theme-cycle-btn__svg--system" width="16" height="16" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+          aria-hidden="true">
+          <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+          <line x1="8" y1="21" x2="16" y2="21" />
+          <line x1="12" y1="17" x2="12" y2="21" />
+        </svg>
+        <svg class="theme-cycle-btn__svg theme-cycle-btn__svg--light" width="16" height="16" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+          aria-hidden="true">
+          <circle cx="12" cy="12" r="5" />
+          <line x1="12" y1="1" x2="12" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="23" />
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+          <line x1="1" y1="12" x2="3" y2="12" />
+          <line x1="21" y1="12" x2="23" y2="12" />
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        </svg>
+        <svg class="theme-cycle-btn__svg theme-cycle-btn__svg--dark" width="16" height="16" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+          aria-hidden="true">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      </button>
+    </p>
+  </footer>
+  <script type="importmap">{}</script>
+  <script type="module" src="main#[.{fingerprint}].js"></script>
+</body>
+
+</html>

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/main.js
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/main.js
@@ -1,0 +1,760 @@
+import { dotnet } from './_framework/dotnet.js';
+import {
+  decodeShareHash,
+  encodeShareState,
+  isShareWithinLimits,
+} from './share-payload.js';
+
+/* ─── Theme ─── */
+
+const THEME_STORAGE_KEY = 'skqr-playground-color-mode';
+const THEME_CYCLE_ORDER = ['system', 'light', 'dark'];
+
+function colorSchemeDarkQuery() {
+  return window.matchMedia('(prefers-color-scheme: dark)');
+}
+
+function getStoredColorMode() {
+  try {
+    const v = localStorage.getItem(THEME_STORAGE_KEY);
+    if (v === 'light' || v === 'dark') return v;
+  } catch (_) {
+    /* ignore */
+  }
+  return 'system';
+}
+
+function setStoredColorMode(mode) {
+  try {
+    if (mode === 'system') localStorage.removeItem(THEME_STORAGE_KEY);
+    else localStorage.setItem(THEME_STORAGE_KEY, mode);
+  } catch (_) {
+    /* ignore */
+  }
+}
+
+function applyColorModeToDocument(mode) {
+  const root = document.documentElement;
+  if (mode === 'light') root.setAttribute('data-theme', 'light');
+  else if (mode === 'dark') root.setAttribute('data-theme', 'dark');
+  else root.removeAttribute('data-theme');
+  const meta = document.getElementById('meta-color-scheme');
+  if (meta) {
+    if (mode === 'light') meta.setAttribute('content', 'light');
+    else if (mode === 'dark') meta.setAttribute('content', 'dark');
+    else meta.setAttribute('content', 'light dark');
+  }
+}
+
+function themeAccessibilityLabel(mode) {
+  const suffix = 'Click to cycle: System, Light, Dark.';
+  if (mode === 'light') return `Color theme: Light. ${suffix}`;
+  if (mode === 'dark') return `Color theme: Dark. ${suffix}`;
+  return `Color theme: System. ${suffix}`;
+}
+
+const themeCycleBtn = document.getElementById('theme-cycle-btn');
+
+function updateThemeCycleButton() {
+  if (!themeCycleBtn) return;
+  const mode = getStoredColorMode();
+  themeCycleBtn.dataset.themeMode = mode;
+  themeCycleBtn.setAttribute('aria-label', themeAccessibilityLabel(mode));
+}
+
+if (themeCycleBtn) {
+  themeCycleBtn.addEventListener('click', () => {
+    const cur = getStoredColorMode();
+    const i = Math.max(0, THEME_CYCLE_ORDER.indexOf(cur));
+    const next = THEME_CYCLE_ORDER[(i + 1) % THEME_CYCLE_ORDER.length];
+    setStoredColorMode(next);
+    applyColorModeToDocument(next);
+    updateThemeCycleButton();
+  });
+}
+updateThemeCycleButton();
+// System-mode visuals follow prefers-color-scheme via CSS; refresh the button label on change.
+colorSchemeDarkQuery().addEventListener('change', updateThemeCycleButton);
+
+/* ─── Toasts ─── */
+
+/** @typedef {'error'|'success'|'info'} ToastVariant */
+/** @type {Record<ToastVariant, number>} */
+const TOAST_DURATION_MS = { error: 8000, success: 3800, info: 4200 };
+const toastStack = document.getElementById('toast-stack');
+
+/**
+ * @param {string} message
+ * @param {ToastVariant} [variant]
+ * @param {number} [durationMs]
+ */
+function showToast(message, variant = 'info', durationMs) {
+  if (!toastStack) return;
+  const ms = durationMs ?? TOAST_DURATION_MS[variant] ?? TOAST_DURATION_MS.info;
+
+  const wrap = document.createElement('div');
+  wrap.className = `toast toast--${variant}`;
+  wrap.setAttribute('role', variant === 'error' ? 'alert' : 'status');
+
+  const bodyEl = document.createElement('div');
+  bodyEl.className = 'toast__body';
+  bodyEl.textContent = message ?? '';
+
+  const dismissBtn = document.createElement('button');
+  dismissBtn.type = 'button';
+  dismissBtn.className = 'toast__dismiss';
+  dismissBtn.setAttribute('aria-label', 'Dismiss notification');
+  dismissBtn.textContent = '✕';
+
+  wrap.append(bodyEl, dismissBtn);
+  toastStack.appendChild(wrap);
+  requestAnimationFrame(() => wrap.classList.add('toast--show'));
+
+  const hideTimer = window.setTimeout(() => removeToastElement(wrap), ms);
+  dismissBtn.addEventListener('click', () => {
+    window.clearTimeout(hideTimer);
+    removeToastElement(wrap);
+  });
+}
+
+/** @param {HTMLElement} el */
+function removeToastElement(el) {
+  if (!el?.parentElement || el.dataset.toastClosing) return;
+  el.dataset.toastClosing = '1';
+  el.classList.remove('toast--show');
+  el.classList.add('toast--out');
+  window.setTimeout(() => el.remove(), 240);
+}
+
+/* ─── Element references ─── */
+
+const loading = document.getElementById('loading');
+const versionEl = document.getElementById('playground-version');
+const contentEl = document.getElementById('content');
+const presetSelect = document.getElementById('preset-select');
+const eccSelect = document.getElementById('ecc-select');
+const versionSelect = document.getElementById('version-select');
+const sizeRange = document.getElementById('size-range');
+const sizeOut = document.getElementById('size-out');
+const quietRange = document.getElementById('quiet-range');
+const quietOut = document.getElementById('quiet-out');
+const moduleShapeSelect = document.getElementById('module-shape-select');
+const moduleSizeRange = document.getElementById('module-size-range');
+const moduleSizeOut = document.getElementById('module-size-out');
+const cornerRow = document.getElementById('corner-row');
+const cornerRange = document.getElementById('corner-range');
+const cornerOut = document.getElementById('corner-out');
+const finderSelect = document.getElementById('finder-select');
+const fgRow = document.getElementById('fg-row');
+const fgColor = document.getElementById('fg-color');
+const bgColor = document.getElementById('bg-color');
+const bgTransparent = document.getElementById('bg-transparent');
+const gradientToggle = document.getElementById('gradient-toggle');
+const gradientPanel = document.getElementById('gradient-panel');
+const gradientColorsEl = document.getElementById('gradient-colors');
+const gradientAddBtn = document.getElementById('gradient-add-btn');
+const gradientDirection = document.getElementById('gradient-direction');
+const logoModeSelect = document.getElementById('logo-mode-select');
+const logoFileRow = document.getElementById('logo-file-row');
+const logoFile = document.getElementById('logo-file');
+const logoSizeRange = document.getElementById('logo-size-range');
+const logoSizeOut = document.getElementById('logo-size-out');
+const logoBorderRange = document.getElementById('logo-border-range');
+const logoBorderOut = document.getElementById('logo-border-out');
+const previewImg = document.getElementById('qr-preview');
+const statsEl = document.getElementById('qr-stats');
+const generateErrorEl = document.getElementById('generate-error');
+const downloadBtn = document.getElementById('download-btn');
+const copyImageBtn = document.getElementById('copy-image-btn');
+const permalinkBtn = document.getElementById('permalink-btn');
+
+// Version select: auto + 1..40
+{
+  const auto = document.createElement('option');
+  auto.value = '-1';
+  auto.textContent = 'Auto';
+  versionSelect.appendChild(auto);
+  for (let v = 1; v <= 40; v++) {
+    const opt = document.createElement('option');
+    opt.value = String(v);
+    opt.textContent = `${v} (${17 + 4 * v}×${17 + 4 * v})`;
+    versionSelect.appendChild(opt);
+  }
+  versionSelect.value = '-1';
+}
+
+/* ─── Presets ─── */
+
+const PRESETS = {
+  instagram: {
+    ecc: 'H',
+    moduleShape: 'rounded',
+    moduleSizePercent: 0.92,
+    moduleCornerRadius: 0.45,
+    finderShape: 'roundedCircle',
+    foreground: '#111111',
+    background: '#ffffff',
+    gradientEnabled: true,
+    gradientColors: ['#F77737', '#E1306C', '#833AB4', '#5851DB'],
+    gradientDirection: 'BottomLeftToTopRight',
+    logoMode: 'default',
+    logoSizePercent: 18,
+    logoBorderWidth: 6,
+  },
+  classic: {
+    ecc: 'M',
+    moduleShape: 'rectangle',
+    moduleSizePercent: 1.0,
+    moduleCornerRadius: 0.3,
+    finderShape: 'auto',
+    foreground: '#000000',
+    background: '#ffffff',
+    gradientEnabled: false,
+    gradientColors: ['#000000', '#444444'],
+    gradientDirection: 'TopLeftToBottomRight',
+    logoMode: 'none',
+    logoSizePercent: 18,
+    logoBorderWidth: 6,
+  },
+  midnight: {
+    ecc: 'Q',
+    moduleShape: 'circle',
+    moduleSizePercent: 0.95,
+    moduleCornerRadius: 0.3,
+    finderShape: 'roundedCircle',
+    foreground: '#22d3ee',
+    background: '#0b1220',
+    gradientEnabled: true,
+    gradientColors: ['#22d3ee', '#818cf8', '#e879f9'],
+    gradientDirection: 'TopToBottom',
+    logoMode: 'none',
+    logoSizePercent: 18,
+    logoBorderWidth: 6,
+  },
+  ocean: {
+    ecc: 'Q',
+    moduleShape: 'rounded',
+    moduleSizePercent: 0.95,
+    moduleCornerRadius: 0.6,
+    finderShape: 'rounded',
+    foreground: '#0c4a6e',
+    background: '#f0f9ff',
+    gradientEnabled: true,
+    gradientColors: ['#0ea5e9', '#0369a1', '#1e3a8a'],
+    gradientDirection: 'TopLeftToBottomRight',
+    logoMode: 'none',
+    logoSizePercent: 18,
+    logoBorderWidth: 6,
+  },
+  sunset: {
+    ecc: 'Q',
+    moduleShape: 'rounded',
+    moduleSizePercent: 0.9,
+    moduleCornerRadius: 0.35,
+    finderShape: 'rounded',
+    foreground: '#7c2d12',
+    background: '#fffbeb',
+    gradientEnabled: true,
+    gradientColors: ['#b45309', '#dc2626', '#9d174d'],
+    gradientDirection: 'BottomToTop',
+    logoMode: 'none',
+    logoSizePercent: 18,
+    logoBorderWidth: 6,
+  },
+};
+
+/* ─── State <-> DOM ─── */
+
+const EMPTY_BYTES = new Uint8Array(0);
+/** Uploaded logo image bytes (not part of share links). */
+let customLogoBytes = EMPTY_BYTES;
+/** True while applyStateToControls runs, so input events do not flip the preset to (custom). */
+let applyingState = false;
+
+/** @returns {object} playground state; doubles as the WASM QrRequest payload (camelCase) */
+function collectState() {
+  return {
+    content: contentEl.value,
+    ecc: eccSelect.value,
+    size: Number(sizeRange.value),
+    quietZone: Number(quietRange.value),
+    version: Number(versionSelect.value),
+    moduleShape: moduleShapeSelect.value,
+    moduleSizePercent: Number(moduleSizeRange.value) / 100,
+    moduleCornerRadius: Number(cornerRange.value) / 100,
+    finderShape: finderSelect.value,
+    foreground: fgColor.value,
+    background: bgTransparent.checked ? 'transparent' : bgColor.value,
+    gradient: {
+      enabled: gradientToggle.checked,
+      colors: getGradientColors(),
+      direction: gradientDirection.value,
+    },
+    logo: {
+      mode: logoModeSelect.value,
+      sizePercent: Number(logoSizeRange.value),
+      borderWidth: Number(logoBorderRange.value),
+    },
+  };
+}
+
+/** @param {object} state partial state (missing fields keep current control values) */
+function applyStateToControls(state) {
+  applyingState = true;
+  try {
+    if (typeof state.content === 'string') contentEl.value = state.content;
+    if (state.ecc) eccSelect.value = state.ecc;
+    if (Number.isFinite(state.size)) sizeRange.value = String(clamp(state.size, 128, 1024));
+    if (Number.isFinite(state.quietZone)) quietRange.value = String(clamp(state.quietZone, 0, 10));
+    if (Number.isFinite(state.version)) versionSelect.value = String(state.version);
+    if (state.moduleShape) moduleShapeSelect.value = state.moduleShape;
+    if (Number.isFinite(state.moduleSizePercent)) moduleSizeRange.value = String(Math.round(clamp(state.moduleSizePercent, 0.5, 1) * 100));
+    if (Number.isFinite(state.moduleCornerRadius)) cornerRange.value = String(Math.round(clamp(state.moduleCornerRadius, 0, 1) * 100));
+    if (state.finderShape) finderSelect.value = state.finderShape;
+    if (state.foreground) fgColor.value = state.foreground;
+    if (state.background === 'transparent') {
+      bgTransparent.checked = true;
+    } else if (state.background) {
+      bgTransparent.checked = false;
+      bgColor.value = state.background;
+    }
+    if (state.gradient) {
+      if (typeof state.gradient.enabled === 'boolean') gradientToggle.checked = state.gradient.enabled;
+      if (Array.isArray(state.gradient.colors) && state.gradient.colors.length >= 2) {
+        renderGradientColors(state.gradient.colors);
+      }
+      if (state.gradient.direction) gradientDirection.value = state.gradient.direction;
+    }
+    if (state.logo) {
+      if (state.logo.mode) logoModeSelect.value = state.logo.mode;
+      if (Number.isFinite(state.logo.sizePercent)) logoSizeRange.value = String(clamp(state.logo.sizePercent, 5, 35));
+      if (Number.isFinite(state.logo.borderWidth)) logoBorderRange.value = String(clamp(state.logo.borderWidth, 0, 24));
+    }
+    syncDerivedControls();
+  } finally {
+    applyingState = false;
+  }
+}
+
+/** Flat preset entry → state shape used by applyStateToControls / share links. */
+function presetToState(preset) {
+  return {
+    ecc: preset.ecc,
+    moduleShape: preset.moduleShape,
+    moduleSizePercent: preset.moduleSizePercent,
+    moduleCornerRadius: preset.moduleCornerRadius,
+    finderShape: preset.finderShape,
+    foreground: preset.foreground,
+    background: preset.background,
+    gradient: {
+      enabled: preset.gradientEnabled,
+      colors: preset.gradientColors,
+      direction: preset.gradientDirection,
+    },
+    logo: {
+      mode: preset.logoMode,
+      sizePercent: preset.logoSizePercent,
+      borderWidth: preset.logoBorderWidth,
+    },
+  };
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+/** Updates range outputs and conditional row visibility from current control values. */
+function syncDerivedControls() {
+  sizeOut.textContent = sizeRange.value;
+  quietOut.textContent = quietRange.value;
+  moduleSizeOut.textContent = moduleSizeRange.value;
+  cornerOut.textContent = cornerRange.value;
+  logoSizeOut.textContent = logoSizeRange.value;
+  logoBorderOut.textContent = logoBorderRange.value;
+  cornerRow.hidden = moduleShapeSelect.value !== 'rounded';
+  gradientPanel.hidden = !gradientToggle.checked;
+  fgRow.classList.toggle('field--disabled', gradientToggle.checked);
+  fgColor.disabled = gradientToggle.checked;
+  bgColor.disabled = bgTransparent.checked;
+  logoFileRow.hidden = logoModeSelect.value !== 'custom';
+}
+
+/* ─── Gradient color list ─── */
+
+const GRADIENT_MIN_COLORS = 2;
+const GRADIENT_MAX_COLORS = 6;
+
+function getGradientColors() {
+  return [...gradientColorsEl.querySelectorAll('input[type="color"]')].map((i) => i.value);
+}
+
+/** @param {string[]} colors */
+function renderGradientColors(colors) {
+  gradientColorsEl.replaceChildren();
+  for (const color of colors.slice(0, GRADIENT_MAX_COLORS)) {
+    gradientColorsEl.appendChild(createGradientColorRow(color));
+  }
+  syncGradientButtons();
+}
+
+/** @param {string} color */
+function createGradientColorRow(color) {
+  const row = document.createElement('div');
+  row.className = 'gradient-color-row';
+
+  const input = document.createElement('input');
+  input.type = 'color';
+  input.value = normalizeHexColor(color);
+
+  const remove = document.createElement('button');
+  remove.type = 'button';
+  remove.className = 'small-btn gradient-color-row__remove';
+  remove.textContent = '✕';
+  remove.setAttribute('aria-label', 'Remove this gradient color');
+  remove.addEventListener('click', () => {
+    if (gradientColorsEl.children.length <= GRADIENT_MIN_COLORS) return;
+    row.remove();
+    syncGradientButtons();
+    markCustomPreset();
+    scheduleGenerate();
+  });
+
+  row.append(input, remove);
+  return row;
+}
+
+function syncGradientButtons() {
+  const count = gradientColorsEl.children.length;
+  gradientAddBtn.disabled = count >= GRADIENT_MAX_COLORS;
+  for (const btn of gradientColorsEl.querySelectorAll('.gradient-color-row__remove')) {
+    btn.disabled = count <= GRADIENT_MIN_COLORS;
+  }
+}
+
+/** <input type=color> requires #rrggbb; anything unparsable falls back to black. */
+function normalizeHexColor(value) {
+  return /^#[0-9a-fA-F]{6}$/.test(value) ? value.toLowerCase() : '#000000';
+}
+
+gradientAddBtn.addEventListener('click', () => {
+  if (gradientColorsEl.children.length >= GRADIENT_MAX_COLORS) return;
+  const colors = getGradientColors();
+  gradientColorsEl.appendChild(createGradientColorRow(colors[colors.length - 1] ?? '#833ab4'));
+  syncGradientButtons();
+  markCustomPreset();
+  scheduleGenerate();
+});
+
+/* ─── WASM runtime ─── */
+
+let exports = null;
+let runtimeReady = false;
+let runtimeAlive = true;
+
+const RELEASE_TAG_BASE_URL = 'https://github.com/guitarrapc/SkiaSharp.QrCode/releases/tag/';
+
+function isRuntimeDeadError(err) {
+  if (!err) return false;
+  const msg = String(err?.message ?? err).toLowerCase();
+  return msg.includes('.net runtime already exited')
+    || msg.includes('runtime already exited')
+    || msg.includes('runtime has already exited');
+}
+
+function handleRuntimeDeath() {
+  runtimeAlive = false;
+  showToast('The WebAssembly runtime has crashed. Please reload the page to continue.', 'error', 60000);
+  generateErrorEl.hidden = false;
+  generateErrorEl.textContent = 'Runtime crashed — please reload the page.';
+}
+
+function syncVersionBadge() {
+  if (!exports || !versionEl) return;
+  try {
+    const v = exports.SkiaSharp.QrCode.Playground.QrInterop.GetProductVersion();
+    if (typeof v === 'string' && v.length > 0 && v !== 'unknown') {
+      versionEl.textContent = `v${v}`;
+      versionEl.href = RELEASE_TAG_BASE_URL + encodeURIComponent(v);
+      versionEl.setAttribute('aria-label', `Release ${v} — open on GitHub`);
+      versionEl.hidden = false;
+    }
+  } catch {
+    /* ignore — older bundles or trimmed exports */
+  }
+}
+
+/* ─── Generation ─── */
+
+const utf8Decoder = new TextDecoder();
+/** Most recent successful PNG, backing Download / Copy image. */
+let lastPngBytes = null;
+let lastObjectUrl = null;
+let generateTimer = null;
+
+// setTimeout (not requestAnimationFrame): rAF does not fire in hidden/background tabs,
+// which would silently stall regeneration. 60ms coalesces slider drags nicely.
+const GENERATE_DEBOUNCE_MS = 60;
+
+function scheduleGenerate() {
+  if (generateTimer !== null) return;
+  generateTimer = window.setTimeout(() => {
+    generateTimer = null;
+    generate();
+  }, GENERATE_DEBOUNCE_MS);
+}
+
+function generate() {
+  if (!runtimeAlive || !runtimeReady || !exports) return;
+
+  const state = collectState();
+  if (!state.content.trim()) {
+    showGenerateError('Enter content to encode.');
+    return;
+  }
+
+  const logoBytes = state.logo.mode === 'custom' ? customLogoBytes : EMPTY_BYTES;
+  let bytes;
+  const t0 = performance.now();
+  try {
+    bytes = exports.SkiaSharp.QrCode.Playground.QrInterop.Generate(JSON.stringify(state), logoBytes);
+  } catch (err) {
+    if (isRuntimeDeadError(err)) {
+      handleRuntimeDeath();
+      return;
+    }
+    showGenerateError(err?.message ?? String(err));
+    return;
+  }
+  const interopMs = performance.now() - t0;
+
+  // Error envelope is UTF-8 JSON starting with '{'; PNG always starts with 0x89.
+  if (bytes.length === 0 || bytes[0] === 0x7b) {
+    let message = 'QR generation failed.';
+    try {
+      message = JSON.parse(utf8Decoder.decode(bytes)).error ?? message;
+    } catch {
+      /* keep generic message */
+    }
+    showGenerateError(message);
+    return;
+  }
+
+  lastPngBytes = bytes;
+  const blob = new Blob([bytes], { type: 'image/png' });
+  const url = URL.createObjectURL(blob);
+  if (lastObjectUrl) URL.revokeObjectURL(lastObjectUrl);
+  lastObjectUrl = url;
+  previewImg.src = url;
+  previewImg.hidden = false;
+  generateErrorEl.hidden = true;
+  downloadBtn.disabled = false;
+  copyImageBtn.disabled = false;
+
+  try {
+    const meta = JSON.parse(exports.SkiaSharp.QrCode.Playground.QrInterop.GetLastMeta());
+    statsEl.textContent =
+      `QR version ${meta.qrVersion} · ${meta.matrixSize}×${meta.matrixSize} modules · `
+      + `${meta.totalMs} ms in WASM (${interopMs.toFixed(1)} ms total) · ${formatBytes(meta.bytes)}`;
+  } catch {
+    statsEl.textContent = '';
+  }
+}
+
+/** Shows an inline error while keeping the last good image visible. */
+function showGenerateError(message) {
+  generateErrorEl.hidden = false;
+  generateErrorEl.textContent = message;
+}
+
+function formatBytes(n) {
+  if (!Number.isFinite(n)) return '';
+  if (n < 1024) return `${n} B`;
+  return `${(n / 1024).toFixed(1)} KB`;
+}
+
+/* ─── Control events ─── */
+
+function markCustomPreset() {
+  if (!applyingState) presetSelect.value = 'custom';
+}
+
+for (const el of [
+  contentEl, eccSelect, versionSelect, sizeRange, quietRange,
+  moduleShapeSelect, moduleSizeRange, cornerRange, finderSelect,
+  fgColor, bgColor, bgTransparent,
+  gradientToggle, gradientDirection,
+  logoModeSelect, logoSizeRange, logoBorderRange,
+]) {
+  el.addEventListener('input', () => {
+    syncDerivedControls();
+    markCustomPreset();
+    scheduleGenerate();
+  });
+}
+
+// Color inputs inside the dynamic gradient list (event delegation).
+gradientColorsEl.addEventListener('input', () => {
+  markCustomPreset();
+  scheduleGenerate();
+});
+
+presetSelect.addEventListener('input', () => {
+  const preset = PRESETS[presetSelect.value];
+  if (!preset) return;
+  applyStateToControls(presetToState(preset));
+  scheduleGenerate();
+});
+
+logoFile.addEventListener('change', async () => {
+  const file = logoFile.files?.[0];
+  if (!file) return;
+  try {
+    customLogoBytes = new Uint8Array(await file.arrayBuffer());
+    logoModeSelect.value = 'custom';
+    syncDerivedControls();
+    markCustomPreset();
+    scheduleGenerate();
+  } catch (e) {
+    showToast(`Could not read the image file: ${e?.message ?? e}`, 'error');
+  }
+});
+
+/* ─── Download / copy image ─── */
+
+downloadBtn.addEventListener('click', () => {
+  if (!lastPngBytes) return;
+  const blob = new Blob([lastPngBytes], { type: 'image/png' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'qrcode.png';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+});
+
+copyImageBtn.addEventListener('click', async () => {
+  if (!lastPngBytes) return;
+  try {
+    const blob = new Blob([lastPngBytes], { type: 'image/png' });
+    await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+    showToast('Image copied to clipboard.', 'success');
+  } catch (e) {
+    showToast(`Could not copy image: ${e?.message ?? e}`, 'error');
+  }
+});
+
+/* ─── Share link ─── */
+
+/**
+ * Synchronous clipboard fallback (helps while the originating click is still a "user gesture").
+ * @param {string} text
+ * @returns {boolean}
+ */
+function tryClipboardCopyViaTextArea(text) {
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.left = '-9999px';
+  ta.style.top = '0';
+  document.body.appendChild(ta);
+  try {
+    ta.focus();
+    ta.select();
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    ta.remove();
+  }
+}
+
+/** @param {string} text */
+async function copyTextToClipboard(text) {
+  if (tryClipboardCopyViaTextArea(text)) return true;
+  const w = navigator.clipboard?.writeText;
+  if (!w) return false;
+  try {
+    await w.call(navigator.clipboard, text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+permalinkBtn.addEventListener('click', async () => {
+  try {
+    const state = collectState();
+    if (state.logo.mode === 'custom') {
+      // Uploaded image bytes do not fit in a URL; the link falls back to the built-in logo.
+      state.logo = { ...state.logo, mode: 'default' };
+      showToast('Uploaded logo images are not included in share links — the link uses the built-in logo instead.', 'info');
+    }
+    const hash = await encodeShareState(state);
+    const url = `${location.pathname}${location.search}#${hash}`;
+    const fullUrl = `${location.origin}${url}`;
+    if (!isShareWithinLimits(hash, fullUrl)) {
+      showToast('Content is too long to fit in a share URL. Shorten the QR content and try again.', 'error');
+      return;
+    }
+    history.replaceState(null, '', url);
+    const copied = await copyTextToClipboard(location.href);
+    showToast(
+      copied ? 'Link copied to clipboard.' : 'URL updated — copy from the address bar if clipboard was blocked.',
+      copied ? 'success' : 'info',
+    );
+  } catch (e) {
+    showToast(e?.message ?? String(e), 'error');
+  }
+});
+
+/* ─── Startup ─── */
+
+async function restoreFromLocationHash() {
+  const raw = window.location.hash;
+  if (!raw || raw.length <= 1) return false;
+  const decoded = await decodeShareHash(raw.slice(1));
+  if (!decoded.ok) {
+    showToast(`Could not restore from URL: ${decoded.error}. Showing defaults.`, 'info', 6000);
+    return false;
+  }
+  applyStateToControls(decoded.state);
+  presetSelect.value = 'custom';
+  return true;
+}
+
+async function initializeRuntime() {
+  try {
+    const restored = await restoreFromLocationHash();
+    if (!restored) {
+      applyStateToControls(presetToState(PRESETS.instagram));
+    }
+
+    const runtime = await dotnet
+      .withApplicationArguments('playground')
+      .create();
+    const config = runtime.getConfig();
+    exports = await runtime.getAssemblyExports(config.mainAssemblyName);
+    await runtime.runMain();
+    runtimeReady = true;
+    syncVersionBadge();
+    loading.style.display = 'none';
+    permalinkBtn.disabled = false;
+    generate();
+  } catch (err) {
+    if (isRuntimeDeadError(err)) {
+      handleRuntimeDeath();
+      return;
+    }
+    runtimeAlive = false;
+    runtimeReady = false;
+    loading.style.display = 'none';
+    showToast(err?.message ?? String(err), 'error', 60000);
+  }
+}
+
+renderGradientColors(PRESETS.instagram.gradientColors);
+syncDerivedControls();
+void initializeRuntime();

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/main.js
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/main.js
@@ -469,6 +469,14 @@ function isRuntimeDeadError(err) {
 
 function handleRuntimeDeath() {
   runtimeAlive = false;
+  runtimeReady = false;
+  // Stop an in-flight benchmark loop at its next batch boundary.
+  benchCancelled = true;
+  // Everything below either needs the runtime or would act on stale output.
+  downloadBtn.disabled = true;
+  copyImageBtn.disabled = true;
+  permalinkBtn.disabled = true;
+  benchRunBtn.disabled = true;
   showToast('The WebAssembly runtime has crashed. Please reload the page to continue.', 'error', 60000);
   generateErrorEl.hidden = false;
   generateErrorEl.textContent = 'Runtime crashed — please reload the page.';

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/main.js
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/main.js
@@ -167,6 +167,12 @@ const generateErrorEl = document.getElementById('generate-error');
 const downloadBtn = document.getElementById('download-btn');
 const copyImageBtn = document.getElementById('copy-image-btn');
 const permalinkBtn = document.getElementById('permalink-btn');
+const benchModeSelect = document.getElementById('bench-mode-select');
+const benchCountSelect = document.getElementById('bench-count-select');
+const benchRunBtn = document.getElementById('bench-run-btn');
+const benchCancelBtn = document.getElementById('bench-cancel-btn');
+const benchProgress = document.getElementById('bench-progress');
+const benchResult = document.getElementById('bench-result');
 
 // Version select: auto + 1..40
 {
@@ -710,6 +716,109 @@ permalinkBtn.addEventListener('click', async () => {
   }
 });
 
+/* ─── Performance benchmark ─── */
+
+/** Target wall-clock per BenchmarkBatch call; keeps the UI responsive between batches. */
+const BENCH_BATCH_TARGET_MS = 150;
+
+let benchRunning = false;
+let benchCancelled = false;
+
+function formatRate(count, ms) {
+  if (ms <= 0) return '—';
+  const rate = (count / ms) * 1000;
+  return `${rate >= 100 ? Math.round(rate).toLocaleString() : rate.toFixed(1)} codes/s`;
+}
+
+function setBenchControlsRunning(running) {
+  benchRunBtn.disabled = running || !runtimeReady || !runtimeAlive;
+  benchCancelBtn.hidden = !running;
+  benchModeSelect.disabled = running;
+  benchCountSelect.disabled = running;
+}
+
+benchCancelBtn.addEventListener('click', () => {
+  benchCancelled = true;
+  benchCancelBtn.disabled = true;
+});
+
+benchRunBtn.addEventListener('click', () => void runBenchmark());
+
+async function runBenchmark() {
+  if (benchRunning || !runtimeReady || !runtimeAlive) return;
+
+  const state = collectState();
+  if (!state.content.trim()) {
+    showToast('Enter content to encode before running the benchmark.', 'info');
+    return;
+  }
+  // Snapshot options once so mid-run control edits do not skew results.
+  const optionsJson = JSON.stringify(state);
+  const mode = benchModeSelect.value;
+  const total = Number(benchCountSelect.value);
+  const logoBytes = mode === 'render' && state.logo.mode === 'custom' ? customLogoBytes : EMPTY_BYTES;
+
+  benchRunning = true;
+  benchCancelled = false;
+  benchCancelBtn.disabled = false;
+  setBenchControlsRunning(true);
+  benchProgress.hidden = false;
+  benchProgress.max = total;
+  benchProgress.value = 0;
+  benchResult.textContent = 'Running…';
+
+  let done = 0;
+  let wasmMs = 0;
+  let meta = null;
+  // Encode mode is orders of magnitude faster than render mode; start small and adapt.
+  let batch = mode === 'encode' ? 128 : 4;
+  const wallStart = performance.now();
+
+  try {
+    while (done < total && !benchCancelled) {
+      const count = Math.min(batch, total - done);
+      const json = exports.SkiaSharp.QrCode.Playground.QrInterop.BenchmarkBatch(optionsJson, mode, done, count, logoBytes);
+      const result = JSON.parse(json);
+      if (result.error) {
+        benchResult.textContent = `Failed: ${result.error}`;
+        break;
+      }
+      done += result.count;
+      wasmMs += result.elapsedMs;
+      meta = result;
+
+      benchProgress.value = done;
+      benchResult.textContent = `${done.toLocaleString()} / ${total.toLocaleString()} — ${formatRate(done, wasmMs)}`;
+
+      // Resize the next batch toward the wall-clock target (bounded so one batch cannot stall the tab).
+      const perItem = Math.max(result.elapsedMs / result.count, 0.0001);
+      batch = Math.max(1, Math.min(50000, Math.round(BENCH_BATCH_TARGET_MS / perItem)));
+
+      // Yield to the event loop so progress paints and Cancel stays clickable.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    if (done > 0 && meta && !benchResult.textContent.startsWith('Failed')) {
+      const wallSeconds = ((performance.now() - wallStart) / 1000).toFixed(2);
+      const avgMs = wasmMs / done;
+      const prefix = benchCancelled ? `Cancelled — ${done.toLocaleString()} of ${total.toLocaleString()}` : done.toLocaleString();
+      benchResult.textContent =
+        `${prefix} codes in ${(wasmMs / 1000).toFixed(2)} s of WASM time — ${formatRate(done, wasmMs)} `
+        + `(avg ${avgMs >= 1 ? avgMs.toFixed(2) : avgMs.toFixed(3)} ms/code, QR v${meta.qrVersion} ${meta.matrixSize}×${meta.matrixSize}, wall ${wallSeconds} s)`;
+    }
+  } catch (err) {
+    if (isRuntimeDeadError(err)) {
+      handleRuntimeDeath();
+    } else {
+      benchResult.textContent = `Failed: ${err?.message ?? err}`;
+    }
+  } finally {
+    benchRunning = false;
+    setBenchControlsRunning(false);
+    benchProgress.hidden = true;
+  }
+}
+
 /* ─── Startup ─── */
 
 async function restoreFromLocationHash() {
@@ -742,6 +851,7 @@ async function initializeRuntime() {
     syncVersionBadge();
     loading.style.display = 'none';
     permalinkBtn.disabled = false;
+    benchRunBtn.disabled = false;
     generate();
   } catch (err) {
     if (isRuntimeDeadError(err)) {

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/share-payload.js
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/share-payload.js
@@ -38,6 +38,11 @@ export async function decodeShareHash(hashSegment) {
   if (!hashSegment || !hashSegment.length) {
     return { ok: false, error: 'empty hash' };
   }
+  // Reject oversized input before any decode work: the hash is attacker-controlled
+  // (arbitrary URL), and base64 + inflate of a huge payload burns CPU/memory on page load.
+  if (hashSegment.length > MAX_SHARE_HASH_LENGTH) {
+    return { ok: false, error: 'share payload too large' };
+  }
   const dot = hashSegment.indexOf('.');
   if (dot !== 1) {
     return { ok: false, error: 'unknown payload format' };

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/share-payload.js
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/share-payload.js
@@ -1,0 +1,118 @@
+/**
+ * Share-link payload codec.
+ *
+ * Hash segment format: "<mode>.<base64url>"
+ *   mode "1" — deflate-raw compressed UTF-8 JSON (via native CompressionStream)
+ *   mode "0" — plain UTF-8 JSON (fallback for browsers without CompressionStream)
+ *
+ * The JSON payload is the playground state object plus a "v" schema version.
+ */
+
+export const SHARE_PAYLOAD_VERSION = 1;
+export const MAX_SHARE_HASH_LENGTH = 16384;
+export const MAX_SHARE_URL_LENGTH = 8192;
+
+/**
+ * @param {object} state playground state (must be JSON-serializable)
+ * @returns {Promise<string>} hash segment (no leading #)
+ */
+export async function encodeShareState(state) {
+  const payload = { v: SHARE_PAYLOAD_VERSION, ...state };
+  const jsonUtf8 = new TextEncoder().encode(JSON.stringify(payload));
+  if (typeof CompressionStream === 'function') {
+    try {
+      const compressed = await pipeThrough(jsonUtf8, new CompressionStream('deflate-raw'));
+      return `1.${uint8ToBase64Url(compressed)}`;
+    } catch {
+      /* fall through to uncompressed */
+    }
+  }
+  return `0.${uint8ToBase64Url(jsonUtf8)}`;
+}
+
+/**
+ * @param {string} hashSegment hash without the leading #
+ * @returns {Promise<{ ok: true, state: object } | { ok: false, error: string }>}
+ */
+export async function decodeShareHash(hashSegment) {
+  if (!hashSegment || !hashSegment.length) {
+    return { ok: false, error: 'empty hash' };
+  }
+  const dot = hashSegment.indexOf('.');
+  if (dot !== 1) {
+    return { ok: false, error: 'unknown payload format' };
+  }
+  const mode = hashSegment.slice(0, dot);
+  let bytes;
+  try {
+    bytes = base64UrlToUint8(hashSegment.slice(dot + 1));
+  } catch (e) {
+    return { ok: false, error: e?.message ?? String(e) };
+  }
+
+  if (mode === '1') {
+    if (typeof DecompressionStream !== 'function') {
+      return { ok: false, error: 'this browser cannot decompress the shared link' };
+    }
+    try {
+      bytes = await pipeThrough(bytes, new DecompressionStream('deflate-raw'));
+    } catch (e) {
+      return { ok: false, error: `corrupted share payload: ${e?.message ?? e}` };
+    }
+  } else if (mode !== '0') {
+    return { ok: false, error: `unknown payload mode '${mode}'` };
+  }
+
+  let state;
+  try {
+    state = JSON.parse(new TextDecoder().decode(bytes));
+  } catch (e) {
+    return { ok: false, error: `invalid share JSON: ${e?.message ?? e}` };
+  }
+  if (!state || typeof state !== 'object') {
+    return { ok: false, error: 'share payload is not an object' };
+  }
+  return { ok: true, state };
+}
+
+/**
+ * @param {string} hashSegment
+ * @param {string} fullUrl
+ * @returns {boolean}
+ */
+export function isShareWithinLimits(hashSegment, fullUrl) {
+  return hashSegment.length <= MAX_SHARE_HASH_LENGTH && fullUrl.length <= MAX_SHARE_URL_LENGTH;
+}
+
+/**
+ * @param {Uint8Array} input
+ * @param {CompressionStream | DecompressionStream} transform
+ * @returns {Promise<Uint8Array>}
+ */
+async function pipeThrough(input, transform) {
+  const stream = new Blob([input]).stream().pipeThrough(transform);
+  const buffer = await new Response(stream).arrayBuffer();
+  return new Uint8Array(buffer);
+}
+
+/** @param {Uint8Array} bytes */
+function uint8ToBase64Url(bytes) {
+  let binary = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** @param {string} text */
+function base64UrlToUint8(text) {
+  const base64 = text.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/style.css
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/style.css
@@ -434,6 +434,26 @@ output {
   font-size: 0.9rem;
 }
 
+/* ─── Benchmark ─── */
+
+.bench-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+#bench-progress {
+  width: 100%;
+  height: 8px;
+  margin-top: 10px;
+  accent-color: var(--accent);
+}
+
+#bench-result {
+  margin-top: 6px;
+}
+
 /* ─── Toasts ─── */
 
 .toast-stack {

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/style.css
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/style.css
@@ -1,0 +1,577 @@
+/* ─── Theme tokens ─── */
+
+:root {
+  color-scheme: light dark;
+  --accent: #d62976;
+  --accent-2: #962fbf;
+  --bg: #f6f7fb;
+  --panel-bg: #ffffff;
+  --panel-border: #e3e6ee;
+  --text: #1f2430;
+  --text-muted: #5b6474;
+  --input-bg: #ffffff;
+  --input-border: #c9cfdd;
+  --shadow: 0 1px 3px rgba(16, 24, 40, 0.08);
+  --danger: #d13438;
+  --success: #107c41;
+  --checker-a: #ffffff;
+  --checker-b: #e6e8ef;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #12141c;
+    --panel-bg: #1a1d28;
+    --panel-border: #2a2f40;
+    --text: #e6e9f2;
+    --text-muted: #98a1b5;
+    --input-bg: #12141c;
+    --input-border: #3a4157;
+    --shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    --danger: #ff6b70;
+    --success: #4ade80;
+    --checker-a: #262b3a;
+    --checker-b: #1a1d28;
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg: #12141c;
+  --panel-bg: #1a1d28;
+  --panel-border: #2a2f40;
+  --text: #e6e9f2;
+  --text-muted: #98a1b5;
+  --input-bg: #12141c;
+  --input-border: #3a4157;
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --danger: #ff6b70;
+  --success: #4ade80;
+  --checker-a: #262b3a;
+  --checker-b: #1a1d28;
+}
+
+/* ─── Base ─── */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Segoe UI", "Helvetica Neue", Arial, "Hiragino Sans", "Noto Sans JP", sans-serif;
+  line-height: 1.5;
+}
+
+a {
+  color: var(--accent);
+}
+
+main {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 0 16px 24px;
+}
+
+/* ─── Header ─── */
+
+#header-bar {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 20px 16px 8px;
+}
+
+.site-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+#header-bar h1 {
+  margin: 0;
+  font-size: 1.45rem;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.site-logo {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  background:
+    radial-gradient(circle at 30% 70%, #fa7e1e 0%, #d62976 55%, #962fbf 100%);
+  position: relative;
+}
+
+.site-logo::after {
+  content: "";
+  position: absolute;
+  inset: 7px;
+  border: 2.5px solid #fff;
+  border-radius: 4px;
+}
+
+.tagline {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.version-badge {
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel-bg);
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.version-badge:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ─── Layout ─── */
+
+#playground {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(320px, 480px);
+  gap: 16px;
+  align-items: start;
+  margin-top: 12px;
+}
+
+@media (max-width: 860px) {
+  #playground {
+    grid-template-columns: 1fr;
+  }
+
+  .preview-column {
+    order: -1;
+  }
+}
+
+.controls-column {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.preview-column {
+  position: sticky;
+  top: 12px;
+  min-width: 0;
+}
+
+@media (max-width: 860px) {
+  .preview-column {
+    position: static;
+  }
+}
+
+/* ─── Panels ─── */
+
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  padding: 14px 16px;
+}
+
+details.panel summary {
+  cursor: pointer;
+  font-weight: 600;
+  user-select: none;
+  margin: -2px 0 2px;
+}
+
+details.panel[open] summary {
+  margin-bottom: 10px;
+}
+
+.panel__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px 16px;
+}
+
+/* ─── Fields ─── */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.field__label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.field--inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.field--checkbox {
+  cursor: pointer;
+}
+
+.field--disabled {
+  opacity: 0.45;
+}
+
+.field__hint {
+  margin: 10px 0 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+textarea,
+select,
+input[type="url"],
+input[type="file"] {
+  font: inherit;
+  color: var(--text);
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: 8px;
+  padding: 7px 10px;
+  max-width: 100%;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+
+textarea:focus-visible,
+select:focus-visible,
+input:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+input[type="color"] {
+  inline-size: 44px;
+  block-size: 30px;
+  padding: 2px;
+  border: 1px solid var(--input-border);
+  border-radius: 6px;
+  background: var(--input-bg);
+  cursor: pointer;
+}
+
+input[type="checkbox"] {
+  accent-color: var(--accent);
+  width: 16px;
+  height: 16px;
+}
+
+output {
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+
+/* ─── Gradient list ─── */
+
+#gradient-panel {
+  margin-top: 12px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px 16px;
+}
+
+.gradient-colors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 2px 0 6px;
+}
+
+.gradient-color-row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 3px;
+}
+
+.small-btn {
+  font: inherit;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--input-border);
+  border-radius: 6px;
+  padding: 3px 8px;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.small-btn:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.small-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.gradient-color-row__remove {
+  border: none;
+  padding: 2px 5px;
+}
+
+/* ─── Preview ─── */
+
+.preview-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.preview-frame {
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  min-height: 280px;
+  padding: 12px;
+  background-image:
+    linear-gradient(45deg, var(--checker-b) 25%, transparent 25%, transparent 75%, var(--checker-b) 75%),
+    linear-gradient(45deg, var(--checker-b) 25%, transparent 25%, transparent 75%, var(--checker-b) 75%);
+  background-color: var(--checker-a);
+  background-size: 20px 20px;
+  background-position: 0 0, 10px 10px;
+}
+
+#qr-preview {
+  max-width: 100%;
+  max-height: min(70vh, 560px);
+  height: auto;
+  image-rendering: -webkit-optimize-contrast;
+}
+
+.qr-stats {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  min-height: 1.2em;
+}
+
+.generate-error {
+  color: var(--danger);
+  font-size: 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+
+.preview-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.action-btn {
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.88rem;
+  color: var(--text);
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: 8px;
+  padding: 8px 14px;
+  cursor: pointer;
+}
+
+.action-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.action-btn--primary {
+  background: linear-gradient(135deg, #fa7e1e, #d62976 55%, #962fbf);
+  border: none;
+  color: #fff;
+}
+
+.action-btn--primary:hover:not(:disabled) {
+  color: #fff;
+  filter: brightness(1.08);
+}
+
+.action-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.notification {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--panel-border);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+/* ─── Toasts ─── */
+
+.toast-stack {
+  position: fixed;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(560px, calc(100vw - 24px));
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-left: 4px solid var(--accent);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+  padding: 10px 12px;
+  opacity: 0;
+  transform: translateY(-6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  font-size: 0.88rem;
+}
+
+.toast--show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast--out {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+.toast--error {
+  border-left-color: var(--danger);
+}
+
+.toast--success {
+  border-left-color: var(--success);
+}
+
+.toast__body {
+  flex: 1;
+  overflow-wrap: anywhere;
+}
+
+.toast__dismiss {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0 2px;
+}
+
+/* ─── About & footer ─── */
+
+.playground-about,
+footer {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 8px 16px;
+}
+
+.playground-about h2 {
+  font-size: 1.05rem;
+  margin: 8px 0;
+}
+
+.playground-about__body {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+footer {
+  padding-bottom: 28px;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.footer-copy-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  border-top: 1px solid var(--panel-border);
+  padding-top: 14px;
+}
+
+.repo-mark {
+  color: var(--text-muted);
+  display: inline-flex;
+}
+
+.repo-mark:hover {
+  color: var(--accent);
+}
+
+.repo-mark__icon {
+  width: 20px;
+  height: 20px;
+}
+
+.footer-copy-sep {
+  opacity: 0.5;
+}
+
+/* ─── Theme cycle button ─── */
+
+.toolbar-icon-btn {
+  background: none;
+  border: 1px solid var(--input-border);
+  border-radius: 8px;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 5px 7px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.toolbar-icon-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.theme-cycle-btn__svg {
+  display: none;
+}
+
+.theme-cycle-btn[data-theme-mode="system"] .theme-cycle-btn__svg--system,
+.theme-cycle-btn[data-theme-mode="light"] .theme-cycle-btn__svg--light,
+.theme-cycle-btn[data-theme-mode="dark"] .theme-cycle-btn__svg--dark {
+  display: block;
+}

--- a/src/SkiaSharp.QrCode/Image/IconShape.cs
+++ b/src/SkiaSharp.QrCode/Image/IconShape.cs
@@ -63,7 +63,8 @@ public sealed class ImageIconShape : IconShape
         }
 
         // Draw an image
-        canvas.DrawBitmap(_image, rect);
+        // SKSamplingOptions.Default matches what the obsolete DrawBitmap(bitmap, rect) overload used.
+        canvas.DrawBitmap(_image, rect, SKSamplingOptions.Default);
     }
 }
 
@@ -116,7 +117,8 @@ public sealed class ImageTextIconShape : IconShape
         }
 
         // Draw an image
-        canvas.DrawBitmap(_image, rect);
+        // SKSamplingOptions.Default matches what the obsolete DrawBitmap(bitmap, rect) overload used.
+        canvas.DrawBitmap(_image, rect, SKSamplingOptions.Default);
 
         // Draw text below the image
         if (!string.IsNullOrEmpty(_text))


### PR DESCRIPTION
closes: #301

## Summary

Add **SkiaSharp.QrCode.Playground** (`src/SkiaSharp.QrCode.Playground`), a fully static browser playground published to GitHub Pages: https://guitarrapc.github.io/SkiaSharp.QrCode/

- `Microsoft.NET.Sdk.WebAssembly` app (no Blazor, no server). The page script loads `_framework/dotnet.js` directly and calls `[JSExport]` methods; Release publishes with AOT + full trimming, with the real libSkiaSharp linked into the WASM binary.
- Realtime QR tuning: content, ECC level, version, quiet zone, image size, module/finder shapes, solid or multi-stop gradient colors (8 directions), transparent background, and logo overlay (none / built-in Instagram-style camera glyph drawn with SkiaSharp itself / uploaded image).
- Style presets; the default is an Instagram-style gradient + logo.
- Share links: full state is deflate-compressed into the URL hash via native `CompressionStream` (no server, no CDN dependency). Download PNG / copy image to clipboard.
- Performance benchmark panel: sequentially generates up to 100,000 unique codes in two modes — **encode-only** (zero-allocation `CreateQrCode(text, ecc, Span<byte>)` in a tight loop) and **full pipeline** (encode + Skia render + PNG encode) — with adaptive batching so progress and Cancel stay responsive on the single-threaded WASM runtime.
- Deploy: `build-playground` / `deploy-playground` jobs in `release.yaml` publish to GitHub Pages on release tag pushes, versioned with the release tag (shown as a badge in the page). CI (`build.yaml`) verifies the publish path on ubuntu.

## Intent

- Let users try SkiaSharp.QrCode without installing anything — the playground runs the actual library compiled to WebAssembly, so output is identical to the NuGet package.
- Showcase the customization API (gradients, shapes, logos) and the zero-allocation API's throughput under sustained load.
- Keep hosting free and operations minimal: static GitHub Pages, deployed as part of the normal release flow so the playground always matches the released version.

## Notes

- The SkiaSharp native asset is referenced only when publishing (`_IsPublishing` gate), so solution builds across the CI matrix stay managed-only and do not need the Emscripten toolchain. Local runs must go through `dotnet publish` (see the project README).
- Do not pass `-r browser-wasm` to publish: as a CLI global property it propagates to the multi-targeted library reference and demands the `wasm-tools-net8` workload; the WebAssembly SDK defaults the RID anyway.
- Requires GitHub Pages set to **Source: GitHub Actions** in repository settings before the next release.
- Verified locally: browser run of the AOT Release output, ZXing decode of all presets (incl. default logo preset), share-link round-trip with Japanese content, benchmark progress/cancel/error paths.