### PR TITLE
feat: adjust svg api and playground support

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,12 @@ app.MapGet("/qr", (string url) =>
     var pngBytes = QRCodeImageBuilder.GetPngBytes(url);
     return Results.File(pngBytes, "image/png");
 });
+
+app.MapGet("/qr.svg", (string url) =>
+{
+    var svgBytes = QRCodeImageBuilder.GetSvgBytes(url);
+    return Results.File(svgBytes, "image/svg+xml");
+});
 ```
 
 ### Does it support Blazor WebAssembly?
@@ -514,18 +520,24 @@ SVG output draws the QR code as vector shapes, so it scales to any size without 
 using SkiaSharp;
 using SkiaSharp.QrCode.Image;
 
+// One-liner: save to stream
 using var stream = File.Create("qrcode.svg");
 QRCodeImageBuilder.SaveSvg("https://example.com", stream);
+
+// One-liner: SVG document string, e.g. for inline HTML embedding
+var svg = QRCodeImageBuilder.GetSvgString("https://example.com");
 
 // Builder: full styling support
 var svgString = new QRCodeImageBuilder("https://example.com")
     .WithModulePixelSize(10)
     .WithErrorCorrection(ECCLevel.H)
     .WithColors(codeColor: SKColor.Parse("1B9CFC"))
-    .ToSvgString(); // or SaveToSvg(stream) / GetSvgBytes(...)
+    .ToSvgString(); // or SaveToSvg(stream) / SaveToSvg(bufferWriter) / GetSvgBytes(...)
 ```
 
 Size options define the SVG viewport (in SVG units instead of pixels); `WithFormat()` does not apply to SVG output.
+
+The root element always carries a `viewBox`, so the QR code scales its content when displayed at any size (`<img>`, CSS, or attribute-based sizing). Plain rectangular modules also get `shape-rendering="crispEdges"` to prevent antialiasing seams between modules; custom shapes (circles, rounded rects) keep antialiasing for smooth curves.
 
 > [!TIP]
 > Default rectangle modules produce compact SVG (horizontal module runs merge into single `<rect>` elements). Custom module shapes and gradients render correctly but produce larger documents, since each module becomes an individual vector element. Icon images are embedded as base64 data URIs.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Single line QR code generation:
 using SkiaSharp.QrCode.Image;
 
 // one-liner save to file
-QRCodeImageBuilder.SavePng("Hello", "qrcode.png");
+File.WriteAllBytes("qrcode.png", QRCodeImageBuilder.GetPngBytes("Hello"));
 
 // Or get bytes
 var pngBytes = QRCodeImageBuilder.GetPngBytes("https://example.com");
@@ -83,14 +83,13 @@ WiFi QR Code.
 
 ```csharp
 var wifiString = "WIFI:T:WPA;S:MyNetwork;P:MyPassword;;";
-QRCodeImageBuilder.SavePng(wifiString, "wifi-qr.png");
+File.WriteAllBytes("wifi-qr.png", QRCodeImageBuilder.GetPngBytes(wifiString));
 ```
 
 SVG (vector) output.
 
 ```csharp
-using var stream = File.Create("qrcode.svg");
-QRCodeImageBuilder.SaveSvg("https://example.com", stream);
+File.WriteAllText("qrcode.svg", QRCodeImageBuilder.GetSvgString("https://example.com"));
 ```
 
 Generate with Custom Settings.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See [samples/ConsoleApp](samples/ConsoleApp) for code examples generating these 
 
 Try SkiaSharp.QrCode in your browser — no install required: **[SkiaSharp.QrCode Playground](https://guitarrapc.github.io/SkiaSharp.QrCode/)**
 
-The playground runs the actual library compiled to WebAssembly (GitHub Pages, fully static). Tune gradients, module shapes, finder patterns and logos in realtime, then download the PNG or share your settings as a permalink. Source lives in [src/SkiaSharp.QrCode.Playground](src/SkiaSharp.QrCode.Playground); it is deployed to GitHub Pages by [release.yaml](.github/workflows/release.yaml) as part of every release.
+The playground runs the actual library compiled to WebAssembly (GitHub Pages, fully static). Tune gradients, module shapes, finder patterns and logos in realtime, then download the PNG or SVG, or share your settings as a permalink. Source lives in [src/SkiaSharp.QrCode.Playground](src/SkiaSharp.QrCode.Playground); it is deployed to GitHub Pages by [release.yaml](.github/workflows/release.yaml) as part of every release.
 
 ## Overview
 

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -841,7 +841,7 @@ Console.WriteLine();
 Console.WriteLine("""
     Pattern 22: SVG Output (Vector Format)
       - Best for: Print, web embedding, infinite scaling without quality loss
-      - API: QRCodeImageBuilder.SaveSvg() / SaveToSvg() / ToSvgString()
+      - API: QRCodeImageBuilder.SaveSvg() / GetSvgString() / SaveToSvg() / ToSvgString()
     """);
 {
     // One-liner: save SVG to stream
@@ -877,6 +877,10 @@ Console.WriteLine("""
     var firstLineEnd = svgString.IndexOf('\n');
     var firstLine = firstLineEnd >= 0 ? svgString.Substring(0, firstLineEnd) : svgString;
     Console.WriteLine($"  ✓ ToSvgString(): {svgString.Length} chars, starts with: {firstLine}");
+
+    // Static one-liner string output for inline HTML embedding
+    var inlineSvg = QRCodeImageBuilder.GetSvgString(content, ECCLevel.M, size: 256);
+    Console.WriteLine($"  ✓ GetSvgString(): viewBox present: {inlineSvg.Contains("viewBox=\"0 0 256 256\"")}");
 }
 Console.WriteLine();
 

--- a/samples/ConsoleApp/samples/pattern22_svg_simple.svg
+++ b/samples/ConsoleApp/samples/pattern22_svg_simple.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="512" height="512">
+<svg viewBox="0 0 512 512" shape-rendering="crispEdges" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="512" height="512">
 	<rect fill="white" width="512" height="512"/>
 	<rect x="45.511112" y="45.511112" width="79.64444" height="11.377777"/>
 	<rect x="136.53334" y="45.511112" width="22.755554" height="11.377777"/>

--- a/samples/ConsoleApp/samples/pattern22_svg_styled.svg
+++ b/samples/ConsoleApp/samples/pattern22_svg_styled.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="570" height="570">
+<svg viewBox="0 0 570 570" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="570" height="570">
 	<rect fill="white" width="570" height="570"/>
 	<defs>
 		<linearGradient id="gradient_0" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="570" y2="570">

--- a/src/SkiaSharp.QrCode.Playground/QrInterop.cs
+++ b/src/SkiaSharp.QrCode.Playground/QrInterop.cs
@@ -77,6 +77,40 @@ public static partial class QrInterop
         }
     }
 
+    /// <summary>
+    /// Generates a QR code SVG document from JSON options (see <see cref="QrRequest"/>).
+    /// Returns UTF-8 SVG bytes on success (first byte '&lt;' 0x3C), or UTF-8 JSON
+    /// <c>{"error":"..."}</c> on failure (first byte 0x7B) — the JS side
+    /// distinguishes the two by the first byte.
+    /// </summary>
+    /// <param name="optionsJson">Serialized <see cref="QrRequest"/> (camelCase).</param>
+    /// <param name="customLogo">Uploaded logo image bytes; empty unless logo mode is "custom".</param>
+    [JSExport]
+    public static byte[] GenerateSvg(string optionsJson, byte[] customLogo)
+    {
+        try
+        {
+            var request = JsonSerializer.Deserialize(optionsJson, PlaygroundJsonContext.Default.QrRequest)
+                ?? throw new InvalidOperationException("Options JSON deserialized to null.");
+            if (string.IsNullOrWhiteSpace(request.Content))
+                throw new ArgumentException("Content is empty.");
+
+            var data = QRCodeGenerator.CreateQrCode(
+                request.Content.AsSpan(),
+                ParseEcc(request.Ecc),
+                requestedVersion: request.Version,
+                quietZoneSize: Math.Clamp(request.QuietZone, 0, 10));
+
+            using var stream = new MemoryStream();
+            CreateBuilder(request, data, customLogo).SaveToSvg(stream);
+            return stream.ToArray();
+        }
+        catch (Exception ex)
+        {
+            return SerializeError(ex);
+        }
+    }
+
     private static byte[] GenerateCore(QrRequest request, byte[] customLogo)
     {
         if (string.IsNullOrWhiteSpace(request.Content))

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/index.html
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/index.html
@@ -258,6 +258,8 @@
           <div id="qr-stats" class="qr-stats"></div>
           <div class="preview-actions">
             <button type="button" id="download-btn" class="action-btn" disabled>Download PNG</button>
+            <button type="button" id="download-svg-btn" class="action-btn" disabled
+              title="Vector output — scales to any size without quality loss">Download SVG</button>
             <button type="button" id="copy-image-btn" class="action-btn" disabled>Copy image</button>
             <button type="button" id="permalink-btn" class="action-btn action-btn--primary" disabled
               title="Share — copy a link with all settings encoded in the URL">Share link</button>

--- a/src/SkiaSharp.QrCode.Playground/wwwroot/main.js
+++ b/src/SkiaSharp.QrCode.Playground/wwwroot/main.js
@@ -165,6 +165,7 @@ const previewImg = document.getElementById('qr-preview');
 const statsEl = document.getElementById('qr-stats');
 const generateErrorEl = document.getElementById('generate-error');
 const downloadBtn = document.getElementById('download-btn');
+const downloadSvgBtn = document.getElementById('download-svg-btn');
 const copyImageBtn = document.getElementById('copy-image-btn');
 const permalinkBtn = document.getElementById('permalink-btn');
 const benchModeSelect = document.getElementById('bench-mode-select');
@@ -474,6 +475,7 @@ function handleRuntimeDeath() {
   benchCancelled = true;
   // Everything below either needs the runtime or would act on stale output.
   downloadBtn.disabled = true;
+  downloadSvgBtn.disabled = true;
   copyImageBtn.disabled = true;
   permalinkBtn.disabled = true;
   benchRunBtn.disabled = true;
@@ -562,6 +564,7 @@ function generate() {
   previewImg.hidden = false;
   generateErrorEl.hidden = true;
   downloadBtn.disabled = false;
+  downloadSvgBtn.disabled = false;
   copyImageBtn.disabled = false;
 
   try {
@@ -642,6 +645,50 @@ downloadBtn.addEventListener('click', () => {
   const a = document.createElement('a');
   a.href = url;
   a.download = 'qrcode.png';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+});
+
+// SVG is rendered on demand (not on every preview regeneration) with the current
+// settings; the preview <img> itself stays PNG-backed.
+downloadSvgBtn.addEventListener('click', () => {
+  if (!runtimeAlive || !runtimeReady || !exports) return;
+
+  const state = collectState();
+  if (!state.content.trim()) return;
+
+  const logoBytes = state.logo.mode === 'custom' ? customLogoBytes : EMPTY_BYTES;
+  let bytes;
+  try {
+    bytes = exports.SkiaSharp.QrCode.Playground.QrInterop.GenerateSvg(JSON.stringify(state), logoBytes);
+  } catch (err) {
+    if (isRuntimeDeadError(err)) {
+      handleRuntimeDeath();
+      return;
+    }
+    showToast(`Could not generate SVG: ${err?.message ?? err}`, 'error');
+    return;
+  }
+
+  // Error envelope is UTF-8 JSON starting with '{'; SVG always starts with '<'.
+  if (bytes.length === 0 || bytes[0] === 0x7b) {
+    let message = 'SVG generation failed.';
+    try {
+      message = JSON.parse(utf8Decoder.decode(bytes)).error ?? message;
+    } catch {
+      /* keep generic message */
+    }
+    showToast(message, 'error');
+    return;
+  }
+
+  const blob = new Blob([bytes], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'qrcode.svg';
   document.body.appendChild(a);
   a.click();
   a.remove();

--- a/src/SkiaSharp.QrCode/Image/BufferWriterStream.cs
+++ b/src/SkiaSharp.QrCode/Image/BufferWriterStream.cs
@@ -1,0 +1,43 @@
+using System.Buffers;
+
+namespace SkiaSharp.QrCode.Image;
+
+/// <summary>
+/// Write-only stream adapter over an <see cref="IBufferWriter{T}"/>. Data is copied in
+/// writer-provided segments (via <see cref="BuffersExtensions.Write{T}"/>), so no single
+/// contiguous buffer is ever requested for the whole payload — segmented writers such as
+/// PipeWriter never receive an oversized GetSpan request.
+/// </summary>
+internal sealed class BufferWriterStream : Stream
+{
+    private readonly IBufferWriter<byte> _writer;
+
+    public BufferWriterStream(IBufferWriter<byte> writer)
+    {
+        _writer = writer;
+    }
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        _writer.Write(buffer.AsSpan(offset, count));
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+}

--- a/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
@@ -554,11 +554,9 @@ public class QRCodeImageBuilder
         using var image = GenerateImage();
         using var data = image.Encode(_format, _quality);
 
-        // write to IBufferWriter
-        var span = data.AsSpan();
-        var buffer = writer.GetSpan(span.Length);
-        span.CopyTo(buffer);
-        writer.Advance(span.Length);
+        // Write in writer-provided segments; a single GetSpan for the whole payload
+        // would force segmented writers (e.g. PipeWriter) into one contiguous buffer.
+        writer.Write(data.AsSpan());
     }
 
     /// <summary>
@@ -593,27 +591,16 @@ public class QRCodeImageBuilder
         if (!output.CanWrite)
             throw new ArgumentException("Output stream must be writable", nameof(output));
 
-        using var document = RenderSvgDocument(out var insertAt, out var rootAttributes);
-        var buffer = document.GetBuffer();
-        var length = (int)document.Length;
-
-        if (insertAt < 0)
-        {
-            output.Write(buffer, 0, length);
-            return;
-        }
-
-        var attributeBytes = Encoding.UTF8.GetBytes(rootAttributes);
-        output.Write(buffer, 0, insertAt);
-        output.Write(attributeBytes, 0, attributeBytes.Length);
-        output.Write(buffer, insertAt, length - insertAt);
+        RenderSvg(output);
     }
 
     /// <summary>
     /// Generate QR code and write as SVG document to an IBufferWriter.
     /// </summary>
     /// <remarks>
-    /// See <see cref="SaveToSvg(Stream)"/> for rendering behavior.
+    /// See <see cref="SaveToSvg(Stream)"/> for rendering behavior. Data is written in
+    /// writer-provided segments, so segmented writers (e.g. PipeWriter) work without
+    /// a single contiguous buffer for the whole document.
     /// </remarks>
     /// <param name="writer">The buffer writer to write to.</param>
     /// <exception cref="ArgumentNullException"></exception>
@@ -622,25 +609,8 @@ public class QRCodeImageBuilder
         if (writer is null)
             throw new ArgumentNullException(nameof(writer));
 
-        using var document = RenderSvgDocument(out var insertAt, out var rootAttributes);
-        var buffer = document.GetBuffer();
-        var length = (int)document.Length;
-
-        if (insertAt < 0)
-        {
-            var raw = writer.GetSpan(length);
-            buffer.AsSpan(0, length).CopyTo(raw);
-            writer.Advance(length);
-            return;
-        }
-
-        var attributeBytes = Encoding.UTF8.GetBytes(rootAttributes);
-        var total = length + attributeBytes.Length;
-        var span = writer.GetSpan(total);
-        buffer.AsSpan(0, insertAt).CopyTo(span);
-        attributeBytes.AsSpan().CopyTo(span.Slice(insertAt));
-        buffer.AsSpan(insertAt, length - insertAt).CopyTo(span.Slice(insertAt + attributeBytes.Length));
-        writer.Advance(total);
+        using var stream = new BufferWriterStream(writer);
+        RenderSvg(stream);
     }
 
     /// <summary>
@@ -658,37 +628,34 @@ public class QRCodeImageBuilder
     }
 
     /// <summary>
-    /// Renders the SVG document into a memory buffer and prepares root element attributes
-    /// (<c>viewBox</c>, optional <c>shape-rendering</c>) to insert at <paramref name="insertAt"/>.
+    /// Renders the SVG document to the output stream, injecting root element attributes
+    /// (<c>viewBox</c>, optional <c>shape-rendering</c>) while streaming.
     /// </summary>
     /// <remarks>
     /// <see cref="SKSvgCanvas"/> writes <c>width</c>/<c>height</c> on the root element but no
     /// <c>viewBox</c>. Without a viewBox, an SVG embedded at a different size (img element, CSS)
     /// keeps its content at the original coordinates instead of scaling — the main reason to use
-    /// SVG in the first place. The attributes are inserted right after <c>&lt;svg </c>; if the
-    /// marker is not found (unexpected upstream format change), <paramref name="insertAt"/> is -1
-    /// and the document should be written unpatched.
+    /// SVG in the first place. <see cref="SvgRootAttributeInjectorStream"/> inserts the attributes
+    /// right after the <c>&lt;svg </c> marker while the canvas streams to the output, so the
+    /// document is never buffered as a whole; if the marker is not found (unexpected upstream
+    /// format change), the document passes through unpatched.
     /// </remarks>
-    private MemoryStream RenderSvgDocument(out int insertAt, out string rootAttributes)
+    private void RenderSvg(Stream output)
     {
         var qrCodeData = ResolveQrCodeData();
         var (info, contentRect) = CreateLayout(qrCodeData);
 
-        var document = new MemoryStream();
-        // SKSvgCanvas flushes the SVG document when the canvas is disposed,
-        // so dispose before the buffer is consumed.
-        using (var canvas = SKSvgCanvas.Create(SKRect.Create(0, 0, info.Width, info.Height), document))
+        var viewBox = $"viewBox=\"0 0 {info.Width} {info.Height}\" ";
+        var rootAttributes = UseCrispEdges() ? viewBox + "shape-rendering=\"crispEdges\" " : viewBox;
+
+        using var injector = new SvgRootAttributeInjectorStream(output, rootAttributes);
+        // SKSvgCanvas flushes the SVG document when the canvas is disposed, so dispose
+        // it before the injector (which then flushes any pending header bytes).
+        // The output stream itself stays open.
+        using (var canvas = SKSvgCanvas.Create(SKRect.Create(0, 0, info.Width, info.Height), injector))
         {
             RenderContent(canvas, qrCodeData, info, contentRect);
         }
-
-        var viewBox = $"viewBox=\"0 0 {info.Width} {info.Height}\" ";
-        rootAttributes = UseCrispEdges() ? viewBox + "shape-rendering=\"crispEdges\" " : viewBox;
-
-        ReadOnlySpan<byte> marker = "<svg "u8;
-        var index = document.GetBuffer().AsSpan(0, (int)document.Length).IndexOf(marker);
-        insertAt = index < 0 ? -1 : index + marker.Length;
-        return document;
     }
 
     /// <summary>

--- a/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
+++ b/src/SkiaSharp.QrCode/Image/QRCodeImageBuilder.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Text;
 
 namespace SkiaSharp.QrCode.Image;
 
@@ -207,6 +208,62 @@ public class QRCodeImageBuilder
         new QRCodeImageBuilder(qrCodeData)
             .WithSize(size, size)
             .SaveToSvg(output);
+    }
+
+    /// <summary>
+    /// Generate a QR code as SVG document string with default settings.
+    /// </summary>
+    /// <param name="content">The content to encode.</param>
+    /// <param name="eccLevel">Error correction level. Default is M (15%).</param>
+    /// <param name="size">SVG viewport size in units. Default is 512x512.</param>
+    /// <returns>SVG document.</returns>
+    public static string GetSvgString(string content, ECCLevel eccLevel = ECCLevel.M, int size = 512)
+    {
+        return new QRCodeImageBuilder(content)
+            .WithSize(size, size)
+            .WithErrorCorrection(eccLevel)
+            .ToSvgString();
+    }
+
+    /// <summary>
+    /// Generate a QR code as SVG document string with default settings.
+    /// </summary>
+    /// <param name="qrCodeData">The QR code data to render.</param>
+    /// <param name="size">SVG viewport size in units. Default is 512x512.</param>
+    /// <returns>SVG document.</returns>
+    public static string GetSvgString(QRCodeData qrCodeData, int size = 512)
+    {
+        return new QRCodeImageBuilder(qrCodeData)
+            .WithSize(size, size)
+            .ToSvgString();
+    }
+
+    /// <summary>
+    /// Generate a QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.
+    /// </summary>
+    /// <param name="content">The content to encode.</param>
+    /// <param name="writer">The buffer writer to write to.</param>
+    /// <param name="eccLevel">Error correction level. Default is M (15%).</param>
+    /// <param name="size">SVG viewport size in units. Default is 512x512.</param>
+    public static void WriteSvg(string content, IBufferWriter<byte> writer, ECCLevel eccLevel = ECCLevel.M, int size = 512)
+    {
+        new QRCodeImageBuilder(content)
+            .WithSize(size, size)
+            .WithErrorCorrection(eccLevel)
+            .SaveToSvg(writer);
+    }
+
+    /// <summary>
+    /// Generate a QR code and write as SVG (UTF-8 encoded) to an IBufferWriter with default settings.
+    /// </summary>
+    /// <param name="qrCodeData">The QR code data to render.</param>
+    /// <param name="writer">The buffer writer to write to.</param>
+    /// <param name="size">SVG viewport size in units. Default is 512x512.</param>
+    public static void WriteSvg(QRCodeData qrCodeData, IBufferWriter<byte> writer, int size = 512)
+    {
+        new QRCodeImageBuilder(qrCodeData)
+            .WithSize(size, size)
+            .SaveToSvg(writer);
     }
 
     /// <summary>
@@ -514,6 +571,12 @@ public class QRCodeImageBuilder
     /// pattern shapes, and icons (icon images are embedded as base64 data URIs).
     /// </para>
     /// <para>
+    /// The root element carries a <c>viewBox</c>, so the document scales its content when
+    /// embedded at a different size (img element, CSS). For plain rectangular modules,
+    /// <c>shape-rendering="crispEdges"</c> is added to avoid antialiasing seams between modules;
+    /// custom shapes keep antialiasing for smooth curves.
+    /// </para>
+    /// <para>
     /// <see cref="WithFormat(SKEncodedImageFormat, int)"/> is ignored — SVG is a vector format,
     /// not an <see cref="SKEncodedImageFormat"/>. Size options (<see cref="WithSize(int, int)"/>,
     /// <see cref="WithModulePixelSize(int)"/>) define the SVG viewport in units.
@@ -530,13 +593,54 @@ public class QRCodeImageBuilder
         if (!output.CanWrite)
             throw new ArgumentException("Output stream must be writable", nameof(output));
 
-        var qrCodeData = ResolveQrCodeData();
-        var (info, contentRect) = CreateLayout(qrCodeData);
+        using var document = RenderSvgDocument(out var insertAt, out var rootAttributes);
+        var buffer = document.GetBuffer();
+        var length = (int)document.Length;
 
-        // SKSvgCanvas flushes the SVG document when the canvas is disposed,
-        // so dispose before the stream is consumed. The stream itself stays open.
-        using var canvas = SKSvgCanvas.Create(SKRect.Create(0, 0, info.Width, info.Height), output);
-        RenderContent(canvas, qrCodeData, info, contentRect);
+        if (insertAt < 0)
+        {
+            output.Write(buffer, 0, length);
+            return;
+        }
+
+        var attributeBytes = Encoding.UTF8.GetBytes(rootAttributes);
+        output.Write(buffer, 0, insertAt);
+        output.Write(attributeBytes, 0, attributeBytes.Length);
+        output.Write(buffer, insertAt, length - insertAt);
+    }
+
+    /// <summary>
+    /// Generate QR code and write as SVG document to an IBufferWriter.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="SaveToSvg(Stream)"/> for rendering behavior.
+    /// </remarks>
+    /// <param name="writer">The buffer writer to write to.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public void SaveToSvg(IBufferWriter<byte> writer)
+    {
+        if (writer is null)
+            throw new ArgumentNullException(nameof(writer));
+
+        using var document = RenderSvgDocument(out var insertAt, out var rootAttributes);
+        var buffer = document.GetBuffer();
+        var length = (int)document.Length;
+
+        if (insertAt < 0)
+        {
+            var raw = writer.GetSpan(length);
+            buffer.AsSpan(0, length).CopyTo(raw);
+            writer.Advance(length);
+            return;
+        }
+
+        var attributeBytes = Encoding.UTF8.GetBytes(rootAttributes);
+        var total = length + attributeBytes.Length;
+        var span = writer.GetSpan(total);
+        buffer.AsSpan(0, insertAt).CopyTo(span);
+        attributeBytes.AsSpan().CopyTo(span.Slice(insertAt));
+        buffer.AsSpan(insertAt, length - insertAt).CopyTo(span.Slice(insertAt + attributeBytes.Length));
+        writer.Advance(total);
     }
 
     /// <summary>
@@ -550,7 +654,56 @@ public class QRCodeImageBuilder
     {
         using var stream = new MemoryStream();
         SaveToSvg(stream);
-        return System.Text.Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
+        return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
+    }
+
+    /// <summary>
+    /// Renders the SVG document into a memory buffer and prepares root element attributes
+    /// (<c>viewBox</c>, optional <c>shape-rendering</c>) to insert at <paramref name="insertAt"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SKSvgCanvas"/> writes <c>width</c>/<c>height</c> on the root element but no
+    /// <c>viewBox</c>. Without a viewBox, an SVG embedded at a different size (img element, CSS)
+    /// keeps its content at the original coordinates instead of scaling — the main reason to use
+    /// SVG in the first place. The attributes are inserted right after <c>&lt;svg </c>; if the
+    /// marker is not found (unexpected upstream format change), <paramref name="insertAt"/> is -1
+    /// and the document should be written unpatched.
+    /// </remarks>
+    private MemoryStream RenderSvgDocument(out int insertAt, out string rootAttributes)
+    {
+        var qrCodeData = ResolveQrCodeData();
+        var (info, contentRect) = CreateLayout(qrCodeData);
+
+        var document = new MemoryStream();
+        // SKSvgCanvas flushes the SVG document when the canvas is disposed,
+        // so dispose before the buffer is consumed.
+        using (var canvas = SKSvgCanvas.Create(SKRect.Create(0, 0, info.Width, info.Height), document))
+        {
+            RenderContent(canvas, qrCodeData, info, contentRect);
+        }
+
+        var viewBox = $"viewBox=\"0 0 {info.Width} {info.Height}\" ";
+        rootAttributes = UseCrispEdges() ? viewBox + "shape-rendering=\"crispEdges\" " : viewBox;
+
+        ReadOnlySpan<byte> marker = "<svg "u8;
+        var index = document.GetBuffer().AsSpan(0, (int)document.Length).IndexOf(marker);
+        insertAt = index < 0 ? -1 : index + marker.Length;
+        return document;
+    }
+
+    /// <summary>
+    /// Antialiasing between adjacent vector shapes produces visible hairline seams when the SVG
+    /// is scaled to non-integer sizes. For plain rectangular modules crispEdges removes the seams;
+    /// for custom shapes (circles, rounded rects, custom finder patterns or icons) antialiasing
+    /// is kept for smooth curves. Built-in icon shapes only draw rectangles, bitmaps, and text,
+    /// none of which degrade under crispEdges.
+    /// </summary>
+    private bool UseCrispEdges()
+    {
+        return (_moduleShape is null || _moduleShape is RectangleModuleShape)
+            && _moduleSizePercent == 1.0f
+            && _finderPatternShape is null
+            && (_iconData?.Icon is null or ImageIconShape or ImageTextIconShape);
     }
 
     /// <summary>

--- a/src/SkiaSharp.QrCode/Image/SvgRootAttributeInjectorStream.cs
+++ b/src/SkiaSharp.QrCode/Image/SvgRootAttributeInjectorStream.cs
@@ -1,0 +1,121 @@
+using System.Text;
+
+namespace SkiaSharp.QrCode.Image;
+
+/// <summary>
+/// Write-only stream that forwards to an inner stream, injecting extra root element
+/// attributes immediately after the first <c>&lt;svg </c> marker.
+/// </summary>
+/// <remarks>
+/// <see cref="SKSvgCanvas"/> writes <c>width</c>/<c>height</c> on the root element but no
+/// <c>viewBox</c>, and offers no hook to add attributes. Only the document head is buffered,
+/// and only until the marker is complete (it appears within the first bytes of the document);
+/// everything after streams straight through, so the document is never held in memory as a
+/// whole. If the marker does not appear within the first <see cref="MaxHeaderScan"/> bytes
+/// (unexpected upstream format change), the document is forwarded unmodified.
+/// The inner stream is not disposed; dispose this wrapper (after the SVG canvas) to flush
+/// any pending header bytes.
+/// </remarks>
+internal sealed class SvgRootAttributeInjectorStream : Stream
+{
+    // The marker normally completes within the first ~50 bytes (XML declaration + "<svg ").
+    private const int MaxHeaderScan = 512;
+
+    private readonly Stream _inner;
+    private byte[]? _attributeBytes;
+    private byte[]? _header;
+    private int _headerLength;
+
+    public SvgRootAttributeInjectorStream(Stream inner, string rootAttributes)
+    {
+        _inner = inner;
+        _attributeBytes = Encoding.UTF8.GetBytes(rootAttributes);
+    }
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        // Injection already happened (or was abandoned): pure passthrough.
+        if (_attributeBytes is null)
+        {
+            _inner.Write(buffer, offset, count);
+            return;
+        }
+
+        // Accumulate into the header window; a write may split the marker at any
+        // position, so the search always runs over the accumulated prefix.
+        _header ??= new byte[MaxHeaderScan];
+        while (count > 0)
+        {
+            var copyable = Math.Min(count, _header.Length - _headerLength);
+            Buffer.BlockCopy(buffer, offset, _header, _headerLength, copyable);
+            _headerLength += copyable;
+            offset += copyable;
+            count -= copyable;
+
+            var index = _header.AsSpan(0, _headerLength).IndexOf("<svg "u8);
+            if (index >= 0)
+            {
+                var insertAt = index + 5;
+                _inner.Write(_header, 0, insertAt);
+                _inner.Write(_attributeBytes, 0, _attributeBytes.Length);
+                _inner.Write(_header, insertAt, _headerLength - insertAt);
+                CompleteInjection();
+                break;
+            }
+
+            if (_headerLength == _header.Length)
+            {
+                // No marker within the scan window — forward the document unmodified.
+                _inner.Write(_header, 0, _headerLength);
+                CompleteInjection();
+                break;
+            }
+        }
+
+        if (count > 0)
+        {
+            _inner.Write(buffer, offset, count);
+        }
+    }
+
+    public override void Flush()
+    {
+        // Pending header bytes are intentionally held back: the marker may still
+        // complete in a later write, and flushing them would forfeit the insertion point.
+        _inner.Flush();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && _header is not null && _headerLength > 0)
+        {
+            // The document ended inside the scan window without a marker — forward
+            // it unmodified rather than dropping bytes.
+            _inner.Write(_header, 0, _headerLength);
+            CompleteInjection();
+        }
+        base.Dispose(disposing);
+    }
+
+    private void CompleteInjection()
+    {
+        _attributeBytes = null;
+        _header = null;
+        _headerLength = 0;
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+}

--- a/tests/SkiaSharp.QrCode.Tests/QRCodeImageBuilderSvgTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRCodeImageBuilderSvgTest.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Text;
 using System.Xml.Linq;
 using SkiaSharp.QrCode.Image;
@@ -36,6 +37,122 @@ public class QRCodeImageBuilderSvgTest
     }
 
     [Fact]
+    public void SaveToSvg_RootHasViewBox_SoDocumentScalesWhenEmbedded()
+    {
+        // Without viewBox, an SVG embedded at a different size (img/CSS) keeps its
+        // content at original coordinates instead of scaling.
+        var svg = new QRCodeImageBuilder(TestContent)
+            .WithSize(512, 512)
+            .ToSvgString();
+
+        var doc = XDocument.Parse(svg);
+        Assert.Equal("0 0 512 512", doc.Root!.Attribute("viewBox")?.Value);
+    }
+
+    [Fact]
+    public void SaveToSvg_PlainRectModules_UseCrispEdges()
+    {
+        // Default rect modules get shape-rendering=crispEdges to avoid antialiasing
+        // seams between adjacent modules at non-integer display sizes.
+        var svg = new QRCodeImageBuilder(TestContent)
+            .WithSize(512, 512)
+            .ToSvgString();
+
+        var doc = XDocument.Parse(svg);
+        Assert.Equal("crispEdges", doc.Root!.Attribute("shape-rendering")?.Value);
+    }
+
+    [Fact]
+    public void SaveToSvg_CustomShapes_KeepAntialiasing()
+    {
+        // Curved shapes need antialiasing; crispEdges would render them jagged.
+        var svg = new QRCodeImageBuilder(TestContent)
+            .WithSize(512, 512)
+            .WithModuleShape(CircleModuleShape.Default, sizePercent: 0.9f)
+            .ToSvgString();
+
+        var doc = XDocument.Parse(svg);
+        Assert.Null(doc.Root!.Attribute("shape-rendering"));
+        Assert.NotNull(doc.Root.Attribute("viewBox"));
+    }
+
+    [Fact]
+    public void SaveToSvg_CustomFinderPattern_KeepsAntialiasing()
+    {
+        var svg = new QRCodeImageBuilder(TestContent)
+            .WithSize(512, 512)
+            .WithFinderPatternShape(RoundedRectangleFinderPatternShape.Default)
+            .ToSvgString();
+
+        var doc = XDocument.Parse(svg);
+        Assert.Null(doc.Root!.Attribute("shape-rendering"));
+    }
+
+    [Fact]
+    public void SaveToSvg_BuiltInIconShape_UsesCrispEdges()
+    {
+        // Built-in icon shapes draw rectangles, bitmaps, and text only, none of
+        // which degrade under crispEdges — the QR modules stay seam-free.
+        using var bitmap = new SKBitmap(32, 32);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Red);
+        }
+        var icon = IconData.FromImage(bitmap, iconSizePercent: 15, iconBorderWidth: 4);
+
+        var svg = new QRCodeImageBuilder(TestContent)
+            .WithSize(512, 512)
+            .WithErrorCorrection(ECCLevel.H)
+            .WithIcon(icon)
+            .ToSvgString();
+
+        var doc = XDocument.Parse(svg);
+        Assert.Equal("crispEdges", doc.Root!.Attribute("shape-rendering")?.Value);
+    }
+
+    [Fact]
+    public void SaveToSvg_BufferWriter_MatchesStreamOutput()
+    {
+        var builder = new QRCodeImageBuilder(TestContent).WithSize(256, 256);
+
+        using var stream = new MemoryStream();
+        builder.SaveToSvg(stream);
+
+        var writer = new ArrayBufferWriter<byte>();
+        builder.SaveToSvg(writer);
+
+        Assert.Equal(stream.ToArray(), writer.WrittenSpan.ToArray());
+    }
+
+    [Fact]
+    public void SaveToSvg_BufferWriter_Null_Throws()
+    {
+        var builder = new QRCodeImageBuilder(TestContent).WithSize(256, 256);
+
+        Assert.Throws<ArgumentNullException>(() => builder.SaveToSvg((IBufferWriter<byte>)null!));
+    }
+
+    [Fact]
+    public void GetSvgString_Content_MatchesToSvgString()
+    {
+        var expected = new QRCodeImageBuilder(TestContent)
+            .WithSize(512, 512)
+            .WithErrorCorrection(ECCLevel.H)
+            .ToSvgString();
+
+        Assert.Equal(expected, QRCodeImageBuilder.GetSvgString(TestContent, ECCLevel.H, size: 512));
+    }
+
+    [Fact]
+    public void WriteSvg_Content_MatchesGetSvgBytes()
+    {
+        var writer = new ArrayBufferWriter<byte>();
+        QRCodeImageBuilder.WriteSvg(TestContent, writer, ECCLevel.M, size: 256);
+
+        Assert.Equal(QRCodeImageBuilder.GetSvgBytes(TestContent, ECCLevel.M, size: 256), writer.WrittenSpan.ToArray());
+    }
+
+    [Fact]
     public void SaveToSvg_LeavesStreamOpen()
     {
         using var stream = new MemoryStream();
@@ -52,7 +169,7 @@ public class QRCodeImageBuilderSvgTest
     {
         var builder = new QRCodeImageBuilder(TestContent).WithSize(256, 256);
 
-        Assert.Throws<ArgumentNullException>(() => builder.SaveToSvg(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.SaveToSvg((Stream)null!));
 
         using var readOnly = new MemoryStream([0x00], writable: false);
         Assert.Throws<ArgumentException>(() => builder.SaveToSvg(readOnly));

--- a/tests/SkiaSharp.QrCode.Tests/QRCodeImageBuilderSvgTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/QRCodeImageBuilderSvgTest.cs
@@ -133,6 +133,100 @@ public class QRCodeImageBuilderSvgTest
     }
 
     [Fact]
+    public void SaveToSvg_SegmentedBufferWriter_NeverRequestsOversizedSpan()
+    {
+        // Segmented writers (e.g. PipeWriter) cannot serve a GetSpan sized to the whole
+        // document. This writer caps every request at 64 bytes and throws on larger
+        // hints, pinning that SVG output is written in segments.
+        var builder = new QRCodeImageBuilder(TestContent)
+            .WithSize(256, 256)
+            .WithGradient(new GradientOptions([SKColors.Blue, SKColors.Purple], GradientDirection.TopLeftToBottomRight));
+
+        using var expected = new MemoryStream();
+        builder.SaveToSvg(expected);
+
+        var writer = new SegmentCappedBufferWriter(maxSegmentSize: 64);
+        builder.SaveToSvg(writer);
+
+        Assert.Equal(expected.ToArray(), writer.WrittenBytes);
+    }
+
+    [Fact]
+    public void SvgInjector_SingleByteWrites_InjectsAttributesOnce()
+    {
+        // A write may split the "<svg " marker at any position; the injector must
+        // still find it and insert the attributes exactly once.
+        var document = "<?xml version=\"1.0\" ?>\n<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"8\"><rect/></svg>";
+        var payload = Encoding.UTF8.GetBytes(document);
+
+        using var output = new MemoryStream();
+        using (var injector = new SvgRootAttributeInjectorStream(output, "viewBox=\"0 0 8 8\" "))
+        {
+            foreach (var b in payload)
+            {
+                injector.Write([b], 0, 1);
+            }
+        }
+
+        var result = Encoding.UTF8.GetString(output.ToArray());
+        Assert.Equal(document.Replace("<svg ", "<svg viewBox=\"0 0 8 8\" "), result);
+    }
+
+    [Fact]
+    public void SvgInjector_NoMarkerInLargeDocument_PassesThroughUnmodified()
+    {
+        // Marker absent beyond the scan window: the document must pass through unpatched.
+        var payload = Encoding.UTF8.GetBytes(new string('x', 2048));
+
+        using var output = new MemoryStream();
+        using (var injector = new SvgRootAttributeInjectorStream(output, "viewBox=\"0 0 8 8\" "))
+        {
+            injector.Write(payload, 0, payload.Length);
+        }
+
+        Assert.Equal(payload, output.ToArray());
+    }
+
+    [Fact]
+    public void SvgInjector_NoMarkerInTinyDocument_FlushesOnDispose()
+    {
+        // A document that ends inside the scan window without a marker must still be
+        // written out (on dispose), not silently dropped.
+        var payload = Encoding.UTF8.GetBytes("tiny");
+
+        using var output = new MemoryStream();
+        using (var injector = new SvgRootAttributeInjectorStream(output, "viewBox=\"0 0 8 8\" "))
+        {
+            injector.Write(payload, 0, payload.Length);
+        }
+
+        Assert.Equal(payload, output.ToArray());
+    }
+
+    /// <summary>
+    /// IBufferWriter that refuses size hints above a small cap, simulating a segmented
+    /// writer (PipeWriter) that cannot provide one contiguous buffer for a whole document.
+    /// </summary>
+    private sealed class SegmentCappedBufferWriter(int maxSegmentSize) : IBufferWriter<byte>
+    {
+        private readonly MemoryStream _written = new();
+        private readonly byte[] _segment = new byte[maxSegmentSize];
+
+        public byte[] WrittenBytes => _written.ToArray();
+
+        public void Advance(int count) => _written.Write(_segment, 0, count);
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            if (sizeHint > _segment.Length)
+                throw new InvalidOperationException($"Oversized buffer request: {sizeHint} > {_segment.Length}.");
+            return _segment;
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0) => GetMemory(sizeHint).Span;
+    }
+
+    [Fact]
     public void GetSvgString_Content_MatchesToSvgString()
     {
         var expected = new QRCodeImageBuilder(TestContent)


### PR DESCRIPTION
## Summary

Follow-up to the initial SVG support (#329): fix two rendering issues that hurt real-world SVG usage, round out the SVG API surface, add SVG download to the browser playground, and fix README examples that referenced a non-existent API.

## Intent

The initial SVG output had a practical flaw: `SKSvgCanvas` emits `width`/`height` but **no `viewBox`**, so the QR code did not scale its content when embedded at a different size (`<img>`, CSS) — defeating the main reason to use SVG. Antialiasing between adjacent modules also produced hairline seams at non-integer display sizes. Both are fixed at the root element, and the API gaps found while dogfooding (string output for inline HTML embedding, `IBufferWriter` parity with PNG) are filled.

## Changes

### SVG rendering fixes

- Root element always carries `viewBox="0 0 w h"` — content now scales with the viewport
- `shape-rendering="crispEdges"` is added for plain rectangular modules (no AA seams); custom shapes (circles, rounded rects, custom finder patterns) keep antialiasing for smooth curves
- Attributes are injected **while streaming** via an internal `Stream` wrapper that buffers only the document head until the `<svg ` marker is found (≤512 bytes); the document is never buffered as a whole. If the marker is absent (upstream format change), output passes through unmodified

### New public APIs

- `GetSvgString(content | qrCodeData)` — one-liner SVG document string, e.g. for inline HTML embedding
- `WriteSvg(content | qrCodeData, IBufferWriter<byte>)` and instance `SaveToSvg(IBufferWriter<byte>)` — parity with the PNG `WritePng`/`SaveTo` family
- `IBufferWriter` paths (SVG and PNG) write in writer-provided segments — no single contiguous `GetSpan` request for the whole payload, so segmented writers like `PipeWriter` are safe

### Playground

- **Download SVG** button next to Download PNG; SVG is rendered on demand via a new `GenerateSvg` JS export with the same options/error-envelope conventions as PNG generation

### Docs

- README: SVG usage section (viewBox/crispEdges behavior, output size guidance), ASP.NET Core `/qr.svg` endpoint example
- README: fixed Quick Start examples that used a non-existent `SavePng(content, "path")` overload — now `File.WriteAllBytes(path, GetPngBytes(content))` / `File.WriteAllText(path, GetSvgString(content))`. We deliberately did not add file-path overloads: the BCL idiom is already a one-liner, and keeping byte/string/stream as the output primitives avoids growing the static facade and taking on file-semantics responsibilities

## Tests

- SVG structural tests extended (viewBox presence, crispEdges on/off conditions, byte-for-byte parity between `Stream` and `IBufferWriter` output, determinism)
- Injector unit tests: marker split across single-byte writes, marker-absent passthrough (large and tiny documents), segmented-writer test that rejects oversized buffer requests
- Full suite green on net8.0/net10.0, Debug/Release; playground verified end-to-end in a browser (WASM publish)
