### PR TITLE
fix: FinderPattern filled by outer ring dark colour when using transparent bg

### DIFF
--- a/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs
+++ b/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs
@@ -38,9 +38,12 @@ public abstract class FinderPatternShape
     /// <remarks>
     /// The default implementation preserves compatibility with custom finder shapes that
     /// override the color-based overload. Built-in shapes override this overload so the
-    /// renderer can reuse the paint that already drew the QR code background. The renderer
-    /// owns <paramref name="backgroundPaint"/> and may reuse it across calls; implementations
-    /// must not modify or dispose it.
+    /// renderer can reuse its background paint. The renderer may set the paint's blend mode
+    /// to <see cref="SKBlendMode.Clear"/> while drawing on an isolated layer so transparent
+    /// and translucent light modules reveal the background rendered beneath the finder pattern.
+    /// Implementations should therefore draw with this paint directly instead of copying only
+    /// its color. The renderer owns <paramref name="backgroundPaint"/> and may reuse it across
+    /// calls; implementations must not modify or dispose it.
     /// Custom shapes should override this overload when they need to reuse the renderer's
     /// configured background paint; existing custom shapes may continue to override the
     /// <see cref="Draw(SKCanvas, SKRect, SKPaint, SKColor)"/> overload.

--- a/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs
+++ b/src/SkiaSharp.QrCode/Image/FinderPatternShape.cs
@@ -45,8 +45,9 @@ public abstract class FinderPatternShape
     /// its color. The renderer owns <paramref name="backgroundPaint"/> and may reuse it across
     /// calls; implementations must not modify or dispose it.
     /// Custom shapes should override this overload when they need to reuse the renderer's
-    /// configured background paint; existing custom shapes may continue to override the
-    /// <see cref="Draw(SKCanvas, SKRect, SKPaint, SKColor)"/> overload.
+    /// configured background paint or when they must support non-opaque backgrounds (blend modes).
+    /// Existing custom shapes may continue to override <see cref="Draw(SKCanvas, SKRect, SKPaint, SKColor)"/>,
+    /// but that overload cannot use the renderer's blend mode.
     /// </remarks>
     /// <param name="canvas">The canvas to render on.</param>
     /// <param name="rect">The rectangular area for the finder pattern (7x7 modules).</param>

--- a/src/SkiaSharp.QrCode/QRCodeRenderer.cs
+++ b/src/SkiaSharp.QrCode/QRCodeRenderer.cs
@@ -90,6 +90,17 @@ public static class QRCodeRenderer
         // Draw finder patterns
         if (finderPatternShape is not null)
         {
+            // Finder shapes draw the outer dark area before drawing the light inner
+            // ring. A non-opaque light color with SrcOver cannot restore the
+            // background after that dark area has been drawn. In that case, draw
+            // each finder on a temporary layer and clear its light modules to reveal
+            // the already-rendered QR background underneath.
+            var requiresBackgroundRestore = bgColor.Alpha < byte.MaxValue;
+            if (requiresBackgroundRestore)
+            {
+                lightPaint.BlendMode = SKBlendMode.Clear;
+            }
+
             // Curved finder shapes require antialiasing independently from module shapes.
             // Apply the same setting to both paints so their shared edges are rasterized
             // consistently.
@@ -103,7 +114,21 @@ public static class QRCodeRenderer
             for (var i = 0; i < 3; i++)
             {
                 var finderRect = GetFinderPatternRect(data, i, area);
-                finderPatternShape.Draw(canvas, finderRect, darkPaint, lightPaint);
+                if (!requiresBackgroundRestore)
+                {
+                    finderPatternShape.Draw(canvas, finderRect, darkPaint, lightPaint);
+                    continue;
+                }
+
+                var saveCount = canvas.SaveLayer(finderRect, null);
+                try
+                {
+                    finderPatternShape.Draw(canvas, finderRect, darkPaint, lightPaint);
+                }
+                finally
+                {
+                    canvas.RestoreToCount(saveCount);
+                }
             }
         }
 

--- a/tests/SkiaSharp.QrCode.Tests/Rendering/FinderPatternShapeColorTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/Rendering/FinderPatternShapeColorTest.cs
@@ -150,6 +150,71 @@ public class FinderPatternShapeColorTest
     }
 
     [Test]
+    [MethodDataSource(nameof(GetFinderPatternShapes))]
+    public async Task ToByteArray_TransparentBackground_KeepsFinderPatternInnerRingTransparent(FinderPatternShape finderPatternShape)
+    {
+        const string content = "transparent-finder-background-test";
+        var pngBytes = new QRCodeImageBuilder(content)
+            .WithSize(800, 800)
+            .WithErrorCorrection(ECCLevel.H)
+            .WithColors(SKColors.Black, new SKColor(0xFF, 0xFF, 0x00, 0x00), SKColors.Transparent)
+            .WithGradient(new GradientOptions(
+                [SKColors.Blue, SKColors.Purple, SKColors.Pink],
+                GradientDirection.TopLeftToBottomRight,
+                [0f, 0.5f, 1f]))
+            .WithFinderPatternShape(finderPatternShape)
+            .WithModuleShape(RoundedRectangleModuleShape.Default, 0.9f)
+            .ToByteArray();
+
+        using var bitmap = SKBitmap.Decode(pngBytes) ?? throw new InvalidOperationException("Failed to decode generated PNG.");
+        var qr = QRCodeGenerator.CreateQrCode(content, ECCLevel.H);
+        var finderRect = QRCodeRenderer.GetFinderPatternRect(
+            qr,
+            0,
+            SKRect.Create(0, 0, bitmap.Width, bitmap.Height));
+        var moduleSize = finderRect.Width / 7f;
+        var ringPixel = bitmap.GetPixel(
+            (int)MathF.Round(finderRect.Left + moduleSize * 1.5f),
+            (int)MathF.Round(finderRect.Top + moduleSize * 3.5f));
+        var centerPixel = bitmap.GetPixel(
+            (int)MathF.Round(finderRect.Left + moduleSize * 3.5f),
+            (int)MathF.Round(finderRect.Top + moduleSize * 3.5f));
+
+        await Assert.That(ringPixel.Alpha).IsEqualTo((byte)0);
+        await Assert.That(centerPixel.Alpha).IsEqualTo((byte)255);
+    }
+
+    [Test]
+    [MethodDataSource(nameof(GetFinderPatternShapes))]
+    public async Task TranslucentBackground_FinderPatternInnerRingMatchesRenderedBackground(FinderPatternShape finderPatternShape)
+    {
+        var backgroundColor = new SKColor(0xFF, 0xFF, 0xFF, 0x80);
+        var qr = QRCodeGenerator.CreateQrCode("translucent-finder-background-test", ECCLevel.M);
+        var imageSize = qr.Size * 10;
+        var area = SKRect.Create(0, 0, imageSize, imageSize);
+        using var bitmap = new SKBitmap(imageSize, imageSize);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Red);
+
+        QRCodeRenderer.Render(
+            canvas,
+            area,
+            qr,
+            SKColors.Black,
+            backgroundColor,
+            finderPatternShape: finderPatternShape);
+
+        var finderRect = QRCodeRenderer.GetFinderPatternRect(qr, 0, area);
+        var moduleSize = finderRect.Width / 7f;
+        var ringPixel = bitmap.GetPixel(
+            (int)MathF.Round(finderRect.Left + moduleSize * 1.5f),
+            (int)MathF.Round(finderRect.Top + moduleSize * 3.5f));
+        var quietZonePixel = bitmap.GetPixel(0, 0);
+
+        await Assert.That(ringPixel).IsEqualTo(quietZonePixel);
+    }
+
+    [Test]
     [Arguments(false)]
     public async Task RectangleFinderPatternShape_RequiresAntialiasing_IsFalse(bool expected)
     {


### PR DESCRIPTION
closes: #354

## Summary

Fix finder pattern inner ring being filled with the dark outer color when using a transparent or translucent background with custom finder shapes.

## Overview

Custom finder patterns are drawn in two passes: the dark outer ring first, then the light inner ring using the configured background color. When the background is not fully opaque (`alpha < 255`), compositing the inner ring with `SrcOver` cannot remove the dark pixels already written underneath, so the inner ring appears filled instead of showing the QR background (gradient, transparency, etc.).

This PR fixes that by rendering each finder on a temporary layer when the background is transparent or translucent, then clearing the light modules with `SKBlendMode.Clear` to reveal the background already drawn beneath. The existing rendering path is unchanged for fully opaque backgrounds.

## Reproduce step

1. Go to WASM Playground (1.1.0) https://guitarrapc.github.io/SkiaSharp.QrCode/
2. Set `Transparent background` to `true`
3. You will find FinderPattern fill with dark outer colour.

## Before / After

before

<img width="1213" height="941" alt="image" src="https://github.com/user-attachments/assets/0ab8abe8-a107-4b19-8fd6-8147689dbaec" />

after

<img width="1166" height="923" alt="image" src="https://github.com/user-attachments/assets/7ebafa9e-9920-4570-a9ff-6a5248b3449e" />
