### PR TITLE
feat: add tier2 decode for MicroQr

### DIFF
--- a/.github/docs/specs/microqr-spec-map.md
+++ b/.github/docs/specs/microqr-spec-map.md
@@ -107,7 +107,9 @@ Reference tests: [MicroQrCodeImageBuilderUnitTest](../../../tests/SkiaSharp.QrCo
 
 ```
 Luminance ──> Otsu threshold ──> Finder candidates (shared 1:1:3:1:1 scan, ALL candidates)
-          ──> Module size refinement ──> Grid sampling (sizes M4..M1 × 4 orientations × transpose)
+          ──> Axis-aligned fast path
+          ──> Angular finder-axis recovery ──> Center / scale / bounded projective refinement
+          ──> Shared projective grid sampling (sizes M4..M1 × orientations × transpose)
           ──> Matrix decoding (format/RS/capacity checks arbitrate the right grid)
 ```
 
@@ -117,11 +119,13 @@ Luminance ──> Otsu threshold ──> Finder candidates (shared 1:1:3:1:1 sca
 | — | Binarization (Otsu) — shared with Standard QR (lifted to `Internals.ImageDecoders` when Micro QR became the second consumer) | [Binarizer.ComputeOtsuThreshold](../../../src/SkiaSharp.QrCode/Internals/ImageDecoders/Binarizer.cs) |
 | Section 6.3.1 | Finder pattern candidates: the shared 1:1:3:1:1 run scan collecting every cross-checked candidate (Standard QR keeps its best-three selection; lifted to `Internals.ImageDecoders` when Micro QR became the second consumer) | [FinderPatternFinder.FindCandidates](../../../src/SkiaSharp.QrCode/Internals/ImageDecoders/FinderPatternFinder.cs) |
 | — | Independent horizontal/vertical module sizes from dark-light-dark runs through the single finder center (7-module span per axis) | [MicroQrImageDecoder.RefineModuleSize](../../../src/SkiaSharp.QrCode/Internals/MicroQr/MicroQrImageDecoder.cs) |
+| — | Arbitrary-rotation recovery from separated angular finder-axis candidates; local center/scale refinement handles pixel quantization, while a bounded two-parameter projective search supplies the correspondences unavailable from a single finder | [MicroQrImageDecoder.TryDecodeArbitraryOrientation](../../../src/SkiaSharp.QrCode/Internals/MicroQr/MicroQrImageDecoder.cs) |
+| — | Projective transform and module-center sampler shared with Standard QR | [PerspectiveTransform](../../../src/SkiaSharp.QrCode/Internals/ImageDecoders/PerspectiveTransform.cs), [QRImageDecoder.SampleGrid](../../../src/SkiaSharp.QrCode/Internals/StandardQr/QRImageDecoder.cs) |
 | — | Public image entry points (SKBitmap / luminance span / zero-allocation destination) | [MicroQrCodeDecoder.TryDecode / TryDecodeImage](../../../src/SkiaSharp.QrCode/MicroQrCodeDecoder.cs) |
 
-Supported envelope (single-finder tier 1): clean screen-rendered or scanned images with 90°/180°/270° rotation, mirroring, reflectance reversal, non-integer uniform or non-uniform scaling, translation and quiet zone variants, plus mild optical degradation (JPEG artifacts, low contrast, additive noise). Small-angle rotation and perspective distortion are **out of scope**: one finder pattern cannot anchor the orientation/homography recovery that three Standard QR finders allow. `QRCodeDecoder` remains Standard QR-only — Micro QR image scanning is its own explicitly-typed entry point, so default Standard QR scanning performance is unaffected.
+Supported envelope (Tier 1–2, conservative single-finder envelope): clean screen-rendered or scanned images with arbitrary rotation, mirroring, reflectance reversal, non-integer uniform or non-uniform scaling, translation and quiet zone variants, plus mild optical degradation (JPEG artifacts, low contrast, additive noise). The measured keystone envelope uses a symmetric top-edge inset of 2% of symbol width for M1/M2 and 4% for M3/M4; representative rotation-plus-keystone and mirror-plus-keystone combinations are covered. Strong perspective is **out of scope** because one finder cannot provide the independent correspondences available from three Standard QR finders and alignment patterns. `QRCodeDecoder` remains Standard QR-only — Micro QR image scanning is its own explicitly-typed entry point, so default Standard QR scanning performance is unaffected.
 
-Reference tests: [MicroQrCodeDecoderImageTest](../../../tests/SkiaSharp.QrCode.Tests/MicroQr/MicroQrCodeDecoderImageTest.cs) (clean renders for every version × ECC, uniform/non-uniform scale, rotation/mirror/inversion/translation/quiet-zone variants, deterministic degradation subset per test strategy §7, negative cases both symbology directions), [MicroQrFixtureTest](../../../tests/SkiaSharp.QrCode.Tests/MicroQr/MicroQrFixtureTest.cs) (committed external-encoder PNG corpus through the image path).
+Reference tests: [MicroQrCodeDecoderImageTest](../../../tests/SkiaSharp.QrCode.Tests/MicroQr/MicroQrCodeDecoderImageTest.cs) (clean renders for every version × ECC, arbitrary rotation, uniform/non-uniform scale, mirror/inversion/translation/quiet-zone variants, deterministic degradation subset per test strategy §7, negative cases both symbology directions), [MicroQrCodeDecoderPerspectiveTest](../../../tests/SkiaSharp.QrCode.Tests/MicroQr/MicroQrCodeDecoderPerspectiveTest.cs) (measured keystone envelope and rotation/mirror combinations), [MicroQrFixtureTest](../../../tests/SkiaSharp.QrCode.Tests/MicroQr/MicroQrFixtureTest.cs) (committed external-encoder PNG corpus through the image path).
 
 ## Data Model and Serialization
 

--- a/.github/docs/specs/qrcode-symbologies.md
+++ b/.github/docs/specs/qrcode-symbologies.md
@@ -11,7 +11,7 @@ Design record for supporting multiple QR symbologies — Standard QR (ISO/IEC 18
 | Symbology | Standard | Encode | Matrix decode | Image decode |
 |---|---|---|---|---|
 | Standard QR (versions 1–40) | ISO/IEC 18004 | Shipped | Shipped | Shipped (Tier 1–2) |
-| Micro QR (M1–M4) | ISO/IEC 18004 | Shipped | Shipped | Shipped (axis-aligned tier 1) |
+| Micro QR (M1–M4) | ISO/IEC 18004 | Shipped | Shipped | Shipped (Tier 1–2, conservative measured envelope) |
 | rMQR (R7x43–R17x139) | ISO/IEC 23941 | Planned | Planned | Planned |
 
 ### Document set

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ using var bitmap = SKBitmap.Decode("microqr.png");
 var found = MicroQrCodeDecoder.TryDecode(bitmap, out var scanned, out _);
 ```
 
-Micro QR image detection targets clean, screen-rendered or scanned images (90°/180°/270° rotation, mirroring, inverted colors, uniform or non-uniform scaling, translation). Small-angle rotation and perspective are out of scope: the single Micro QR finder pattern cannot anchor the geometry recovery that three Standard QR finders allow.
+Micro QR image detection targets clean, screen-rendered or scanned images, including arbitrary rotation, mirroring, inverted colors, uniform or non-uniform scaling, translation, and mild perspective distortion. Because Micro QR has only one finder pattern and no alignment patterns, its measured perspective envelope is intentionally more conservative than Standard QR: the test suite covers 2% top-edge inset for M1/M2 and 4% for M3/M4, including rotation and mirror combinations. Strong perspective, uneven lighting, and blur remain out of scope.
 
 ## Platform-Specific Considerations
 

--- a/src/SkiaSharp.QrCode/Internals/ImageDecoders/PerspectiveTransform.cs
+++ b/src/SkiaSharp.QrCode/Internals/ImageDecoders/PerspectiveTransform.cs
@@ -48,6 +48,38 @@ internal readonly struct PerspectiveTransform
     }
 
     /// <summary>
+    /// Builds a grid-to-image homography from a known point, its two local axis
+    /// derivatives, and the two projective denominator coefficients. A single
+    /// Micro QR finder supplies the point and local frame; bounded searches over
+    /// <paramref name="perspectiveX"/> and <paramref name="perspectiveY"/> recover
+    /// the remaining two degrees of freedom.
+    /// </summary>
+    internal static PerspectiveTransform FromLocalFrame(
+        float gridX,
+        float gridY,
+        float imageX,
+        float imageY,
+        float derivativeUx,
+        float derivativeUy,
+        float derivativeVx,
+        float derivativeVy,
+        float perspectiveX,
+        float perspectiveY)
+    {
+        var denominator = perspectiveX * gridX + perspectiveY * gridY + 1f;
+        var a11 = derivativeUx * denominator + imageX * perspectiveX;
+        var a12 = derivativeUy * denominator + imageY * perspectiveX;
+        var a21 = derivativeVx * denominator + imageX * perspectiveY;
+        var a22 = derivativeVy * denominator + imageY * perspectiveY;
+        var a31 = imageX * denominator - a11 * gridX - a21 * gridY;
+        var a32 = imageY * denominator - a12 * gridX - a22 * gridY;
+        return new PerspectiveTransform(
+            a11, a21, a31,
+            a12, a22, a32,
+            perspectiveX, perspectiveY, 1f);
+    }
+
+    /// <summary>
     /// Transforms (x, y) through the projective map.
     /// </summary>
     public void Transform(float x, float y, out float xOut, out float yOut)

--- a/src/SkiaSharp.QrCode/Internals/MicroQr/MicroQrImageDecoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/MicroQr/MicroQrImageDecoder.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using SkiaSharp.QrCode.Internals.ImageDecoders;
+using SkiaSharp.QrCode.Internals.StandardQr;
 
 namespace SkiaSharp.QrCode.Internals.MicroQr;
 
@@ -12,23 +13,26 @@ namespace SkiaSharp.QrCode.Internals.MicroQr;
 /// <code>
 /// 1. Global binarization threshold (Otsu, shared with Standard QR)
 /// 2. Finder pattern candidates (shared 1:1:3:1:1 scan; ALL candidates, not best three)
-/// 3. Horizontal/vertical module size refinement through the finder center
-///    (dark-light-dark runs)
-/// 4. Axis-aligned grid sampling anchored on the single finder, trying every
-///    version size (M4..M1) × 4 right-angle orientations × transpose (mirror)
-/// 5. Matrix decoding arbitrates: format info is cross-checked against the matrix
+/// 3. Fast axis-aligned grid sampling anchored on the single finder
+/// 4. Failure-path angular finder-axis recovery, local center/scale refinement and
+///    a bounded projective search using the shared Standard QR sampler
+/// 5. Every version size (M4..M1) × orientation × transpose (mirror) is tried
+/// 6. Matrix decoding arbitrates: format info is cross-checked against the matrix
 ///    size and RS + the ISO Table 9 capacity cap reject wrong-grid samples
 /// </code>
 /// A Micro QR symbol has a single finder pattern, so orientation cannot be derived
 /// from finder geometry the way three finders allow for Standard QR. The detector
-/// therefore supports the axis-aligned envelope: 90°/180°/270° rotations,
-/// mirroring, reflectance reversal, scaling and translation. Small-angle rotation
-/// and perspective distortion are out of scope (documented in the spec map).
+/// therefore recovers the finder's local axes from angular dark-light-dark runs and
+/// searches the two projective coefficients that remain unknown. This supports
+/// arbitrary rotation and mild perspective; strong perspective remains out of scope.
 /// </remarks>
 internal static class MicroQrImageDecoder
 {
     /// <summary>Candidates actually tried, most-confirmed first (false hits rank behind).</summary>
     private const int MaxCandidatesToTry = 8;
+
+    /// <summary>Best local finder-axis estimates retained from the angular sweep.</summary>
+    private const int MaxOrientationCandidates = 16;
 
     /// <summary>
     /// Decodes a Micro QR code from grayscale pixels. Reflectance-reversed symbols
@@ -166,11 +170,382 @@ internal static class MicroQrImageDecoder
                     TrackBestFailure(mirroredStatus, mirroredInfo, ref bestStatus, ref bestInfo);
                 }
             }
+
+            // The fast path above covers the overwhelmingly common axis-aligned
+            // case. On failure, recover the finder square's local axes by sweeping
+            // directions through 90 degrees, then sample along those rotated axes.
+            // A square finder repeats every 90 degrees; the four sign/axis
+            // assignments below recover the symbol orientation.
+            var rotatedStatus = TryDecodeArbitraryOrientation(
+                luminance,
+                width,
+                height,
+                threshold,
+                candidate,
+                modules,
+                destination,
+                out charsWritten,
+                out var rotatedInfo,
+                ref bestStatus,
+                ref bestInfo);
+            if (rotatedStatus == QRCodeDecodeStatus.Success)
+            {
+                info = rotatedInfo;
+                return rotatedStatus;
+            }
         }
 
         charsWritten = 0;
         info = bestInfo;
         return bestStatus;
+    }
+
+    /// <summary>
+    /// Recovers arbitrary image rotation from the single finder pattern. For a
+    /// concentric square finder, a center ray crosses the shortest
+    /// dark-light-dark span when it follows one of the square's local axes. An
+    /// angular sweep therefore supplies the two grid-axis directions without the
+    /// three finder centers available to Standard QR.
+    /// </summary>
+    private static QRCodeDecodeStatus TryDecodeArbitraryOrientation(
+        ReadOnlySpan<byte> luminance,
+        int width,
+        int height,
+        byte threshold,
+        in FinderPattern candidate,
+        Span<byte> modules,
+        Span<char> destination,
+        out int charsWritten,
+        out MicroQrCodeDecodeInfo info,
+        ref QRCodeDecodeStatus bestStatus,
+        ref MicroQrCodeDecodeInfo bestInfo)
+    {
+        Span<OrientationCandidate> orientations = stackalloc OrientationCandidate[MaxOrientationCandidates];
+        var orientationCount = FindOrientationCandidates(luminance, width, height, threshold, candidate, orientations);
+
+        for (var frameIndex = 0; frameIndex < orientationCount; frameIndex++)
+        {
+            ref readonly var frame = ref orientations[frameIndex];
+            for (var orientation = 0; orientation < 4; orientation++)
+            {
+                var (uX, uY, vX, vY) = orientation switch
+                {
+                    0 => (frame.UX, frame.UY, frame.VX, frame.VY),
+                    1 => (frame.VX, frame.VY, -frame.UX, -frame.UY),
+                    2 => (-frame.UX, -frame.UY, -frame.VX, -frame.VY),
+                    _ => (-frame.VX, -frame.VY, frame.UX, frame.UY),
+                };
+
+                var originX = candidate.X - 3.5f * (uX + vX);
+                var originY = candidate.Y - 3.5f * (uY + vY);
+                var samplingSlack = Math.Max(frame.USize, frame.VSize);
+
+                for (var size = 17; size >= 11; size -= 2)
+                {
+                    if (!SymbolFitsImage(originX, originY, uX, uY, vX, vY, size, width, height, samplingSlack))
+                        continue;
+
+                    SampleGrid(luminance, width, height, threshold, originX, originY, uX, uY, vX, vY, size, modules);
+                    var status = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var attemptInfo);
+                    if (status == QRCodeDecodeStatus.Success)
+                    {
+                        info = attemptInfo;
+                        return status;
+                    }
+                    TrackBestFailure(status, attemptInfo, ref bestStatus, ref bestInfo);
+
+                    TransposeInPlace(modules, size);
+                    var mirroredStatus = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var mirroredInfo);
+                    if (mirroredStatus == QRCodeDecodeStatus.Success)
+                    {
+                        info = mirroredInfo;
+                        return mirroredStatus;
+                    }
+                    TrackBestFailure(mirroredStatus, mirroredInfo, ref bestStatus, ref bestInfo);
+
+                    var scaledStatus = TryDecodeScaleVariants(
+                        luminance, width, height, threshold, candidate,
+                        uX, uY, vX, vY, size, modules, destination,
+                        out charsWritten, out var scaledInfo,
+                        ref bestStatus, ref bestInfo);
+                    if (scaledStatus == QRCodeDecodeStatus.Success)
+                    {
+                        info = scaledInfo;
+                        return scaledStatus;
+                    }
+
+                    var projectiveStatus = TryDecodePerspectiveVariants(
+                        luminance,
+                        width,
+                        height,
+                        threshold,
+                        candidate,
+                        uX,
+                        uY,
+                        vX,
+                        vY,
+                        size,
+                        samplingSlack,
+                        modules,
+                        destination,
+                        out charsWritten,
+                        out var projectiveInfo,
+                        ref bestStatus,
+                        ref bestInfo);
+                    if (projectiveStatus == QRCodeDecodeStatus.Success)
+                    {
+                        info = projectiveInfo;
+                        return projectiveStatus;
+                    }
+                }
+            }
+        }
+
+        charsWritten = 0;
+        info = bestInfo;
+        return bestStatus;
+    }
+
+    /// <summary>
+    /// Refines the two local module scales independently around the pixel-quantized
+    /// finder-run estimate while keeping the finder center fixed.
+    /// </summary>
+    private static QRCodeDecodeStatus TryDecodeScaleVariants(
+        ReadOnlySpan<byte> luminance,
+        int width,
+        int height,
+        byte threshold,
+        in FinderPattern candidate,
+        float uX,
+        float uY,
+        float vX,
+        float vY,
+        int size,
+        Span<byte> modules,
+        Span<char> destination,
+        out int charsWritten,
+        out MicroQrCodeDecodeInfo info,
+        ref QRCodeDecodeStatus bestStatus,
+        ref MicroQrCodeDecodeInfo bestInfo)
+    {
+        ReadOnlySpan<float> centerOffsets = stackalloc float[] { 0f, -0.5f, 0.5f };
+        ReadOnlySpan<float> factors = stackalloc float[] { 0.94f, 0.97f, 1f, 1.03f, 1.06f };
+        foreach (var centerYOffset in centerOffsets)
+        {
+            foreach (var centerXOffset in centerOffsets)
+            {
+                foreach (var vFactor in factors)
+                {
+                    foreach (var uFactor in factors)
+                    {
+                        if (centerXOffset == 0f && centerYOffset == 0f && uFactor == 1f && vFactor == 1f)
+                            continue;
+
+                        var scaledUX = uX * uFactor;
+                        var scaledUY = uY * uFactor;
+                        var scaledVX = vX * vFactor;
+                        var scaledVY = vY * vFactor;
+                        var centerX = candidate.X + centerXOffset;
+                        var centerY = candidate.Y + centerYOffset;
+                        var originX = centerX - 3.5f * (scaledUX + scaledVX);
+                        var originY = centerY - 3.5f * (scaledUY + scaledVY);
+
+                        SampleGrid(luminance, width, height, threshold, originX, originY, scaledUX, scaledUY, scaledVX, scaledVY, size, modules);
+                        var status = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var attemptInfo);
+                        if (status == QRCodeDecodeStatus.Success)
+                        {
+                            info = attemptInfo;
+                            return status;
+                        }
+                        TrackBestFailure(status, attemptInfo, ref bestStatus, ref bestInfo);
+
+                        TransposeInPlace(modules, size);
+                        var mirroredStatus = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var mirroredInfo);
+                        if (mirroredStatus == QRCodeDecodeStatus.Success)
+                        {
+                            info = mirroredInfo;
+                            return mirroredStatus;
+                        }
+                        TrackBestFailure(mirroredStatus, mirroredInfo, ref bestStatus, ref bestInfo);
+                    }
+                }
+            }
+        }
+
+        charsWritten = 0;
+        info = bestInfo;
+        return bestStatus;
+    }
+
+    /// <summary>
+    /// A single finder determines a homography's image point and local Jacobian,
+    /// leaving only the two projective denominator coefficients unknown. Search a
+    /// bounded Tier-2 range for those two values; matrix format and RS validation
+    /// select the correct transform without image-specific heuristics.
+    /// </summary>
+    private static QRCodeDecodeStatus TryDecodePerspectiveVariants(
+        ReadOnlySpan<byte> luminance,
+        int width,
+        int height,
+        byte threshold,
+        in FinderPattern candidate,
+        float uX,
+        float uY,
+        float vX,
+        float vY,
+        int size,
+        float samplingSlack,
+        Span<byte> modules,
+        Span<char> destination,
+        out int charsWritten,
+        out MicroQrCodeDecodeInfo info,
+        ref QRCodeDecodeStatus bestStatus,
+        ref MicroQrCodeDecodeInfo bestInfo)
+    {
+        ReadOnlySpan<float> strengths = stackalloc float[] { -0.12f, -0.08f, -0.04f, -0.02f, 0f, 0.02f, 0.04f, 0.08f, 0.12f };
+        for (var pyIndex = 0; pyIndex < strengths.Length; pyIndex++)
+        {
+            var perspectiveY = strengths[pyIndex] / size;
+            for (var pxIndex = 0; pxIndex < strengths.Length; pxIndex++)
+            {
+                var perspectiveX = strengths[pxIndex] / size;
+                if (perspectiveX == 0f && perspectiveY == 0f)
+                    continue; // the affine transform was already tried
+
+                var transform = PerspectiveTransform.FromLocalFrame(
+                    3.5f,
+                    3.5f,
+                    candidate.X,
+                    candidate.Y,
+                    uX,
+                    uY,
+                    vX,
+                    vY,
+                    perspectiveX,
+                    perspectiveY);
+                if (!ProjectiveSymbolFitsImage(transform, size, width, height, samplingSlack))
+                    continue;
+
+                QRImageDecoder.SampleGrid(luminance, width, height, threshold, transform, size, modules);
+                var status = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var attemptInfo);
+                if (status == QRCodeDecodeStatus.Success)
+                {
+                    info = attemptInfo;
+                    return status;
+                }
+                TrackBestFailure(status, attemptInfo, ref bestStatus, ref bestInfo);
+
+                TransposeInPlace(modules, size);
+                var mirroredStatus = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var mirroredInfo);
+                if (mirroredStatus == QRCodeDecodeStatus.Success)
+                {
+                    info = mirroredInfo;
+                    return mirroredStatus;
+                }
+                TrackBestFailure(mirroredStatus, mirroredInfo, ref bestStatus, ref bestInfo);
+            }
+        }
+
+        charsWritten = 0;
+        info = bestInfo;
+        return bestStatus;
+    }
+
+    /// <summary>
+    /// Sweeps one quadrant because finder axes repeat every 90 degrees, retaining
+    /// separated low-score directions. Pixel quantization can shift the shortest
+    /// measured run several degrees away from the true finder axis, so adjacent
+    /// samples of one minimum must not consume every candidate slot.
+    /// </summary>
+    private static int FindOrientationCandidates(
+        ReadOnlySpan<byte> luminance,
+        int width,
+        int height,
+        byte threshold,
+        in FinderPattern candidate,
+        Span<OrientationCandidate> destination)
+    {
+        Span<float> uSizes = stackalloc float[90];
+        Span<float> vSizes = stackalloc float[90];
+        for (var degrees = 0; degrees < 90; degrees++)
+        {
+            var radians = degrees * (Math.PI / 180d);
+            var cos = (float)Math.Cos(radians);
+            var sin = (float)Math.Sin(radians);
+            var uSize = MeasureAxis(luminance, width, height, threshold, candidate.X, candidate.Y, cos, sin);
+            var vSize = MeasureAxis(luminance, width, height, threshold, candidate.X, candidate.Y, -sin, cos);
+            uSizes[degrees] = uSize;
+            vSizes[degrees] = vSize;
+        }
+
+        // The pixel-grid minimum can be a few degrees away from the true finder
+        // axis, particularly for small rotated symbols. Select several separated
+        // minima rather than filling the result with adjacent samples of one dip.
+        Span<int> selectedDegrees = stackalloc int[MaxOrientationCandidates];
+        var count = 0;
+        while (count < destination.Length)
+        {
+            var bestDegree = -1;
+            var bestScore = float.MaxValue;
+            for (var degrees = 0; degrees < 90; degrees++)
+            {
+                var uSize = uSizes[degrees];
+                var vSize = vSizes[degrees];
+                if (float.IsNaN(uSize) || float.IsNaN(vSize) || uSize < 1f || vSize < 1f)
+                    continue;
+
+                var separated = true;
+                for (var i = 0; i < count; i++)
+                {
+                    var distance = Math.Abs(degrees - selectedDegrees[i]);
+                    if (Math.Min(distance, 90 - distance) < 2)
+                    {
+                        separated = false;
+                        break;
+                    }
+                }
+                if (!separated || uSize + vSize >= bestScore)
+                    continue;
+
+                bestDegree = degrees;
+                bestScore = uSize + vSize;
+            }
+
+            if (bestDegree < 0)
+                break;
+
+            selectedDegrees[count] = bestDegree;
+            var radians = bestDegree * (Math.PI / 180d);
+            var cos = (float)Math.Cos(radians);
+            var sin = (float)Math.Sin(radians);
+            var bestUSize = uSizes[bestDegree];
+            var bestVSize = vSizes[bestDegree];
+            destination[count++] = new OrientationCandidate(
+                cos * bestUSize,
+                sin * bestUSize,
+                -sin * bestVSize,
+                cos * bestVSize,
+                bestUSize,
+                bestVSize);
+        }
+
+        return count;
+    }
+
+    private readonly struct OrientationCandidate(
+        float uX,
+        float uY,
+        float vX,
+        float vY,
+        float uSize,
+        float vSize)
+    {
+        public float UX { get; } = uX;
+        public float UY { get; } = uY;
+        public float VX { get; } = vX;
+        public float VY { get; } = vY;
+        public float USize { get; } = uSize;
+        public float VSize { get; } = vSize;
     }
 
     /// <summary>
@@ -212,6 +587,24 @@ internal static class MicroQrImageDecoder
             if (x < -slack || x > width + slack || y < -slack || y > height + slack)
                 return false;
         }
+        return true;
+    }
+
+    private static bool ProjectiveSymbolFitsImage(in PerspectiveTransform transform, int size, int width, int height, float samplingSlack)
+    {
+        for (var corner = 0; corner < 4; corner++)
+        {
+            var gridX = (corner & 1) == 0 ? 0f : size;
+            var gridY = (corner & 2) == 0 ? 0f : size;
+            transform.Transform(gridX, gridY, out var x, out var y);
+            if (float.IsNaN(x) || float.IsInfinity(x) || float.IsNaN(y) || float.IsInfinity(y)
+                || x < -samplingSlack || x > width + samplingSlack
+                || y < -samplingSlack || y > height + samplingSlack)
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 

--- a/src/SkiaSharp.QrCode/Internals/MicroQr/MicroQrImageDecoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/MicroQr/MicroQrImageDecoder.cs
@@ -35,6 +35,22 @@ internal static class MicroQrImageDecoder
     private const int MaxOrientationCandidates = 16;
 
     /// <summary>
+    /// Maximum matrix decode attempts in the arbitrary-orientation failure path
+    /// for one finder candidate. This bounds the multiplicative frame, orientation,
+    /// size, scale and perspective searches while leaving enough for one complete
+    /// orientation frame (all four axis assignments and four symbol sizes), and
+    /// without making the result CPU-speed dependent.
+    /// </summary>
+    private const int MaxArbitraryOrientationDecodeAttempts = 10_000;
+
+    /// <summary>
+    /// Maximum angular-sweep ray length relative to the row-scan module estimate.
+    /// A finder center-to-edge ray is at most 3.5√2 modules; the extra margin
+    /// tolerates pixel quantization and mild perspective.
+    /// </summary>
+    private const float MaxAngularSweepRunModules = 8f;
+
+    /// <summary>
     /// Decodes a Micro QR code from grayscale pixels. Reflectance-reversed symbols
     /// (light modules on a dark background) are handled by one inverted retry when
     /// the normal attempt fails.
@@ -222,6 +238,7 @@ internal static class MicroQrImageDecoder
     {
         Span<OrientationCandidate> orientations = stackalloc OrientationCandidate[MaxOrientationCandidates];
         var orientationCount = FindOrientationCandidates(luminance, width, height, threshold, candidate, orientations);
+        var attemptsRemaining = MaxArbitraryOrientationDecodeAttempts;
 
         for (var frameIndex = 0; frameIndex < orientationCount; frameIndex++)
         {
@@ -242,10 +259,18 @@ internal static class MicroQrImageDecoder
 
                 for (var size = 17; size >= 11; size -= 2)
                 {
+                    if (attemptsRemaining == 0)
+                    {
+                        charsWritten = 0;
+                        info = bestInfo;
+                        return bestStatus;
+                    }
+
                     if (!SymbolFitsImage(originX, originY, uX, uY, vX, vY, size, width, height, samplingSlack))
                         continue;
 
                     SampleGrid(luminance, width, height, threshold, originX, originY, uX, uY, vX, vY, size, modules);
+                    attemptsRemaining--;
                     var status = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var attemptInfo);
                     if (status == QRCodeDecodeStatus.Success)
                     {
@@ -254,7 +279,11 @@ internal static class MicroQrImageDecoder
                     }
                     TrackBestFailure(status, attemptInfo, ref bestStatus, ref bestInfo);
 
+                    if (attemptsRemaining == 0)
+                        continue;
+
                     TransposeInPlace(modules, size);
+                    attemptsRemaining--;
                     var mirroredStatus = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var mirroredInfo);
                     if (mirroredStatus == QRCodeDecodeStatus.Success)
                     {
@@ -263,11 +292,18 @@ internal static class MicroQrImageDecoder
                     }
                     TrackBestFailure(mirroredStatus, mirroredInfo, ref bestStatus, ref bestInfo);
 
+                    // Scale and perspective searches multiply this affine attempt
+                    // by hundreds. Enter them only after either polarity decoded
+                    // valid format information; wrong grids overwhelmingly fail
+                    // before that point.
+                    if (!IsPlausibleRefinement(status) && !IsPlausibleRefinement(mirroredStatus))
+                        continue;
+
                     var scaledStatus = TryDecodeScaleVariants(
                         luminance, width, height, threshold, candidate,
                         uX, uY, vX, vY, size, modules, destination,
                         out charsWritten, out var scaledInfo,
-                        ref bestStatus, ref bestInfo);
+                        ref bestStatus, ref bestInfo, ref attemptsRemaining);
                     if (scaledStatus == QRCodeDecodeStatus.Success)
                     {
                         info = scaledInfo;
@@ -291,7 +327,8 @@ internal static class MicroQrImageDecoder
                         out charsWritten,
                         out var projectiveInfo,
                         ref bestStatus,
-                        ref bestInfo);
+                        ref bestInfo,
+                        ref attemptsRemaining);
                     if (projectiveStatus == QRCodeDecodeStatus.Success)
                     {
                         info = projectiveInfo;
@@ -326,7 +363,8 @@ internal static class MicroQrImageDecoder
         out int charsWritten,
         out MicroQrCodeDecodeInfo info,
         ref QRCodeDecodeStatus bestStatus,
-        ref MicroQrCodeDecodeInfo bestInfo)
+        ref MicroQrCodeDecodeInfo bestInfo,
+        ref int attemptsRemaining)
     {
         ReadOnlySpan<float> centerOffsets = stackalloc float[] { 0f, -0.5f, 0.5f };
         ReadOnlySpan<float> factors = stackalloc float[] { 0.94f, 0.97f, 1f, 1.03f, 1.06f };
@@ -340,6 +378,13 @@ internal static class MicroQrImageDecoder
                 {
                     foreach (var uFactor in factors)
                     {
+                        if (attemptsRemaining == 0)
+                        {
+                            charsWritten = 0;
+                            info = bestInfo;
+                            return bestStatus;
+                        }
+
                         if (centerXOffset == 0f && centerYOffset == 0f && uFactor == 1f && vFactor == 1f)
                             continue;
 
@@ -356,6 +401,7 @@ internal static class MicroQrImageDecoder
                             continue;
 
                         SampleGrid(luminance, width, height, threshold, originX, originY, scaledUX, scaledUY, scaledVX, scaledVY, size, modules);
+                        attemptsRemaining--;
                         var status = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var attemptInfo);
                         if (status == QRCodeDecodeStatus.Success)
                         {
@@ -364,7 +410,11 @@ internal static class MicroQrImageDecoder
                         }
                         TrackBestFailure(status, attemptInfo, ref bestStatus, ref bestInfo);
 
+                        if (attemptsRemaining == 0)
+                            continue;
+
                         TransposeInPlace(modules, size);
+                        attemptsRemaining--;
                         var mirroredStatus = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var mirroredInfo);
                         if (mirroredStatus == QRCodeDecodeStatus.Success)
                         {
@@ -405,7 +455,8 @@ internal static class MicroQrImageDecoder
         out int charsWritten,
         out MicroQrCodeDecodeInfo info,
         ref QRCodeDecodeStatus bestStatus,
-        ref MicroQrCodeDecodeInfo bestInfo)
+        ref MicroQrCodeDecodeInfo bestInfo,
+        ref int attemptsRemaining)
     {
         ReadOnlySpan<float> strengths = stackalloc float[] { -0.12f, -0.08f, -0.04f, -0.02f, 0f, 0.02f, 0.04f, 0.08f, 0.12f };
         for (var pyIndex = 0; pyIndex < strengths.Length; pyIndex++)
@@ -413,6 +464,13 @@ internal static class MicroQrImageDecoder
             var perspectiveY = strengths[pyIndex] / size;
             for (var pxIndex = 0; pxIndex < strengths.Length; pxIndex++)
             {
+                if (attemptsRemaining == 0)
+                {
+                    charsWritten = 0;
+                    info = bestInfo;
+                    return bestStatus;
+                }
+
                 var perspectiveX = strengths[pxIndex] / size;
                 if (perspectiveX == 0f && perspectiveY == 0f)
                     continue; // the affine transform was already tried
@@ -432,6 +490,7 @@ internal static class MicroQrImageDecoder
                     continue;
 
                 QRImageDecoder.SampleGrid(luminance, width, height, threshold, transform, size, modules);
+                attemptsRemaining--;
                 var status = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var attemptInfo);
                 if (status == QRCodeDecodeStatus.Success)
                 {
@@ -440,7 +499,11 @@ internal static class MicroQrImageDecoder
                 }
                 TrackBestFailure(status, attemptInfo, ref bestStatus, ref bestInfo);
 
+                if (attemptsRemaining == 0)
+                    continue;
+
                 TransposeInPlace(modules, size);
+                attemptsRemaining--;
                 var mirroredStatus = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var mirroredInfo);
                 if (mirroredStatus == QRCodeDecodeStatus.Success)
                 {
@@ -472,13 +535,14 @@ internal static class MicroQrImageDecoder
     {
         Span<float> uSizes = stackalloc float[90];
         Span<float> vSizes = stackalloc float[90];
+        var maxRunLength = candidate.ModuleSize * MaxAngularSweepRunModules;
         for (var degrees = 0; degrees < 90; degrees++)
         {
             var radians = degrees * (Math.PI / 180d);
             var cos = (float)Math.Cos(radians);
             var sin = (float)Math.Sin(radians);
-            var uSize = MeasureAxis(luminance, width, height, threshold, candidate.X, candidate.Y, cos, sin);
-            var vSize = MeasureAxis(luminance, width, height, threshold, candidate.X, candidate.Y, -sin, cos);
+            var uSize = MeasureAxis(luminance, width, height, threshold, candidate.X, candidate.Y, cos, sin, maxRunLength);
+            var vSize = MeasureAxis(luminance, width, height, threshold, candidate.X, candidate.Y, -sin, cos, maxRunLength);
             uSizes[degrees] = uSize;
             vSizes[degrees] = vSize;
         }
@@ -575,6 +639,11 @@ internal static class MicroQrImageDecoder
         };
     }
 
+    private static bool IsPlausibleRefinement(QRCodeDecodeStatus status)
+        => status is not QRCodeDecodeStatus.NotDetected
+            and not QRCodeDecodeStatus.InvalidMatrix
+            and not QRCodeDecodeStatus.FormatInformationInvalid;
+
     /// <summary>
     /// All four grid corners must land inside the image (with one module of slack
     /// for sampling clamp tolerance); orientations pointing off the image cannot
@@ -639,10 +708,19 @@ internal static class MicroQrImageDecoder
             verticalModuleSize = horizontalModuleSize;
     }
 
-    private static float MeasureAxis(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, float centerX, float centerY, float dirX, float dirY)
+    private static float MeasureAxis(
+        ReadOnlySpan<byte> luminance,
+        int width,
+        int height,
+        byte threshold,
+        float centerX,
+        float centerY,
+        float dirX,
+        float dirY,
+        float maxRunLength = float.PositiveInfinity)
     {
-        var forward = DarkLightDarkRun(luminance, width, height, threshold, centerX, centerY, dirX, dirY);
-        var backward = DarkLightDarkRun(luminance, width, height, threshold, centerX, centerY, -dirX, -dirY);
+        var forward = DarkLightDarkRun(luminance, width, height, threshold, centerX, centerY, dirX, dirY, maxRunLength);
+        var backward = DarkLightDarkRun(luminance, width, height, threshold, centerX, centerY, -dirX, -dirY, maxRunLength);
         if (float.IsNaN(forward) || float.IsNaN(backward))
             return float.NaN;
 
@@ -652,14 +730,15 @@ internal static class MicroQrImageDecoder
     /// <summary>
     /// Walks from the finder center along a direction until the dark-light-dark
     /// sequence completes (center square → light ring → dark ring → out), returning
-    /// the traveled distance (≈ 3.5 modules). NaN when the image edge interrupts.
+    /// the traveled distance (≈ 3.5 modules). NaN when the image edge or the
+    /// caller's maximum run length interrupts the sequence.
     /// Returning step − 0.5 centers the one-pixel overshoot of the integer-step
     /// walk (same correction as the Standard QR measurement).
     /// </summary>
-    private static float DarkLightDarkRun(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, float startX, float startY, float dirX, float dirY)
+    private static float DarkLightDarkRun(ReadOnlySpan<byte> luminance, int width, int height, byte threshold, float startX, float startY, float dirX, float dirY, float maxRunLength)
     {
         var phase = 0;
-        for (var step = 1f; ; step += 1f)
+        for (var step = 1f; step <= maxRunLength; step += 1f)
         {
             var x = (int)(startX + dirX * step + 0.5f);
             var y = (int)(startY + dirY * step + 0.5f);
@@ -687,6 +766,8 @@ internal static class MicroQrImageDecoder
                     break;
             }
         }
+
+        return float.NaN;
     }
 
     /// <summary>

--- a/src/SkiaSharp.QrCode/Internals/MicroQr/MicroQrImageDecoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/MicroQr/MicroQrImageDecoder.cs
@@ -330,6 +330,8 @@ internal static class MicroQrImageDecoder
     {
         ReadOnlySpan<float> centerOffsets = stackalloc float[] { 0f, -0.5f, 0.5f };
         ReadOnlySpan<float> factors = stackalloc float[] { 0.94f, 0.97f, 1f, 1.03f, 1.06f };
+        var uSize = (float)Math.Sqrt(uX * uX + uY * uY);
+        var vSize = (float)Math.Sqrt(vX * vX + vY * vY);
         foreach (var centerYOffset in centerOffsets)
         {
             foreach (var centerXOffset in centerOffsets)
@@ -349,6 +351,9 @@ internal static class MicroQrImageDecoder
                         var centerY = candidate.Y + centerYOffset;
                         var originX = centerX - 3.5f * (scaledUX + scaledVX);
                         var originY = centerY - 3.5f * (scaledUY + scaledVY);
+                        var samplingSlack = Math.Max(uSize * uFactor, vSize * vFactor);
+                        if (!SymbolFitsImage(originX, originY, scaledUX, scaledUY, scaledVX, scaledVY, size, width, height, samplingSlack))
+                            continue;
 
                         SampleGrid(luminance, width, height, threshold, originX, originY, scaledUX, scaledUY, scaledVX, scaledVY, size, modules);
                         var status = MicroQrMatrixDecoder.DecodeMatrix(modules.Slice(0, size * size), size, destination, out charsWritten, out var attemptInfo);

--- a/src/SkiaSharp.QrCode/MicroQrCodeDecoder.cs
+++ b/src/SkiaSharp.QrCode/MicroQrCodeDecoder.cs
@@ -22,10 +22,9 @@ namespace SkiaSharp.QrCode;
 /// zone border is detected and skipped automatically) or images via the
 /// <see cref="TryDecode(SKBitmap, out string)"/> / <see cref="TryDecodeImage(ReadOnlySpan{byte}, int, int, out string, out MicroQrCodeDecodeInfo)"/>
 /// overloads. Image detection targets clean, screen-rendered or scanned images:
-/// 90°/180°/270° rotations, mirroring, reflectance reversal, uniform or
-/// non-uniform scaling and translation are supported; small-angle rotation and
-/// perspective distortion are out of scope for the single-finder detector. Micro
-/// QR image scanning is a separate, explicitly-typed entry point —
+/// arbitrary rotation, mirroring, reflectance reversal, uniform or non-uniform
+/// scaling, translation and mild perspective distortion are supported. Micro QR
+/// image scanning is a separate, explicitly-typed entry point —
 /// <see cref="QRCodeDecoder"/> continues to scan Standard QR only.
 /// </para>
 /// </remarks>
@@ -151,11 +150,9 @@ public static class MicroQrCodeDecoder
     /// </summary>
     /// <remarks>
     /// Targets clean, well-lit images such as screenshots, rendered symbols and
-    /// scans: 90°/180°/270° rotations, mirroring, reflectance reversal
-    /// (light-on-dark), uniform or non-uniform scaling and translation are handled.
-    /// Small-angle rotation, perspective distortion, uneven lighting and blur are
-    /// out of scope — the single Micro QR finder pattern cannot anchor the geometry
-    /// recovery that three Standard QR finders allow.
+    /// scans: arbitrary rotation, mirroring, reflectance reversal (light-on-dark),
+    /// uniform or non-uniform scaling, translation and mild perspective distortion
+    /// are handled. Strong perspective, uneven lighting and blur are out of scope.
     /// </remarks>
     /// <param name="bitmap">The bitmap to scan.</param>
     /// <param name="text">Decoded text, or an empty string when decoding fails.</param>

--- a/tests/SkiaSharp.QrCode.Tests/MicroQr/MicroQrCodeDecoderImageTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/MicroQr/MicroQrCodeDecoderImageTest.cs
@@ -172,6 +172,54 @@ public class MicroQrCodeDecoderImageTest
     }
 
     [Test]
+    [Arguments(MicroQrVersion.M1, MicroQrEccLevel.ErrorDetectionOnly, "123", 30)]
+    [Arguments(MicroQrVersion.M2, MicroQrEccLevel.L, "12345", -7)]
+    [Arguments(MicroQrVersion.M3, MicroQrEccLevel.L, "HELLO WORLD", 45)]
+    [Arguments(MicroQrVersion.M4, MicroQrEccLevel.M, "MICRO QR M4 TEST", 5)]
+    [Arguments(MicroQrVersion.M4, MicroQrEccLevel.M, "MICRO QR M4 TEST", 30)]
+    public async Task Decode_ArbitraryRotations(MicroQrVersion version, MicroQrEccLevel eccLevel, string content, int degrees)
+    {
+        using var bitmap = RenderRotated(content, version, eccLevel, degrees);
+
+        var success = MicroQrCodeDecoder.TryDecode(bitmap, out var text, out var info);
+
+        await Assert.That(success).IsTrue().Because($"version={version}, degrees={degrees}, status={info.Status}");
+        await Assert.That(text).IsEqualTo(content);
+    }
+
+    [Test]
+    [Arguments(MicroQrVersion.M1, MicroQrEccLevel.ErrorDetectionOnly, "123")]
+    [Arguments(MicroQrVersion.M4, MicroQrEccLevel.M, "MICRO QR M4 TEST")]
+    public async Task Decode_EveryIntegerRotation(MicroQrVersion version, MicroQrEccLevel eccLevel, string content)
+    {
+        for (var degrees = 0; degrees < 90; degrees++)
+        {
+            using var bitmap = RenderRotated(content, version, eccLevel, degrees);
+
+            var success = MicroQrCodeDecoder.TryDecode(bitmap, out var text, out var info);
+
+            await Assert.That(success).IsTrue().Because($"version={version}, degrees={degrees}, status={info.Status}");
+            await Assert.That(text).IsEqualTo(content).Because($"version={version}, degrees={degrees}");
+        }
+    }
+
+    private static SKBitmap RenderRotated(string content, MicroQrVersion version, MicroQrEccLevel eccLevel, float degrees)
+    {
+        var data = MicroQrCodeGenerator.CreateMicroQrCode(content, eccLevel, version);
+        var qrPx = data.Size * 8;
+        var canvasPx = (int)(qrPx * 1.5f) + 16;
+        var bitmap = new SKBitmap(new SKImageInfo(canvasPx, canvasPx, SKColorType.Bgra8888, SKAlphaType.Premul));
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.White);
+        canvas.Translate(canvasPx / 2f, canvasPx / 2f);
+        canvas.RotateDegrees(degrees);
+        canvas.Translate(-qrPx / 2f, -qrPx / 2f);
+        QRCodeRenderer.Render(canvas, SKRect.Create(0, 0, qrPx, qrPx), data, SKColors.Black, SKColors.White);
+        canvas.Flush();
+        return bitmap;
+    }
+
+    [Test]
     public async Task Decode_MirroredImage()
     {
         const string content = "12345";

--- a/tests/SkiaSharp.QrCode.Tests/MicroQr/MicroQrCodeDecoderPerspectiveTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/MicroQr/MicroQrCodeDecoderPerspectiveTest.cs
@@ -1,0 +1,148 @@
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// Tier-2 Micro QR image decoding: mild perspective (keystone), including
+/// composition with arbitrary rotation and mirroring. Micro QR has no alignment
+/// patterns, so its measured perspective envelope is intentionally conservative.
+/// </summary>
+public class MicroQrCodeDecoderPerspectiveTest
+{
+    [Test]
+    [Arguments(MicroQrVersion.M1, MicroQrEccLevel.ErrorDetectionOnly, "123", 0.02f)]
+    [Arguments(MicroQrVersion.M2, MicroQrEccLevel.L, "12345", 0.02f)]
+    [Arguments(MicroQrVersion.M3, MicroQrEccLevel.L, "HELLO WORLD", 0.04f)]
+    [Arguments(MicroQrVersion.M4, MicroQrEccLevel.M, "MICRO QR M4 TEST", 0.02f)]
+    [Arguments(MicroQrVersion.M4, MicroQrEccLevel.M, "MICRO QR M4 TEST", 0.04f)]
+    public async Task Decode_Keystone(MicroQrVersion version, MicroQrEccLevel eccLevel, string content, float tilt)
+    {
+        using var bitmap = RenderKeystone(content, version, eccLevel, tilt, rotateDegrees: 0);
+
+        var success = MicroQrCodeDecoder.TryDecode(bitmap, out var decoded, out var info);
+
+        await Assert.That(success).IsTrue().Because($"version={version}, tilt={tilt:P0}, status={info.Status}");
+        await Assert.That(decoded).IsEqualTo(content);
+        await Assert.That(info.Version).IsEqualTo(version);
+    }
+
+    [Test]
+    [Arguments(MicroQrVersion.M1, MicroQrEccLevel.ErrorDetectionOnly, "123", 0.02f, 30)]
+    [Arguments(MicroQrVersion.M4, MicroQrEccLevel.M, "MICRO QR M4 TEST", 0.04f, 30)]
+    public async Task Decode_RotationPlusKeystone(MicroQrVersion version, MicroQrEccLevel eccLevel, string content, float tilt, int degrees)
+    {
+        using var bitmap = RenderKeystone(content, version, eccLevel, tilt, degrees);
+
+        var success = MicroQrCodeDecoder.TryDecode(bitmap, out var decoded, out var info);
+
+        await Assert.That(success).IsTrue().Because($"version={version}, tilt={tilt:P0}, degrees={degrees}, status={info.Status}");
+        await Assert.That(decoded).IsEqualTo(content);
+    }
+
+    [Test]
+    public async Task Decode_MirrorPlusKeystone()
+    {
+        const string content = "MICRO QR M4 TEST";
+        using var source = RenderKeystone(content, MicroQrVersion.M4, MicroQrEccLevel.M, tilt: 0.02f, rotateDegrees: 0);
+        using var mirrored = new SKBitmap(new SKImageInfo(source.Width, source.Height, SKColorType.Bgra8888, SKAlphaType.Premul));
+        using (var canvas = new SKCanvas(mirrored))
+        {
+            canvas.Clear(SKColors.White);
+            canvas.Scale(-1, 1, source.Width / 2f, 0);
+            canvas.DrawBitmap(source, 0, 0, SKSamplingOptions.Default);
+        }
+
+        var success = MicroQrCodeDecoder.TryDecode(mirrored, out var decoded, out var info);
+
+        await Assert.That(success).IsTrue().Because($"status={info.Status}");
+        await Assert.That(decoded).IsEqualTo(content);
+    }
+
+    private static SKBitmap RenderKeystone(
+        string content,
+        MicroQrVersion version,
+        MicroQrEccLevel eccLevel,
+        float tilt,
+        float rotateDegrees)
+    {
+        var qr = MicroQrCodeGenerator.CreateMicroQrCode(content, eccLevel, version, quietZoneSize: 2);
+        var qrPx = qr.Size * 8;
+
+        using var flat = new SKBitmap(new SKImageInfo(qrPx, qrPx, SKColorType.Bgra8888, SKAlphaType.Premul));
+        using (var canvas = new SKCanvas(flat))
+        {
+            QRCodeRenderer.Render(canvas, SKRect.Create(0, 0, qrPx, qrPx), qr, SKColors.Black, SKColors.White);
+            canvas.Flush();
+        }
+
+        var canvasPx = (int)(qrPx * 1.6f) + 32;
+        var result = new SKBitmap(new SKImageInfo(canvasPx, canvasPx, SKColorType.Bgra8888, SKAlphaType.Premul));
+        using (var canvas = new SKCanvas(result))
+        {
+            canvas.Clear(SKColors.White);
+
+            var margin = (canvasPx - qrPx) / 2f;
+            var shrink = tilt * qrPx;
+            var warp = SquareToQuad(
+                qrPx,
+                qrPx,
+                new SKPoint(margin + shrink, margin),
+                new SKPoint(margin + qrPx - shrink, margin),
+                new SKPoint(margin + qrPx, margin + qrPx),
+                new SKPoint(margin, margin + qrPx));
+
+            if (rotateDegrees != 0)
+            {
+                var rotation = SKMatrix.CreateRotationDegrees(rotateDegrees, canvasPx / 2f, canvasPx / 2f);
+                warp = rotation.PreConcat(warp);
+            }
+
+            canvas.SetMatrix(warp);
+            canvas.DrawBitmap(flat, 0, 0, SKSamplingOptions.Default);
+            canvas.Flush();
+        }
+
+        return result;
+    }
+
+    private static SKMatrix SquareToQuad(float width, float height, SKPoint topLeft, SKPoint topRight, SKPoint bottomRight, SKPoint bottomLeft)
+    {
+        var dx3 = topLeft.X - topRight.X + bottomRight.X - bottomLeft.X;
+        var dy3 = topLeft.Y - topRight.Y + bottomRight.Y - bottomLeft.Y;
+        float a13, a23, a11, a21, a12, a22;
+        if (dx3 == 0f && dy3 == 0f)
+        {
+            a11 = topRight.X - topLeft.X;
+            a21 = bottomRight.X - topRight.X;
+            a12 = topRight.Y - topLeft.Y;
+            a22 = bottomRight.Y - topRight.Y;
+            a13 = 0f;
+            a23 = 0f;
+        }
+        else
+        {
+            var dx1 = topRight.X - bottomRight.X;
+            var dx2 = bottomLeft.X - bottomRight.X;
+            var dy1 = topRight.Y - bottomRight.Y;
+            var dy2 = bottomLeft.Y - bottomRight.Y;
+            var denominator = dx1 * dy2 - dx2 * dy1;
+            a13 = (dx3 * dy2 - dx2 * dy3) / denominator;
+            a23 = (dx1 * dy3 - dx3 * dy1) / denominator;
+            a11 = topRight.X - topLeft.X + a13 * topRight.X;
+            a21 = bottomLeft.X - topLeft.X + a23 * bottomLeft.X;
+            a12 = topRight.Y - topLeft.Y + a13 * topRight.Y;
+            a22 = bottomLeft.Y - topLeft.Y + a23 * bottomLeft.Y;
+        }
+
+        return new SKMatrix
+        {
+            ScaleX = a11 / width,
+            SkewX = a21 / height,
+            TransX = topLeft.X,
+            SkewY = a12 / width,
+            ScaleY = a22 / height,
+            TransY = topLeft.Y,
+            Persp0 = a13 / width,
+            Persp1 = a23 / height,
+            Persp2 = 1f,
+        };
+    }
+}

--- a/tests/SkiaSharp.QrCode.Tests/Shared/PerspectiveTransformUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/Shared/PerspectiveTransformUnitTest.cs
@@ -63,6 +63,37 @@ public class PerspectiveTransformUnitTest
         }
     }
 
+    [Test]
+    public async Task FromLocalFrame_PreservesAnchorAndDerivatives()
+    {
+        const float gridX = 3.5f;
+        const float gridY = 3.5f;
+        const float imageX = 42f;
+        const float imageY = 27f;
+        const float derivativeUx = 7.2f;
+        const float derivativeUy = 1.1f;
+        const float derivativeVx = -0.8f;
+        const float derivativeVy = 6.6f;
+        const float step = 0.001f;
+
+        var transform = PerspectiveTransform.FromLocalFrame(
+            gridX, gridY,
+            imageX, imageY,
+            derivativeUx, derivativeUy,
+            derivativeVx, derivativeVy,
+            perspectiveX: 0.004f,
+            perspectiveY: -0.003f);
+
+        await AssertMaps(transform, gridX, gridY, imageX, imageY);
+
+        transform.Transform(gridX + step, gridY, out var uX, out var uY);
+        transform.Transform(gridX, gridY + step, out var vX, out var vY);
+        await Assert.That((uX - imageX) / step).IsEqualTo(derivativeUx).Within(0.02f);
+        await Assert.That((uY - imageY) / step).IsEqualTo(derivativeUy).Within(0.02f);
+        await Assert.That((vX - imageX) / step).IsEqualTo(derivativeVx).Within(0.02f);
+        await Assert.That((vY - imageY) / step).IsEqualTo(derivativeVy).Within(0.02f);
+    }
+
     private static async Task AssertMaps(PerspectiveTransform transform, float x, float y, float expectedX, float expectedY)
     {
         transform.Transform(x, y, out var actualX, out var actualY);


### PR DESCRIPTION
## Summary

- Add arbitrary-rotation recovery to Micro QR image decoding.
- Add conservative Tier 2 perspective correction for Micro QR symbols.
- Reuse the Standard QR projective transform and grid sampler.
- Add exhaustive integer-angle rotation tests and keystone combination tests.
- Update the documented Micro QR image-decoding envelope.

## Intent

Bring Micro QR image decoding closer to the Standard QR Tier 1–2 feature set while accounting for the geometric limitations of Micro QR's single finder pattern and lack of alignment patterns.

## Expected behavior

- Decode clean Micro QR images at arbitrary rotations.
- Decode mirrored, inverted, scaled, and translated symbols as before.
- Decode mild keystone distortion within the measured envelope:
  - M1/M2: 2% symmetric top-edge inset
  - M3/M4: 4% symmetric top-edge inset
- Support representative rotation-plus-keystone and mirror-plus-keystone combinations.
- Preserve the existing fast path and allocation-free behavior for axis-aligned images.

Strong perspective distortion, uneven lighting, and blur remain outside the supported image envelope.

## Breaking changes

None.