### PR TITLE
feat: improve FinderPatternFinder performance by Simd

### DIFF
--- a/.github/docs/specs/qrcode-decoder.md
+++ b/.github/docs/specs/qrcode-decoder.md
@@ -174,3 +174,18 @@ Kanji mode, FNC1, Structured Append, other ECI charsets.
   ⌊moduleSize/2⌋ row stride (the vertical cross-check recenters exactly, so striding
   is result-identical) — 23x on the not-found sweep, scalar fallback elsewhere
   (`MICRO_OPTIMIZATION_AlignmentFind` in the MicroBenchmarks repository).
+- The finder scan reuses the same SIMD mask-walk kernel shape, but its row stride
+  cannot come from the module size — the module size is unknown before detection.
+  The bound comes from the worst case instead: the 1:1:3:1:1 band is 3 modules tall
+  and a version-40 symbol filling the frame has the smallest possible modules, so
+  stride 3·height/(4·177) still hits every supported symbol's band several times.
+  The key trick making striding envelope-safe: a failed stride pass rescans *only
+  the skipped rows*, keeping its candidates — the union covers exactly the rows of
+  a full scan for exactly one sweep of total work, so detection can never regress
+  (a naive full-rescan fallback measured 0.87x, i.e. a regression, in the scalar
+  variant). The best-3 selection before that fallback must run on a copy: it
+  compacts and sorts the candidate list in place. Combined result 9.6-11.4x on the
+  scan, image E2E (`Image_Url_M`) 309 µs → 132 µs (−57%); the SIMD walk alone is
+  bit-identical to the scalar walk and parity-tested
+  (`MICRO_OPTIMIZATION_FinderScan` in the MicroBenchmarks repository). Otsu
+  binarization is now the largest remaining full-image pass.

--- a/src/SkiaSharp.QrCode/Internals/ImageDecoders/FinderPatternFinder.cs
+++ b/src/SkiaSharp.QrCode/Internals/ImageDecoders/FinderPatternFinder.cs
@@ -1,3 +1,10 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+#endif
+
 namespace SkiaSharp.QrCode.Internals.ImageDecoders;
 
 /// <summary>
@@ -20,10 +27,25 @@ internal struct FinderPattern
 /// it as a candidate (the standard ZXing-style detection approach). Designed for
 /// Tier-1 inputs — clean, well-lit, screen-rendered or scanned images with mild
 /// rotation — not for low-contrast photos.
+/// <para>
+/// The scan strides over rows: the band of rows showing the 1:1:3:1:1 signature
+/// is 3 modules tall, and although the module size is unknown before detection,
+/// the worst case (a version-40 symbol filling the frame) bounds it from below,
+/// so a stride of 3·height/(4·177) still hits the band of every supported symbol
+/// several times. When the stride pass finds nothing, the rows it skipped are
+/// scanned as a complementary pass — together exactly one full-image sweep, so
+/// striding can never lose a symbol a full scan would find. On net8.0+ each row
+/// is classified into a dark bitmask with SIMD compares and walked run-by-run
+/// via trailing-zero counts instead of pixel-by-pixel (measured ~11x combined
+/// on the found path; see the FinderScan findings log in MicroBenchmarks).
+/// </para>
 /// </remarks>
 internal static class FinderPatternFinder
 {
     private const int MaxCandidates = 32;
+
+    /// <summary>Version 40, the largest supported symbol, is 177 modules wide.</summary>
+    private const int MaxSymbolModules = 177;
 
     /// <summary>
     /// Searches the image for finder patterns and returns the best three.
@@ -35,85 +57,263 @@ internal static class FinderPatternFinder
     /// <param name="patterns">Receives the three finder patterns (top-left first is NOT guaranteed).</param>
     /// <returns>True when at least three mutually consistent finder patterns were found.</returns>
     public static bool TryFind(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, Span<FinderPattern> patterns)
+        => TryFindCore(luminance, width, height, threshold, forceScalar: false, patterns);
+
+    /// <summary>Scalar-kernel entry for parity tests; behavior-identical to <see cref="TryFind"/>.</summary>
+    internal static bool TryFindScalar(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, Span<FinderPattern> patterns)
+        => TryFindCore(luminance, width, height, threshold, forceScalar: true, patterns);
+
+    private static bool TryFindCore(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, bool forceScalar, Span<FinderPattern> patterns)
     {
+        // Row stride bound: a v40 symbol filling the frame has module size
+        // height/177, so its 3-module center band is 3·height/177 px tall and a
+        // stride of a quarter of that hits it ≥ 4 times (≥ 2 when the symbol
+        // occupies half the frame) — enough for the Count-based confirmation in
+        // TrySelectBestThree. Smaller strides than 3 don't pay for themselves.
+        var stride = Math.Max(3, 3 * height / (4 * MaxSymbolModules));
+
         Span<FinderPattern> candidates = stackalloc FinderPattern[MaxCandidates];
         var candidateCount = 0;
 
-        Span<int> runs = stackalloc int[5];
-
-        for (var y = 0; y < height; y++)
+        for (var y = 0; y < height; y += stride)
         {
-            var row = luminance.Slice(y * width, width);
-            runs.Clear();
-            var runIndex = 0;
-            var currentDark = false;
+            ScanRow(luminance, width, height, threshold, y, forceScalar, candidates, ref candidateCount);
+        }
 
-            for (var x = 0; x < width; x++)
+        if (stride > 1)
+        {
+            // Select on a copy: TrySelectBestThree compacts and sorts in place,
+            // and a failed selection must leave the list intact for the rescan.
+            Span<FinderPattern> scratch = stackalloc FinderPattern[MaxCandidates];
+            candidates.Slice(0, candidateCount).CopyTo(scratch);
+            if (TrySelectBestThree(scratch.Slice(0, candidateCount), patterns))
+                return true;
+
+            // Complementary rescan: only the rows the stride pass skipped, keeping
+            // its candidates. Covers exactly the rows of a full scan, so the
+            // detection envelope cannot regress; costs one full sweep in total.
+            for (var baseY = 0; baseY < height; baseY += stride)
             {
-                var dark = row[x] < threshold;
-                if (x == 0)
+                var limit = Math.Min(baseY + stride, height);
+                for (var y = baseY + 1; y < limit; y++)
                 {
-                    currentDark = dark;
-                    runs[0] = 1;
-                    runIndex = 0;
-                    // A pattern window must start with a dark run
-                    if (!dark)
-                        runIndex = -1;
-                    continue;
+                    ScanRow(luminance, width, height, threshold, y, forceScalar, candidates, ref candidateCount);
                 }
-
-                if (dark == currentDark)
-                {
-                    if (runIndex >= 0)
-                        runs[runIndex]++;
-                    continue;
-                }
-
-                // Color flipped: advance the run window
-                currentDark = dark;
-                if (runIndex < 0)
-                {
-                    // Waiting for the first dark run
-                    if (dark)
-                    {
-                        runIndex = 0;
-                        runs[0] = 1;
-                    }
-                    continue;
-                }
-
-                if (runIndex < 4)
-                {
-                    runIndex++;
-                    runs[runIndex] = 1;
-                    continue;
-                }
-
-                // Window full (5 runs) and a new dark run begins: evaluate, then shift
-                if (IsFinderRatio(runs))
-                {
-                    TryAddCandidate(luminance, width, height, threshold, runs, x, y, candidates, ref candidateCount);
-                }
-
-                // Shift out the oldest dark/light pair; the window still starts
-                // with a dark run and the incoming light run continues at index 3.
-                runs[0] = runs[2];
-                runs[1] = runs[3];
-                runs[2] = runs[4];
-                runs[3] = 1;
-                runs[4] = 0;
-                runIndex = 3;
-            }
-
-            // End of row: evaluate a complete trailing window
-            if (runIndex == 4 && IsFinderRatio(runs))
-            {
-                TryAddCandidate(luminance, width, height, threshold, runs, width, y, candidates, ref candidateCount);
             }
         }
 
         return TrySelectBestThree(candidates.Slice(0, candidateCount), patterns);
     }
+
+    private static void ScanRow(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, int y, bool forceScalar, Span<FinderPattern> candidates, ref int candidateCount)
+    {
+#if NET8_0_OR_GREATER
+        // SIMD path: classify 32 pixels per compare into a dark bitmask, then walk
+        // RUNS via tzcnt instead of pixels — result bit-identical to the scalar walk.
+        if (!forceScalar && Vector256.IsHardwareAccelerated && width >= 32)
+        {
+            ScanRowMask(luminance, width, height, threshold, y, candidates, ref candidateCount);
+            return;
+        }
+#endif
+        _ = forceScalar;
+        ScanRowScalar(luminance, width, height, threshold, y, candidates, ref candidateCount);
+    }
+
+    private static void ScanRowScalar(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, int y, Span<FinderPattern> candidates, ref int candidateCount)
+    {
+        Span<int> runs = stackalloc int[5];
+        var row = luminance.Slice(y * width, width);
+        var runIndex = 0;
+        var currentDark = false;
+
+        for (var x = 0; x < width; x++)
+        {
+            var dark = row[x] < threshold;
+            if (x == 0)
+            {
+                currentDark = dark;
+                runs[0] = 1;
+                runIndex = 0;
+                // A pattern window must start with a dark run
+                if (!dark)
+                    runIndex = -1;
+                continue;
+            }
+
+            if (dark == currentDark)
+            {
+                if (runIndex >= 0)
+                    runs[runIndex]++;
+                continue;
+            }
+
+            // Color flipped: advance the run window
+            currentDark = dark;
+            if (runIndex < 0)
+            {
+                // Waiting for the first dark run
+                if (dark)
+                {
+                    runIndex = 0;
+                    runs[0] = 1;
+                }
+                continue;
+            }
+
+            if (runIndex < 4)
+            {
+                runIndex++;
+                runs[runIndex] = 1;
+                continue;
+            }
+
+            // Window full (5 runs) and the 5th (dark) run just completed: evaluate,
+            // then shift out the oldest dark/light pair; the window still starts
+            // with a dark run and the incoming light run continues at index 3.
+            if (IsFinderRatio(runs))
+            {
+                TryAddCandidate(luminance, width, height, threshold, runs, x, y, candidates, ref candidateCount);
+            }
+
+            // Shift out the oldest dark/light pair; the window still starts
+            // with a dark run and the incoming light run continues at index 3.
+            runs[0] = runs[2];
+            runs[1] = runs[3];
+            runs[2] = runs[4];
+            runs[3] = 1;
+            runs[4] = 0;
+            runIndex = 3;
+        }
+
+        // End of row: evaluate a complete trailing window
+        if (runIndex == 4 && IsFinderRatio(runs))
+        {
+            TryAddCandidate(luminance, width, height, threshold, runs, width, y, candidates, ref candidateCount);
+        }
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Mask-based row scan: 32 pixels per vector compare produce a dark bitmask;
+    /// runs are walked via trailing-zero counts. The 1:1:3:1:1 window is evaluated
+    /// at the end of every dark run from the third onward — exactly the positions
+    /// and order the scalar walk evaluates, so the result is bit-identical.
+    /// </summary>
+    private static void ScanRowMask(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, int y, Span<FinderPattern> candidates, ref int candidateCount)
+    {
+        // The mask covers a full row; keep the common case on the stack (512 B
+        // covers rows up to ~4000 px) and rent for wider images.
+        var maskLength = ((width + 63) >> 6) + 1;
+        ulong[]? rented = maskLength > 64 ? ArrayPool<ulong>.Shared.Rent(maskLength) : null;
+        Span<ulong> mask = rented is null ? stackalloc ulong[64] : rented;
+        mask = mask.Slice(0, maskLength);
+        mask.Clear();
+
+        try
+        {
+            // Build the dark bitmask (bit i = pixel i of this row is dark)
+            var row = luminance.Slice(y * width, width);
+            var i = 0;
+            if (threshold > 0)
+            {
+                // unsigned v < t ⟺ min(v, t-1) == v; threshold == 0 means nothing is dark
+                var thresholdMinus1 = Vector256.Create((byte)(threshold - 1));
+                ref var rowRef = ref MemoryMarshal.GetReference(row);
+                for (; i + 32 <= width; i += 32)
+                {
+                    var v = Vector256.LoadUnsafe(ref rowRef, (nuint)i);
+                    var dark = Vector256.Equals(Vector256.Min(v, thresholdMinus1), v);
+                    mask[i >> 6] |= (ulong)dark.ExtractMostSignificantBits() << (i & 63);
+                }
+            }
+            for (; i < width; i++)
+            {
+                if (row[i] < threshold)
+                    mask[i >> 6] |= 1ul << (i & 63);
+            }
+
+            // Walk dark runs. The scalar window is [dark, light, dark, light, dark],
+            // evaluated whenever its 5th run (a dark run) completes — at its
+            // dark→light transition or at the end of the row. That is: at the end
+            // of every dark run from the third onward, with the window being that
+            // run plus the two dark runs (and light gaps) before it.
+            var darkStart = NextBit(mask, 0, width, set: true);
+            var dPrev2 = 0; // dark run k-2
+            var gPrev1 = 0; // light gap between k-2 and k-1
+            var dPrev1 = 0; // dark run k-1
+            var gCur = 0;   // light gap between k-1 and k
+            var darkRuns = 0;
+
+            Span<int> runs = stackalloc int[5];
+            while (darkStart < width)
+            {
+                var darkEnd = NextBit(mask, darkStart, width, set: false);
+                var dCur = darkEnd - darkStart;
+
+                if (darkRuns >= 2 && IsFinderRatio(dPrev2, gPrev1, dPrev1, gCur, dCur))
+                {
+                    runs[0] = dPrev2;
+                    runs[1] = gPrev1;
+                    runs[2] = dPrev1;
+                    runs[3] = gCur;
+                    runs[4] = dCur;
+                    TryAddCandidate(luminance, width, height, threshold, runs, darkEnd, y, candidates, ref candidateCount);
+                }
+
+                var nextDark = NextBit(mask, darkEnd, width, set: true);
+                dPrev2 = dPrev1;
+                gPrev1 = gCur;
+                dPrev1 = dCur;
+                gCur = nextDark - darkEnd;
+                darkRuns++;
+                darkStart = nextDark;
+            }
+        }
+        finally
+        {
+            if (rented is not null)
+                ArrayPool<ulong>.Shared.Return(rented);
+        }
+    }
+
+    /// <summary>Int-argument twin of the span <see cref="IsFinderRatio(ReadOnlySpan{int})"/> with identical float math.</summary>
+    private static bool IsFinderRatio(int r0, int r1, int r2, int r3, int r4)
+    {
+        // Runs from the mask walk are never zero (a gap between two dark runs is
+        // at least one light pixel); the total check mirrors the span version.
+        var total = r0 + r1 + r2 + r3 + r4;
+        if (total < 7)
+            return false;
+
+        var moduleSize = total / 7f;
+        var maxVariance = moduleSize / 2f;
+        return Math.Abs(moduleSize - r0) < maxVariance
+            && Math.Abs(moduleSize - r1) < maxVariance
+            && Math.Abs(3f * moduleSize - r2) < 3f * maxVariance
+            && Math.Abs(moduleSize - r3) < maxVariance
+            && Math.Abs(moduleSize - r4) < maxVariance;
+    }
+
+    /// <summary>Index of the next set (or clear) bit at or after <paramref name="from"/>, or <paramref name="length"/>.</summary>
+    private static int NextBit(ReadOnlySpan<ulong> mask, int from, int length, bool set)
+    {
+        while (from < length)
+        {
+            var word = mask[from >> 6];
+            if (!set)
+                word = ~word;
+            word &= ulong.MaxValue << (from & 63);
+            if (word != 0)
+            {
+                var index = (from & ~63) + BitOperations.TrailingZeroCount(word);
+                return Math.Min(index, length);
+            }
+            from = (from & ~63) + 64;
+        }
+        return length;
+    }
+#endif
 
     /// <summary>
     /// Checks the 1:1:3:1:1 ratio with 50% per-module tolerance.
@@ -217,8 +417,6 @@ internal static class FinderPatternFinder
             runs[0]++;
             i--;
         }
-
-        var start = i;
 
         i = center + 1;
         while (i < limit && IsDark(luminance, width, vertical ? centerX : i, vertical ? i : centerY, threshold))

--- a/tests/SkiaSharp.QrCode.Tests/FinderPatternFinderParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/FinderPatternFinderParityTest.cs
@@ -1,0 +1,136 @@
+using SkiaSharp.QrCode.Internals.ImageDecoders;
+using Xunit;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// Parity test for the finder-pattern row-scan kernels: the SIMD mask walk
+/// (net8.0+, AVX2) evaluates the 1:1:3:1:1 window at exactly the positions the
+/// scalar walk does, so <see cref="FinderPatternFinder.TryFind"/> and
+/// <see cref="FinderPatternFinder.TryFindScalar"/> must agree bit-for-bit —
+/// found flag, centers and module sizes — across synthetic QR-like scenes
+/// (finder patterns + timing lines + random data modules, 3/2/0 patterns).
+/// </summary>
+public class FinderPatternFinderParityTest
+{
+    private const byte Threshold = 128;
+
+    [Fact]
+    public void SimdAndScalarKernels_AgreeBitForBit()
+    {
+        // (dimension, ppm, finderCount): both benchmark shapes, a 2-finder scene
+        // (found only if noise fakes a third candidate — kernels must agree either
+        // way), and a no-pattern scene.
+        var configs = new (int Dimension, int Ppm, int FinderCount)[]
+        {
+            (37, 8, 3),
+            (97, 5, 3),
+            (37, 8, 2),
+            (56, 8, 0),
+        };
+
+        foreach (var seed in new[] { 1, 7, 42, 1234, 20260712 })
+        {
+            foreach (var (dimension, ppm, finderCount) in configs)
+            {
+                var scene = BuildQrScene(dimension, ppm, finderCount, seed, out var width, out var height);
+
+                Span<FinderPattern> simd = stackalloc FinderPattern[3];
+                Span<FinderPattern> scalar = stackalloc FinderPattern[3];
+                var simdFound = FinderPatternFinder.TryFind(scene, width, height, Threshold, simd);
+                var scalarFound = FinderPatternFinder.TryFindScalar(scene, width, height, Threshold, scalar);
+
+                Assert.True(simdFound == scalarFound, $"found mismatch (seed={seed}, dim={dimension}, finders={finderCount}): simd={simdFound}, scalar={scalarFound}");
+                if (simdFound)
+                {
+                    for (var i = 0; i < 3; i++)
+                    {
+                        Assert.True(
+                            simd[i].X == scalar[i].X && simd[i].Y == scalar[i].Y && simd[i].ModuleSize == scalar[i].ModuleSize,
+                            $"pattern {i} mismatch (seed={seed}, dim={dimension}): simd=({simd[i].X},{simd[i].Y},{simd[i].ModuleSize}), scalar=({scalar[i].X},{scalar[i].Y},{scalar[i].ModuleSize})");
+                    }
+                }
+
+                if (finderCount == 3)
+                {
+                    Assert.True(scalarFound, $"3-finder scene not detected (seed={seed}, dim={dimension}) — scene generator or finder broken");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// QR-like scene: quiet zone, up to three 7×7 finder patterns (dark border,
+    /// light ring, dark center) with light separators, timing lines, and ~45%
+    /// random dark data modules elsewhere.
+    /// </summary>
+    private static byte[] BuildQrScene(int dimension, int ppm, int finderCount, int seed, out int width, out int height)
+    {
+        const int Quiet = 4;
+        var totalModules = dimension + 2 * Quiet;
+        width = totalModules * ppm;
+        height = totalModules * ppm;
+        var scene = new byte[width * height];
+        scene.AsSpan().Fill(255);
+
+        // Finder pattern top-left corners in symbol module coordinates
+        var corners = new (int X, int Y)[] { (0, 0), (dimension - 7, 0), (0, dimension - 7) };
+
+        var random = new Random(seed);
+        for (var my = 0; my < dimension; my++)
+        {
+            for (var mx = 0; mx < dimension; mx++)
+            {
+                // Reserved: finder zones + their 1-module separators (light)
+                var reserved = false;
+                for (var f = 0; f < finderCount; f++)
+                {
+                    if (mx >= corners[f].X - 1 && mx <= corners[f].X + 7 && my >= corners[f].Y - 1 && my <= corners[f].Y + 7)
+                    {
+                        reserved = true;
+                        break;
+                    }
+                }
+                if (reserved)
+                    continue;
+
+                if (finderCount > 0 && (my == 6 || mx == 6))
+                {
+                    // Timing lines: alternating, dark on even module index
+                    if ((mx + my) % 2 == 0)
+                        FillModule(scene, width, ppm, Quiet + mx, Quiet + my, 0);
+                }
+                else if (random.Next(100) < 45)
+                {
+                    FillModule(scene, width, ppm, Quiet + mx, Quiet + my, 0);
+                }
+            }
+        }
+
+        for (var f = 0; f < finderCount; f++)
+        {
+            for (var dy = 0; dy < 7; dy++)
+            {
+                for (var dx = 0; dx < 7; dx++)
+                {
+                    // dark border (ring 3), light ring (ring 2), dark 3×3 center
+                    var ring = Math.Max(Math.Abs(dx - 3), Math.Abs(dy - 3));
+                    if (ring != 2)
+                    {
+                        FillModule(scene, width, ppm, Quiet + corners[f].X + dx, Quiet + corners[f].Y + dy, 0);
+                    }
+                }
+            }
+        }
+
+        return scene;
+    }
+
+    private static void FillModule(byte[] scene, int width, int ppm, int moduleX, int moduleY, byte value)
+    {
+        for (var y = moduleY * ppm; y < (moduleY + 1) * ppm; y++)
+        {
+            scene.AsSpan(y * width + moduleX * ppm, ppm).Fill(value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Speed up the QR finder-pattern scan (`FinderPatternFinder.TryFind`) — the last remaining scalar full-image pass in the image decode pipeline — with a row-stride scan and a SIMD dark-mask run walk (net8.0+, AVX2). Image-level decode E2E is **2.35x faster (−57%)** with zero allocations, and the detection envelope is fully preserved.

## Intent

After the previous rounds of decode optimization (GFNI syndromes, SIMD perspective sampling, SIMD alignment search), the finder scan dominated the image decode cost: it walked every pixel of every row with a branchy run-length state machine. This PR applies the same proven kernel shape used for the alignment-pattern search, adapted to the finder's constraint that **the module size is unknown before detection**:

- **Row stride from the worst case, not the module size.** The 1:1:3:1:1 band of a finder pattern is 3 modules tall. A version-40 symbol (177 modules) filling the frame bounds the module size from below, so `stride = max(3, 3·H/(4·177))` still hits the band of every supported symbol ≥ 4 times full-frame (≥ 2 at half-frame), keeping the multi-row confirmation logic intact.
- **Complementary rescan makes striding envelope-safe.** If the stride pass finds nothing, only the rows it *skipped* are scanned, keeping its candidates. The union covers exactly the rows of a full scan for exactly one sweep of total work — striding can never lose a symbol a full scan would find, and the not-found path (non-QR images, inverted-polarity retry) gets no penalty.
- **SIMD dark-mask run walk (net8.0+).** Each row is classified into a dark bitmask (32 px per AVX2 compare) and walked run-by-run via trailing-zero counts instead of pixel-by-pixel. The 1:1:3:1:1 window is evaluated at exactly the positions and order of the scalar walk, so the result is **bit-identical**.

## Expected behavior

- **No API or behavioral change.** `TryFind` keeps its signature; detection results are identical (SIMD vs scalar kernels are bit-identical; the stride+rescan algorithm covers the same rows as the previous full scan).
- netstandard2.0/2.1 and non-AVX2 hardware use the scalar row kernel with the same stride algorithm.
- Zero heap allocation in steady state (row mask is stack-allocated up to ~4000 px wide rows, `ArrayPool` beyond).
- New `FinderPatternFinderParityTest` asserts exact SIMD/scalar equality across seeded QR-like scenes; full test suite passes (net8.0: 1159, net10.0: 1171).

## Benchmarks

Ryzen 9 7950X3D, .NET 10.0.9, X64 RyuJIT (AVX-512), Windows 11.

### Finder scan kernel (micro-benchmark, 15 iterations)

| Scenario | Before | After | Speedup |
|---|---:|---:|---:|
| v5 symbol, 360 px (found) | 216.4 µs | 19.0 µs | **11.4x** |
| v20 symbol, 525 px (found) | 453.8 µs | 47.1 µs | **9.6x** |
| no QR present, 512 px (full sweep) | 488.6 µs | 73.4 µs | **6.7x** |

All variants allocation-free. A naive full-rescan fallback measured as a *regression* (0.87x) on the not-found path in the scalar variant — the complementary rescan is what makes the stride safe *and* fast.

### Decode E2E (`QrCodeDecodeEndToEnd`)

| Scenario | Before | After | Change |
|---|---:|---:|---:|
| Image_Url_M (render → binarize → detect → sample → decode) | 309.0 µs | 131.5 µs | **2.35x (−57%)** |
| Matrix_Short_M | 1.06 µs | 1.06 µs | unchanged |
| Matrix_Url_M | 5.93 µs | 5.93 µs | unchanged |
| Matrix_Long_L | 134.7 µs | 134.7 µs | unchanged |
| Matrix_Long_H | 152.1 µs | 152.1 µs | unchanged |

Matrix-level scenarios don't touch the image pipeline and are unaffected. With this change, the image decode cost is now dominated by Otsu binarization, the next optimization candidate.