### PR TITLE
feat: improve otsu histogram construction to pixel runs aggregation

### DIFF
--- a/.github/docs/specs/qrcode-decoder.md
+++ b/.github/docs/specs/qrcode-decoder.md
@@ -187,5 +187,17 @@ Kanji mode, FNC1, Structured Append, other ECI charsets.
   compacts and sorts the candidate list in place. Combined result 9.6-11.4x on the
   scan, image E2E (`Image_Url_M`) 309 µs → 132 µs (−57%); the SIMD walk alone is
   bit-identical to the scalar walk and parity-tested
-  (`MICRO_OPTIMIZATION_FinderScan` in the MicroBenchmarks repository). Otsu
-  binarization is now the largest remaining full-image pass.
+  (`MICRO_OPTIMIZATION_FinderScan` in the MicroBenchmarks repository).
+- The Otsu histogram fill aggregates runs instead of incrementing per pixel:
+  `histogram[value]++` serializes on store-forwarding when consecutive pixels hit
+  the same bin, and QR-like images (long runs of two values) are that pattern's
+  worst case — measured ~8x slower per pixel than random input. Reading 8 pixels
+  as one ulong and folding uniform groups (`v == ror(v, 8)`) into a single `+= 8`
+  is 8-10x on QR-like input; the textbook multi-lane fix managed only ~2.4x here
+  because two hot bins keep colliding even across four lanes. The winner is pure
+  scalar C#, so every TFM gets it (no SIMD, no `#if`), and the threshold is
+  byte-identical (OtsuThresholdParityTest). Accepted trade-off: uniform random
+  noise — never-uniform groups, the adversarial floor that even real photos
+  don't hit — pays up to ~1.3x. Image E2E (`Image_Url_M`) 132 µs → 38 µs; with
+  the finder scan work, 309 → 38 µs (8.0x) total
+  (`MICRO_OPTIMIZATION_OtsuHistogram` in the MicroBenchmarks repository).

--- a/src/SkiaSharp.QrCode/Internals/ImageDecoders/QRImageDecoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/ImageDecoders/QRImageDecoder.cs
@@ -1,4 +1,6 @@
 using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 #if NET8_0_OR_GREATER
 using System.Runtime.Intrinsics;
 #endif
@@ -188,13 +190,48 @@ internal static class QRImageDecoder
     /// Otsu's method: picks the threshold that maximizes between-class variance
     /// of the luminance histogram. Suits Tier-1 inputs with clear bimodal contrast.
     /// </summary>
+    /// <remarks>
+    /// The histogram fill aggregates runs: a per-pixel `histogram[value]++` walk
+    /// serializes on store-forwarding whenever consecutive pixels hit the same
+    /// bin, and QR-like images (long runs of two dominant values) are the worst
+    /// case. Reading 8 pixels as one ulong and testing uniformity with a byte
+    /// rotation turns a whole uniform group into a single `+= 8`; non-uniform
+    /// groups (module boundaries, photos) fall back to 8 increments — measured
+    /// ~8-10x on QR-like inputs, break-even to modestly slower on uniform random
+    /// noise (see the OtsuHistogram findings log in MicroBenchmarks). The result
+    /// is byte-identical either way, and bin order is irrelevant to a histogram,
+    /// so the walk is endian-safe.
+    /// </remarks>
     internal static byte ComputeOtsuThreshold(ReadOnlySpan<byte> luminance)
     {
         Span<int> histogram = stackalloc int[256];
         histogram.Clear();
-        foreach (var value in luminance)
+
+        var offset = 0;
+        ref var p = ref MemoryMarshal.GetReference(luminance);
+        for (; offset + 8 <= luminance.Length; offset += 8)
         {
-            histogram[value]++;
+            var v = Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref p, offset));
+            // All 8 bytes equal ⟺ rotating by one byte is a fixed point
+            // (netstandard has no BitOperations.RotateRight; the JIT emits ror)
+            if (v == ((v >> 8) | (v << 56)))
+            {
+                histogram[(byte)v] += 8;
+                continue;
+            }
+
+            histogram[(byte)v]++;
+            histogram[(byte)(v >> 8)]++;
+            histogram[(byte)(v >> 16)]++;
+            histogram[(byte)(v >> 24)]++;
+            histogram[(byte)(v >> 32)]++;
+            histogram[(byte)(v >> 40)]++;
+            histogram[(byte)(v >> 48)]++;
+            histogram[(byte)(v >> 56)]++;
+        }
+        for (; offset < luminance.Length; offset++)
+        {
+            histogram[luminance[offset]]++;
         }
 
         var total = luminance.Length;

--- a/tests/SkiaSharp.QrCode.Tests/OtsuThresholdParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/OtsuThresholdParityTest.cs
@@ -1,0 +1,142 @@
+using SkiaSharp.QrCode.Internals.ImageDecoders;
+using Xunit;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// Parity test for the run-aggregated Otsu histogram fill: the wide-load walk in
+/// <see cref="QRImageDecoder.ComputeOtsuThreshold"/> (8 pixels per ulong, uniform
+/// groups folded into a single += 8) must return a byte-identical threshold to a
+/// naive per-pixel reference across QR-like scenes, noise, gradients, constants,
+/// and ragged lengths (tail handling).
+/// </summary>
+public class OtsuThresholdParityTest
+{
+    [Fact]
+    public void WideLoadAndNaiveHistogram_AgreeByteForByte()
+    {
+        var inputs = new List<byte[]>
+        {
+            BuildQrLike(360, ppm: 8, seed: 42),
+            BuildQrLike(96, ppm: 4, seed: 7),
+            BuildNoise(512, seed: 42),
+            BuildNoise(64, seed: 1234),
+            BuildGradient(256),
+            new byte[1000],          // all zero
+            Filled(1000, 255),       // all white
+            Filled(777, 128),        // constant mid-gray
+            Array.Empty<byte>(),     // empty (returns the 128 default)
+        };
+        // Ragged lengths exercise the scalar tail after the 8-byte groups
+        var rng = new Random(9);
+        for (var length = 1; length <= 67; length++)
+        {
+            var ragged = new byte[length];
+            rng.NextBytes(ragged);
+            inputs.Add(ragged);
+        }
+
+        foreach (var input in inputs)
+        {
+            var expected = NaiveOtsuThreshold(input);
+            var actual = QRImageDecoder.ComputeOtsuThreshold(input);
+            Assert.True(expected == actual, $"threshold mismatch on length={input.Length}: wide={actual}, naive={expected}");
+        }
+    }
+
+    /// <summary>Per-pixel reference: the original histogram fill + the same search.</summary>
+    private static byte NaiveOtsuThreshold(ReadOnlySpan<byte> luminance)
+    {
+        Span<int> histogram = stackalloc int[256];
+        histogram.Clear();
+        foreach (var value in luminance)
+        {
+            histogram[value]++;
+        }
+
+        var total = luminance.Length;
+        long sumAll = 0;
+        for (var i = 0; i < 256; i++)
+        {
+            sumAll += (long)i * histogram[i];
+        }
+
+        long sumBackground = 0;
+        long weightBackground = 0;
+        var bestVariance = -1.0;
+        var bestThreshold = 128;
+
+        for (var t = 0; t < 256; t++)
+        {
+            weightBackground += histogram[t];
+            if (weightBackground == 0)
+                continue;
+            var weightForeground = total - weightBackground;
+            if (weightForeground == 0)
+                break;
+
+            sumBackground += (long)t * histogram[t];
+            var meanBackground = (double)sumBackground / weightBackground;
+            var meanForeground = (double)(sumAll - sumBackground) / weightForeground;
+            var diff = meanBackground - meanForeground;
+            var variance = weightBackground * (double)weightForeground * diff * diff;
+
+            if (variance > bestVariance)
+            {
+                bestVariance = variance;
+                bestThreshold = t + 1;
+            }
+        }
+
+        return (byte)Math.Min(bestThreshold, 255);
+    }
+
+    private static byte[] BuildQrLike(int size, int ppm, int seed)
+    {
+        var scene = new byte[size * size];
+        scene.AsSpan().Fill(255);
+        var random = new Random(seed);
+        var modules = size / ppm;
+        for (var my = 0; my < modules; my++)
+        {
+            for (var mx = 0; mx < modules; mx++)
+            {
+                if (random.Next(100) < 45)
+                {
+                    for (var y = my * ppm; y < (my + 1) * ppm; y++)
+                    {
+                        scene.AsSpan(y * size + mx * ppm, ppm).Clear();
+                    }
+                }
+            }
+        }
+        return scene;
+    }
+
+    private static byte[] BuildNoise(int size, int seed)
+    {
+        var scene = new byte[size * size];
+        new Random(seed).NextBytes(scene);
+        return scene;
+    }
+
+    private static byte[] BuildGradient(int size)
+    {
+        var scene = new byte[size * size];
+        for (var y = 0; y < size; y++)
+        {
+            for (var x = 0; x < size; x++)
+            {
+                scene[y * size + x] = (byte)((x + y) * 255 / (2 * size - 2));
+            }
+        }
+        return scene;
+    }
+
+    private static byte[] Filled(int length, byte value)
+    {
+        var buffer = new byte[length];
+        buffer.AsSpan().Fill(value);
+        return buffer;
+    }
+}


### PR DESCRIPTION
## Summary

Speed up the Otsu binarization threshold (`QRImageDecoder.ComputeOtsuThreshold`) — the largest remaining full-image pass in the image decode pipeline after #332 — by aggregating pixel runs in the histogram fill. Image-level decode E2E is **3.43x faster (−71%)**; combined with the finder-scan work in #332, the image pipeline went from 309 µs to 38.5 µs (**8.0x**) total. Pure scalar C#: every TFM gets the win, including netstandard2.0.

## Intent

The histogram fill (`histogram[value]++` per pixel) was the bottleneck, and for an unintuitive reason: consecutive increments to the *same* bin serialize on store-forwarding, and QR-like images — long runs of two dominant values — are that pattern's worst case, measured ~8x slower per pixel than random input. Two remedies were benchmarked:

- **Multi-lane histograms** (the textbook fix — stripe pixels across 4 sub-histograms): only ~2.4x here, because with just two hot bins the lanes keep colliding anyway.
- **Run aggregation** (shipped): read 8 pixels as one `ulong`; when all bytes are equal (`v == ror(v, 8)` — a rotation by one byte is a fixed point iff the value is uniform), fold the whole group into a single `+= 8`. On QR-like input ~87% of groups are uniform, so the same-bin conflict disappears *and* the work drops 8x. Non-uniform groups (module boundaries) fall back to 8 increments into the same single histogram — adjacent bytes differ there anyway, so lanes buy nothing.

The rotate check beats a multiply-broadcast check by up to 16%: it sits on the branch condition's critical path, and `ror` is 1 cycle vs 3. netstandard2.0 has no `BitOperations.RotateRight`, so the code writes `(v >> 8) | (v << 56)` directly — the JIT emits `ror`.

## Expected behavior

- **No API or behavioral change.** The computed threshold is byte-identical to the previous per-pixel fill — a histogram doesn't care in which order or lane bytes are counted, which also makes the walk endian-safe with no `IsLittleEndian` branch.
- No TFM split: the implementation is plain scalar C# (`Unsafe.ReadUnaligned`, already used elsewhere in the codebase), so netstandard2.0/2.1/net8.0/net10.0 all take the fast path.
- Zero heap allocation, unchanged stack usage (same single 256-entry histogram).
- New `OtsuThresholdParityTest` asserts byte-identical thresholds against a naive reference across QR-like scenes, noise, gradients, constants, the empty input, and lengths 1–67 (scalar-tail coverage). Full test suite passes (net8.0: 1160, net10.0: 1172).
- Known trade-off: uniform random noise (never-uniform groups — the adversarial floor; even real photos have flat regions where aggregation fires) pays the rotate+branch with no payoff, measured between parity and ~1.3x. Accepted: such input means "not a QR code", a path #332 already made ~5x cheaper.

## Benchmarks

Ryzen 9 7950X3D, .NET 10.0.9, X64 RyuJIT, Windows 11.

### Otsu threshold kernel (micro-benchmark, 15 iterations)

| Scenario | Before | After | Speedup |
|---|---:|---:|---:|
| QR-like texture, 360 px | 124.4 µs | 13.0 µs | **9.6x** |
| QR-like texture, 1024 px | 1018.8 µs | 98.9 µs | **10.3x** |
| uniform random noise, 512 px | 74–88 µs | ~98 µs | parity to ~1.3x (accepted) |

All variants allocation-free. Multi-lane histograms (2.4x), eight lanes (worse than four), and a multiply-based uniformity check (up to 16% behind `ror`) were measured and rejected along the way.

### Decode E2E (`QrCodeDecodeEndToEnd`)

| Scenario | Before | After | Change |
|---|---:|---:|---:|
| Image_Url_M (binarize → detect → sample → decode) | 131.9 µs | 38.5 µs | **3.43x (−71%)** |
| Matrix_Short_M | 1.08 µs | 1.08 µs | unchanged |
| Matrix_Url_M | 5.54 µs | 5.54 µs | unchanged |
| Matrix_Long_L | 129.3 µs | 129.3 µs | unchanged |
| Matrix_Long_H | 128.7 µs | 128.7 µs | unchanged |

Matrix-level scenarios don't touch the image pipeline and are unaffected. At 360 px the image decode now spends ~19 µs in the finder scan, ~13 µs in Otsu, and ~6 µs in sampling + matrix decode — further image-pipeline tuning is in diminishing-returns territory.