### PR TITLE
feat: Performance improvement for Skia image generation

### DIFF
--- a/src/SkiaSharp.QrCode.Benchmark/QrCodeImageEndToEnd.cs
+++ b/src/SkiaSharp.QrCode.Benchmark/QrCodeImageEndToEnd.cs
@@ -1,0 +1,50 @@
+using SkiaSharp.QrCode.Image;
+using System.Text;
+
+/// <summary>
+/// End-to-end PNG image generation through the public API
+/// (QRCodeImageBuilder.GetPngBytes). QRCodeData is pre-generated in setup so
+/// the measurement covers the Skia render + PNG encode path only, not the QR
+/// encoding itself.
+///
+/// Scenarios cover the version/pixel spread:
+///   Small : version 1 matrix (few modules, per-image overhead dominated)
+///   Large : version 40 matrix (~31k modules, per-module draw calls dominated)
+/// each rendered at 512px and 2048px output sizes.
+/// </summary>
+public class QrCodeImageEndToEnd
+{
+    private QRCodeData _small = default!;
+    private QRCodeData _large = default!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _small = QRCodeGenerator.CreateQrCode("HELLO WORLD 2026", ECCLevel.M); // version 1-2
+        _large = QRCodeGenerator.CreateQrCode(BuildDeterministicText(2900), ECCLevel.L); // version 40
+    }
+
+    [Benchmark]
+    public byte[] Small_512px() => QRCodeImageBuilder.GetPngBytes(_small, 512);
+
+    [Benchmark]
+    public byte[] Small_2048px() => QRCodeImageBuilder.GetPngBytes(_small, 2048);
+
+    [Benchmark]
+    public byte[] Large_512px() => QRCodeImageBuilder.GetPngBytes(_large, 512);
+
+    [Benchmark]
+    public byte[] Large_2048px() => QRCodeImageBuilder.GetPngBytes(_large, 2048);
+
+    private static string BuildDeterministicText(int length)
+    {
+        var sb = new StringBuilder(length);
+        var rng = new Random(42);
+        const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 .,:/?&=-_";
+        for (var i = 0; i < length; i++)
+        {
+            sb.Append(alphabet[rng.Next(alphabet.Length)]);
+        }
+        return sb.ToString();
+    }
+}

--- a/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
@@ -486,9 +486,20 @@ public class QRCodeImageBuilder
         using var surface = SKSurface.Create(info);
         var canvas = surface.Canvas;
 
-        // Extension clears the full canvas with clearColor, then draws QR into contentRect.
-        // Extra canvas area (pad) therefore keeps clearColor.
-        canvas.Render(qrCodeData, contentRect, _clearColor, _codeColor, _backgroundColor, _iconData, _moduleShape, _moduleSizePercent, _gradientOptions, _finderPatternShape);
+        // Clear the canvas with clearColor, then draw QR into contentRect; extra
+        // canvas area (pad) keeps clearColor. The clear is skipped when it cannot
+        // remain visible: a fresh surface is already fully transparent, and an
+        // opaque QR background covering the whole canvas overwrites it anyway.
+        var clearColor = _clearColor ?? SKColors.Transparent;
+        var contentCoversCanvas = contentRect.Left <= 0 && contentRect.Top <= 0
+            && contentRect.Right >= info.Width && contentRect.Bottom >= info.Height;
+        var backgroundIsOpaque = (_backgroundColor ?? SKColors.White).Alpha == byte.MaxValue;
+        if (clearColor.Alpha != 0 && !(contentCoversCanvas && backgroundIsOpaque))
+        {
+            canvas.Clear(clearColor);
+        }
+
+        QRCodeRenderer.Render(canvas, contentRect, qrCodeData, _codeColor, _backgroundColor, _iconData, _moduleShape, _moduleSizePercent, _gradientOptions, _finderPatternShape);
 
         return surface.Snapshot();
     }

--- a/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
@@ -483,6 +483,26 @@ public class QRCodeImageBuilder
         var qrCodeData = _qrCodeData ?? QRCodeGenerator.CreateQrCode(_content.AsSpan(), _eccLevel, eciMode: _eciMode, requestedVersion: _requestedVersion, quietZoneSize: _quietZoneSize);
 
         var (info, contentRect) = CreateLayout(qrCodeData);
+
+        var clearColor = _clearColor ?? SKColors.Transparent;
+        var contentCoversCanvas = contentRect.Left <= 0 && contentRect.Top <= 0
+            && contentRect.Right >= info.Width && contentRect.Bottom >= info.Height;
+        var backgroundIsOpaque = (_backgroundColor ?? SKColors.White).Alpha == byte.MaxValue;
+        var clearIsOpaque = clearColor.Alpha == byte.MaxValue;
+
+        // When the base layer (QR background fill, or the cleared canvas) is opaque
+        // everywhere, anything drawn over it stays opaque, so the whole image is
+        // opaque no matter what modules/icons/gradients are painted on top.
+        // An opaque surface lets encoders skip the alpha channel and the unpremul
+        // pass — PNG output becomes RGB: smaller and faster to encode.
+        var isOpaque = contentCoversCanvas
+            ? backgroundIsOpaque || clearIsOpaque
+            : clearIsOpaque;
+        if (isOpaque)
+        {
+            info = info.WithAlphaType(SKAlphaType.Opaque);
+        }
+
         using var surface = SKSurface.Create(info);
         var canvas = surface.Canvas;
 
@@ -490,10 +510,6 @@ public class QRCodeImageBuilder
         // canvas area (pad) keeps clearColor. The clear is skipped when it cannot
         // remain visible: a fresh surface is already fully transparent, and an
         // opaque QR background covering the whole canvas overwrites it anyway.
-        var clearColor = _clearColor ?? SKColors.Transparent;
-        var contentCoversCanvas = contentRect.Left <= 0 && contentRect.Top <= 0
-            && contentRect.Right >= info.Width && contentRect.Bottom >= info.Height;
-        var backgroundIsOpaque = (_backgroundColor ?? SKColors.White).Alpha == byte.MaxValue;
         if (clearColor.Alpha != 0 && !(contentCoversCanvas && backgroundIsOpaque))
         {
             canvas.Clear(clearColor);

--- a/src/SkiaSharp.QrCode/QRCodeData.cs
+++ b/src/SkiaSharp.QrCode/QRCodeData.cs
@@ -462,6 +462,20 @@ public class QRCodeData
     internal int GetCoreSize() => _baseSize;
 
     /// <summary>
+    /// Gets the module state at the specified core position (excluding quiet zone),
+    /// skipping the quiet-zone coordinate translation of the public indexer.
+    /// Caller must guarantee 0 &lt;= coreRow/coreCol &lt; core size.
+    /// </summary>
+    /// <param name="coreRow">Row index in core data (0-based, excluding quiet zone)</param>
+    /// <param name="coreCol">Column index in core data (0-based, excluding quiet zone)</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool GetCoreModule(int coreRow, int coreCol)
+    {
+        var bitIndex = coreRow * _baseSize + coreCol;
+        return (_bits[bitIndex >> 3] & (1 << (7 - (bitIndex & 7)))) != 0;
+    }
+
+    /// <summary>
     /// Copies core data (without quiet zone) to the destination buffer as one
     /// byte (0/1) per module.
     /// </summary>

--- a/src/SkiaSharp.QrCode/QRCodeRenderer.cs
+++ b/src/SkiaSharp.QrCode/QRCodeRenderer.cs
@@ -66,44 +66,17 @@ public static class QRCodeRenderer
             darkPaint.Color = fgColor;
         }
 
-        // Draw the modules
-        var size = data.Size;
-        var coreSize = data.GetCoreSize();
-        var cellHeight = area.Height / size;
-        var cellWidth = area.Width / size;
-        var quietZoneOffset = size - coreSize;
-
-        // Calculate module size with gaps
-        var moduleWidth = cellWidth * moduleSizePercent;
-        var moduleHeight = cellHeight * moduleSizePercent;
-        var xOffset = (cellWidth - moduleWidth) / 2;
-        var yOffset = (cellHeight - moduleHeight) / 2;
-
-        // Draw regular modules (exclude finder patterns)
-        for (int row = 0; row < size; row++)
+        // Draw regular modules (exclude finder patterns when a custom shape draws them).
+        // Full-cell rectangles with antialiasing off touch exactly, so horizontal runs
+        // of dark modules collapse into single rects — far fewer native draw calls.
+        var skipFinderPatterns = finderPatternShape is not null;
+        if (shape is RectangleModuleShape && moduleSizePercent == 1.0f)
         {
-            for (int col = 0; col < size; col++)
-            {
-                // Convert to core coordinates
-                var coreRow = row - quietZoneOffset / 2;
-                var coreCol = col - quietZoneOffset / 2;
-
-                // Skip if outside core area
-                if (coreRow < 0 || coreRow >= coreSize || coreCol < 0 || coreCol >= coreSize)
-                    continue;
-
-                // Skip finder pattern if custom shape is used
-                if (finderPatternShape is not null && data.IsFinderPattern(coreRow, coreCol))
-                    continue;
-
-                if (data[row, col])
-                {
-                    var x = area.Left + col * cellWidth + xOffset;
-                    var y = area.Top + row * cellHeight + yOffset;
-                    var rect = SKRect.Create(x, y, moduleWidth, moduleHeight);
-                    shape.Draw(canvas, rect, darkPaint);
-                }
-            }
+            DrawModuleRuns(canvas, data, area, darkPaint, skipFinderPatterns);
+        }
+        else
+        {
+            DrawModules(canvas, data, area, darkPaint, shape, moduleSizePercent, skipFinderPatterns);
         }
 
         // Draw finder patterns
@@ -279,6 +252,85 @@ public static class QRCodeRenderer
                 finderHeight),
             _ => throw new ArgumentOutOfRangeException(nameof(patternIndex), "Pattern index must be 0 (top-left), 1 (top-right), or 2 (bottom-left)."),
         };
+    }
+
+    /// <summary>
+    /// Draws dark modules as merged horizontal runs of full-cell rectangles.
+    /// Only valid for <see cref="RectangleModuleShape"/> at 100% module size, where
+    /// adjacent modules share edges and merging is visually identical.
+    /// </summary>
+    private static void DrawModuleRuns(SKCanvas canvas, QRCodeData data, SKRect area, SKPaint paint, bool skipFinderPatterns)
+    {
+        var size = data.Size;
+        var coreSize = data.GetCoreSize();
+        var cellWidth = area.Width / size;
+        var cellHeight = area.Height / size;
+        var quietZone = (size - coreSize) / 2;
+
+        // The quiet zone is always light, so only the core area is scanned.
+        for (var coreRow = 0; coreRow < coreSize; coreRow++)
+        {
+            var top = area.Top + (coreRow + quietZone) * cellHeight;
+            var bottom = top + cellHeight;
+            var coreCol = 0;
+            while (coreCol < coreSize)
+            {
+                if (!data.GetCoreModule(coreRow, coreCol) || (skipFinderPatterns && data.IsFinderPattern(coreRow, coreCol)))
+                {
+                    coreCol++;
+                    continue;
+                }
+
+                var runStart = coreCol;
+                do
+                {
+                    coreCol++;
+                } while (coreCol < coreSize
+                    && data.GetCoreModule(coreRow, coreCol)
+                    && !(skipFinderPatterns && data.IsFinderPattern(coreRow, coreCol)));
+
+                var left = area.Left + (runStart + quietZone) * cellWidth;
+                var right = area.Left + (coreCol + quietZone) * cellWidth;
+                canvas.DrawRect(new SKRect(left, top, right, bottom), paint);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws dark modules one by one through the module shape.
+    /// Used for custom shapes and for module sizes below 100% (gaps between modules).
+    /// </summary>
+    private static void DrawModules(SKCanvas canvas, QRCodeData data, SKRect area, SKPaint paint, ModuleShape shape, float moduleSizePercent, bool skipFinderPatterns)
+    {
+        var size = data.Size;
+        var coreSize = data.GetCoreSize();
+        var cellWidth = area.Width / size;
+        var cellHeight = area.Height / size;
+        var quietZone = (size - coreSize) / 2;
+
+        // Calculate module size with gaps
+        var moduleWidth = cellWidth * moduleSizePercent;
+        var moduleHeight = cellHeight * moduleSizePercent;
+        var xOffset = (cellWidth - moduleWidth) / 2;
+        var yOffset = (cellHeight - moduleHeight) / 2;
+
+        // The quiet zone is always light, so only the core area is scanned.
+        for (var coreRow = 0; coreRow < coreSize; coreRow++)
+        {
+            var y = area.Top + (coreRow + quietZone) * cellHeight + yOffset;
+            for (var coreCol = 0; coreCol < coreSize; coreCol++)
+            {
+                if (skipFinderPatterns && data.IsFinderPattern(coreRow, coreCol))
+                    continue;
+
+                if (data.GetCoreModule(coreRow, coreCol))
+                {
+                    var x = area.Left + (coreCol + quietZone) * cellWidth + xOffset;
+                    var rect = SKRect.Create(x, y, moduleWidth, moduleHeight);
+                    shape.Draw(canvas, rect, paint);
+                }
+            }
+        }
     }
 
     private static SKShader? CreateGradientShader(SKRect area, GradientOptions? gradientOptions)

--- a/src/SkiaSharp.QrCode/QRCodeRenderer.cs
+++ b/src/SkiaSharp.QrCode/QRCodeRenderer.cs
@@ -11,6 +11,15 @@ public static class QRCodeRenderer
     /// <summary>
     /// Render the specified data into the given area of the target canvas.
     /// </summary>
+    /// <remarks>
+    /// With the default rectangle shape at <paramref name="moduleSizePercent"/> 1.0,
+    /// horizontal runs of dark modules are drawn as single merged rectangles
+    /// (fewer native draw calls). Merged and per-module rendering are
+    /// pixel-identical under axis-preserving canvas transforms (translation/scale);
+    /// under rotation, shared-edge rounding may differ at sub-pixel level.
+    /// Any custom module shape or a module size below 1.0 falls back to
+    /// per-module drawing.
+    /// </remarks>
     /// <param name="canvas">The canvas to render the QR code on.</param>
     /// <param name="area">The rectangular area where the QR code will be rendered.</param>
     /// <param name="data">The QR code data to render.</param>
@@ -257,7 +266,13 @@ public static class QRCodeRenderer
     /// <summary>
     /// Draws dark modules as merged horizontal runs of full-cell rectangles.
     /// Only valid for <see cref="RectangleModuleShape"/> at 100% module size, where
-    /// adjacent modules share edges and merging is visually identical.
+    /// adjacent modules share edges, antialiasing is always off
+    /// (<see cref="RectangleModuleShape.RequiresAntialiasing"/> is false), and
+    /// merging is pixel-identical to per-module drawing. The parity holds under
+    /// axis-preserving canvas transforms (translation/scale); rotated canvases may
+    /// rasterize shared edges hairline-differently at sub-pixel level — inherent to
+    /// non-axis-aligned rasterization, which affects per-module drawing between
+    /// adjacent modules just the same.
     /// </summary>
     private static void DrawModuleRuns(SKCanvas canvas, QRCodeData data, SKRect area, SKPaint paint, bool skipFinderPatterns)
     {

--- a/src/SkiaSharp.QrCode/QRCodeRenderer.cs
+++ b/src/SkiaSharp.QrCode/QRCodeRenderer.cs
@@ -54,15 +54,16 @@ public static class QRCodeRenderer
         // disable antialiasing as it causes gray border around each module.
         using var darkPaint = new SKPaint() { Style = SKPaintStyle.Fill, IsAntialias = shape.RequiresAntialiasing };
 
-        // Apply gradient if specified
-        if (gradientOptions is not null && gradientOptions.Direction != GradientDirection.None)
+        // Apply gradient if specified. The shader wrapper must be disposed here;
+        // disposing the paint alone leaves the SKShader to the finalizer.
+        using var gradientShader = CreateGradientShader(area, gradientOptions);
+        if (gradientShader is not null)
         {
-            var (start, end) = GetLinearGradientPoints(area, gradientOptions.Direction);
-            darkPaint.Shader = SKShader.CreateLinearGradient(start, end, gradientOptions.Colors, gradientOptions.ColorPositions, SKShaderTileMode.Clamp);
+            darkPaint.Shader = gradientShader;
         }
         else
         {
-            darkPaint.Color = codeColor ?? SKColors.Black;
+            darkPaint.Color = fgColor;
         }
 
         // Draw the modules
@@ -278,6 +279,15 @@ public static class QRCodeRenderer
                 finderHeight),
             _ => throw new ArgumentOutOfRangeException(nameof(patternIndex), "Pattern index must be 0 (top-left), 1 (top-right), or 2 (bottom-left)."),
         };
+    }
+
+    private static SKShader? CreateGradientShader(SKRect area, GradientOptions? gradientOptions)
+    {
+        if (gradientOptions is null || gradientOptions.Direction == GradientDirection.None)
+            return null;
+
+        var (start, end) = GetLinearGradientPoints(area, gradientOptions.Direction);
+        return SKShader.CreateLinearGradient(start, end, gradientOptions.Colors, gradientOptions.ColorPositions, SKShaderTileMode.Clamp);
     }
 
     private static (SKPoint start, SKPoint end) GetLinearGradientPoints(SKRect area, GradientDirection direction)

--- a/tests/SkiaSharp.QrCode.Tests/QRCodeImageBuilderClearBehaviorTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRCodeImageBuilderClearBehaviorTest.cs
@@ -1,0 +1,99 @@
+using SkiaSharp.QrCode.Image;
+using Xunit;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// The builder skips the initial canvas clear when the clear color cannot remain
+/// visible (a fresh surface is already transparent, and an opaque QR background
+/// covering the whole canvas overwrites the cleared pixels). These tests pin that
+/// the builder output stays pixel-identical to the always-clear extension render.
+/// </summary>
+public class QRCodeImageBuilderClearBehaviorTest
+{
+    private const string TestContent = "clear-behavior-test";
+
+    [Fact]
+    public void DefaultTransparentClear_FullCoverage_MatchesExtensionRender()
+    {
+        var qr = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+
+        var actual = BuilderPixels(new QRCodeImageBuilder(qr).WithSize(300, 300));
+        var expected = ExtensionPixels(qr, 300, 300, SKRect.Create(0, 0, 300, 300), clearColor: null, backgroundColor: null);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void OpaqueClearColor_WithPadding_KeepsClearColorInPad()
+    {
+        const int modulePixelSize = 4;
+        var qr = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+        var contentSide = qr.Size * modulePixelSize;
+        var canvasSide = contentSide + 40;
+        var origin = (canvasSide - contentSide) / 2;
+
+        var builder = new QRCodeImageBuilder(qr)
+            .WithModulePixelSize(modulePixelSize)
+            .WithSize(canvasSide, canvasSide)
+            .WithColors(clearColor: SKColors.Red);
+
+        using var bitmap = builder.ToBitmap();
+
+        // Pad outside content keeps the clear color; the clear must not be skipped.
+        Assert.Equal(SKColors.Red, bitmap.GetPixel(0, 0));
+        Assert.Equal(SKColors.Red, bitmap.GetPixel(canvasSide - 1, canvasSide - 1));
+
+        var expected = ExtensionPixels(qr, canvasSide, canvasSide,
+            SKRect.Create(origin, origin, contentSide, contentSide),
+            clearColor: SKColors.Red, backgroundColor: null);
+        Assert.Equal(expected, bitmap.Bytes);
+    }
+
+    [Fact]
+    public void TranslucentBackground_FullCoverage_StillBlendsOverClearColor()
+    {
+        // A translucent QR background lets the clear color show through, so the
+        // clear must still happen even when the content covers the whole canvas.
+        var qr = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+        var translucentWhite = new SKColor(0xFF, 0xFF, 0xFF, 0x80);
+
+        var actual = BuilderPixels(new QRCodeImageBuilder(qr)
+            .WithSize(300, 300)
+            .WithColors(backgroundColor: translucentWhite, clearColor: SKColors.Red));
+        var expected = ExtensionPixels(qr, 300, 300, SKRect.Create(0, 0, 300, 300),
+            clearColor: SKColors.Red, backgroundColor: translucentWhite);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void OpaqueClearColor_FullCoverage_MatchesExtensionRender()
+    {
+        // Opaque background covering the whole canvas: the clear is skipped, and
+        // the output must be identical to the always-clear render.
+        var qr = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+
+        var actual = BuilderPixels(new QRCodeImageBuilder(qr)
+            .WithSize(300, 300)
+            .WithColors(clearColor: SKColors.Red));
+        var expected = ExtensionPixels(qr, 300, 300, SKRect.Create(0, 0, 300, 300),
+            clearColor: SKColors.Red, backgroundColor: null);
+
+        Assert.Equal(expected, actual);
+    }
+
+    private static byte[] BuilderPixels(QRCodeImageBuilder builder)
+    {
+        using var bitmap = builder.ToBitmap();
+        return bitmap.Bytes;
+    }
+
+    private static byte[] ExtensionPixels(QRCodeData qr, int width, int height, SKRect contentRect, SKColor? clearColor, SKColor? backgroundColor)
+    {
+        using var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Render(qr, contentRect, clearColor: clearColor, backgroundColor: backgroundColor);
+        return bitmap.Bytes;
+    }
+}

--- a/tests/SkiaSharp.QrCode.Tests/QRCodeImageBuilderOpaqueEncodingTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRCodeImageBuilderOpaqueEncodingTest.cs
@@ -1,0 +1,123 @@
+using SkiaSharp.QrCode.Image;
+using Xunit;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// The builder renders to an opaque surface when the base layer (QR background
+/// fill or cleared canvas) is opaque everywhere, so encoders emit alpha-less
+/// output (RGB PNG). These tests pin the opacity decision and that the visible
+/// pixels stay identical to the premul (always-alpha) extension render.
+/// </summary>
+public class QRCodeImageBuilderOpaqueEncodingTest
+{
+    private const string TestContent = "opaque-encoding-test";
+
+    [Fact]
+    public void DefaultColors_ProducesOpaqueImage()
+    {
+        var qr = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+
+        using var image = new QRCodeImageBuilder(qr).WithSize(300, 300).ToImage();
+
+        Assert.Equal(SKAlphaType.Opaque, image.AlphaType);
+    }
+
+    [Fact]
+    public void TransparentClearWithPadding_KeepsAlpha()
+    {
+        // Pad area stays transparent, so the surface must keep its alpha channel.
+        const int modulePixelSize = 4;
+        var qr = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+        var canvasSide = qr.Size * modulePixelSize + 40;
+
+        using var image = new QRCodeImageBuilder(qr)
+            .WithModulePixelSize(modulePixelSize)
+            .WithSize(canvasSide, canvasSide)
+            .ToImage();
+
+        Assert.Equal(SKAlphaType.Premul, image.AlphaType);
+
+        using var bitmap = SKBitmap.FromImage(image);
+        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha);
+    }
+
+    [Fact]
+    public void OpaqueClearWithPadding_ProducesOpaqueImage()
+    {
+        const int modulePixelSize = 4;
+        var qr = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+        var canvasSide = qr.Size * modulePixelSize + 40;
+
+        using var image = new QRCodeImageBuilder(qr)
+            .WithModulePixelSize(modulePixelSize)
+            .WithSize(canvasSide, canvasSide)
+            .WithColors(clearColor: SKColors.Red)
+            .ToImage();
+
+        Assert.Equal(SKAlphaType.Opaque, image.AlphaType);
+    }
+
+    [Fact]
+    public void TranslucentBackground_WithTransparentClear_KeepsAlpha()
+    {
+        // Translucent background over a transparent canvas: pixels stay
+        // translucent, so the alpha channel must be preserved.
+        var qr = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+        var translucentWhite = new SKColor(0xFF, 0xFF, 0xFF, 0x80);
+
+        using var image = new QRCodeImageBuilder(qr)
+            .WithSize(300, 300)
+            .WithColors(backgroundColor: translucentWhite)
+            .ToImage();
+
+        Assert.Equal(SKAlphaType.Premul, image.AlphaType);
+
+        using var bitmap = SKBitmap.FromImage(image);
+        Assert.True(bitmap.GetPixel(0, 0).Alpha < byte.MaxValue);
+    }
+
+    [Fact]
+    public void TranslucentBackground_OverOpaqueClear_ProducesOpaqueImage()
+    {
+        // The opaque cleared canvas is the base layer; the translucent background
+        // blends over it and every pixel stays opaque.
+        var qr = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+        var translucentWhite = new SKColor(0xFF, 0xFF, 0xFF, 0x80);
+
+        using var image = new QRCodeImageBuilder(qr)
+            .WithSize(300, 300)
+            .WithColors(backgroundColor: translucentWhite, clearColor: SKColors.Red)
+            .ToImage();
+
+        Assert.Equal(SKAlphaType.Opaque, image.AlphaType);
+    }
+
+    [Fact]
+    public void OpaquePng_DecodesToSamePixelsAsPremulRender()
+    {
+        // The encoded PNG must stay visually identical to the premul render;
+        // only the alpha channel representation may differ.
+        var qr = QRCodeGenerator.CreateQrCode(TestContent, ECCLevel.M);
+        const int size = 300;
+
+        var png = QRCodeImageBuilder.GetPngBytes(qr, size);
+        using var decoded = SKBitmap.Decode(png);
+
+        using var reference = new SKBitmap(size, size);
+        using (var canvas = new SKCanvas(reference))
+        {
+            canvas.Render(qr, SKRect.Create(0, 0, size, size));
+        }
+
+        Assert.Equal(size, decoded.Width);
+        Assert.Equal(size, decoded.Height);
+        for (var y = 0; y < size; y += 3)
+        {
+            for (var x = 0; x < size; x += 3)
+            {
+                Assert.Equal(reference.GetPixel(x, y), decoded.GetPixel(x, y));
+            }
+        }
+    }
+}

--- a/tests/SkiaSharp.QrCode.Tests/QRCodeRendererRunMergeParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRCodeRendererRunMergeParityTest.cs
@@ -46,6 +46,26 @@ public class QRCodeRendererRunMergeParityTest
         Assert.Equal(perModule, merged);
     }
 
+    [Theory]
+    [InlineData(0.3f, 0.7f, 1.0f)]   // sub-pixel translation
+    [InlineData(0f, 0f, 1.37f)]      // fractional upscale
+    [InlineData(5.5f, 3.25f, 0.61f)] // sub-pixel translation + fractional downscale
+    public void MergedRuns_WithAxisPreservingCanvasTransform_MatchPerModuleRendering(float dx, float dy, float scale)
+    {
+        // Axis-preserving transforms (translation/scale) keep both paths
+        // pixel-identical: they compute the same edge coordinates and rasterize
+        // without antialiasing. Rotation is intentionally outside the parity
+        // guarantee — non-axis-aligned rasterization rounds shared edges at
+        // sub-pixel level, which affects per-module drawing between adjacent
+        // modules just the same (measured ~0.003% of pixels at 7-30 degrees).
+        var qr = QRCodeGenerator.CreateQrCode("transform-parity", ECCLevel.M);
+
+        var merged = RenderTransformedPixels(qr, moduleShape: null, dx, dy, scale);
+        var perModule = RenderTransformedPixels(qr, new PerModuleRectangleShape(), dx, dy, scale);
+
+        Assert.Equal(perModule, merged);
+    }
+
     [Fact]
     public void MergedRuns_WithFinderPatternShape_MatchPerModuleRendering()
     {
@@ -57,6 +77,27 @@ public class QRCodeRendererRunMergeParityTest
         var perModule = RenderPixels(qr, 512, moduleShape: new PerModuleRectangleShape(), finderPatternShape: RectangleFinderPatternShape.Default);
 
         Assert.Equal(perModule, merged);
+    }
+
+    private static byte[] RenderTransformedPixels(QRCodeData qr, ModuleShape? moduleShape, float dx, float dy, float scale)
+    {
+        // Render area uses a fractional cell size (411 / module count) inside a
+        // larger bitmap so scaled content stays within bounds.
+        using var bitmap = new SKBitmap(600, 600);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Transparent);
+        canvas.Translate(dx, dy);
+        canvas.Scale(scale);
+
+        QRCodeRenderer.Render(
+            canvas,
+            SKRect.Create(10, 10, 411, 411),
+            qr,
+            SKColors.Black,
+            SKColors.White,
+            moduleShape: moduleShape);
+
+        return bitmap.Bytes;
     }
 
     private static byte[] RenderPixels(

--- a/tests/SkiaSharp.QrCode.Tests/QRCodeRendererRunMergeParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRCodeRendererRunMergeParityTest.cs
@@ -1,0 +1,85 @@
+using SkiaSharp.QrCode.Image;
+using Xunit;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// The renderer collapses horizontal runs of dark modules into single rects for the
+/// default rectangle shape at 100% module size. These tests pin that the merged
+/// fast path is pixel-identical to per-module drawing (forced through a rect shape
+/// of a different type, which bypasses the fast-path type check).
+/// </summary>
+public class QRCodeRendererRunMergeParityTest
+{
+    // Draws exactly like RectangleModuleShape, but as a different type the renderer
+    // routes it through the per-module path instead of the run-merged fast path.
+    private sealed class PerModuleRectangleShape : ModuleShape
+    {
+        public override bool RequiresAntialiasing => false;
+        public override void Draw(SKCanvas canvas, SKRect rect, SKPaint paint) => canvas.DrawRect(rect, paint);
+    }
+
+    [Theory]
+    [InlineData("HELLO WORLD 2026", 0, 290)] // v1-2, no quiet zone, exact multiple
+    [InlineData("HELLO WORLD 2026", 4, 290)] // v1-2, standard quiet zone
+    [InlineData("HELLO WORLD 2026", 4, 411)] // fractional cell size
+    [InlineData("https://github.com/guitarrapc/SkiaSharp.QrCode/blob/main/README.md?foo=sample&bar=dummy", 4, 512)] // v~5
+    public void MergedRuns_MatchPerModuleRendering(string content, int quietZone, int imageSize)
+    {
+        var qr = QRCodeGenerator.CreateQrCode(content, ECCLevel.M, quietZoneSize: quietZone);
+
+        var merged = RenderPixels(qr, imageSize, moduleShape: null);
+        var perModule = RenderPixels(qr, imageSize, moduleShape: new PerModuleRectangleShape());
+
+        Assert.Equal(perModule, merged);
+    }
+
+    [Fact]
+    public void MergedRuns_WithGradient_MatchPerModuleRendering()
+    {
+        var qr = QRCodeGenerator.CreateQrCode("gradient-run-merge-parity", ECCLevel.M);
+        var gradient = new GradientOptions([SKColors.Purple, SKColors.Orange], GradientDirection.TopLeftToBottomRight);
+
+        var merged = RenderPixels(qr, 512, moduleShape: null, gradientOptions: gradient);
+        var perModule = RenderPixels(qr, 512, moduleShape: new PerModuleRectangleShape(), gradientOptions: gradient);
+
+        Assert.Equal(perModule, merged);
+    }
+
+    [Fact]
+    public void MergedRuns_WithFinderPatternShape_MatchPerModuleRendering()
+    {
+        // Runs must break at finder pattern modules so the custom finder shape
+        // is not painted over.
+        var qr = QRCodeGenerator.CreateQrCode("finder-run-merge-parity", ECCLevel.M);
+
+        var merged = RenderPixels(qr, 512, moduleShape: null, finderPatternShape: RectangleFinderPatternShape.Default);
+        var perModule = RenderPixels(qr, 512, moduleShape: new PerModuleRectangleShape(), finderPatternShape: RectangleFinderPatternShape.Default);
+
+        Assert.Equal(perModule, merged);
+    }
+
+    private static byte[] RenderPixels(
+        QRCodeData qr,
+        int imageSize,
+        ModuleShape? moduleShape,
+        GradientOptions? gradientOptions = null,
+        FinderPatternShape? finderPatternShape = null)
+    {
+        var area = SKRect.Create(0, 0, imageSize, imageSize);
+        using var bitmap = new SKBitmap(imageSize, imageSize);
+        using var canvas = new SKCanvas(bitmap);
+
+        QRCodeRenderer.Render(
+            canvas,
+            area,
+            qr,
+            SKColors.Black,
+            SKColors.White,
+            moduleShape: moduleShape,
+            gradientOptions: gradientOptions,
+            finderPatternShape: finderPatternShape);
+
+        return bitmap.Bytes;
+    }
+}


### PR DESCRIPTION
## Summary

Performance pass over the Skia image generation path (render + PNG encode). No visual changes — output pixels are identical, pinned by parity tests.

- **Fix undisposed `SKShader`**: gradient shaders were left to the finalizer; now disposed deterministically.
- **Merge horizontal module runs** (`QRCodeRenderer.DrawModuleRuns`): for the default rectangle shape at 100% module size, consecutive dark modules are drawn as a single rect instead of one `DrawRect` per module (~15k native calls at v40). Custom shapes / gapped modules keep the per-module path.
- **Scan core area only**: the module loop no longer iterates the virtual quiet zone (up to ~48% wasted iterations) and reads bits via a direct core accessor, skipping redundant coordinate translation.
- **Skip redundant canvas clear**: the builder cleared the full canvas and then painted the background over the same pixels; the clear now runs only when it can remain visible (padding area or translucent background).
- **Render to `SKAlphaType.Opaque` when the image is fully opaque**: encoders emit alpha-less RGB PNG, skipping the unpremul pass. Opacity is decided from the base layer alone (background fill or cleared canvas) since anything drawn over an opaque base stays opaque under SrcOver.
- **Add render E2E benchmark** (`QrCodeImageEndToEnd`): measures render + PNG encode with pre-generated `QRCodeData`, small (v1) / large (v40) × 512px / 2048px.

## Intent

QR generation cost was dominated by the image path, not QR encoding. Profiling with the new benchmark showed two levers: per-module native draw calls (dominant at large versions) and PNG encoding of a premul RGBA surface for images that are in practice fully opaque (dominant at large pixel sizes). This PR removes both without changing any public API or rendered output.

## Results

| Case | Before | After | PNG size |
|---|---|---|---|
| v1, 512px | 5.97 ms | 4.60 ms (−23%) | −17% |
| v1, 2048px | 90.7 ms | 69.4 ms (−23%) | −20% |
| v40, 512px | 11.3 ms | 8.84 ms (−22%) | −8% |
| v40, 2048px | 96.2 ms | 73.8 ms (−23%) | −13% |

Render-only (excluding PNG encode), run-merge alone is 2.0x at v40 (2.98 ms → 1.49 ms @512px).

## Notes

- Opaque images now report `SKImage.AlphaType == Opaque` and encode as RGB PNG (previously RGBA). Pixel values are unchanged.
- New regression tests pin pixel parity: `QRCodeRendererRunMergeParityTest` (merged vs per-module), `QRCodeImageBuilderClearBehaviorTest` (clear-skip vs always-clear), `QRCodeImageBuilderOpaqueEncodingTest` (opacity decision + decoded-pixel equality).