### PR TITLE
feat: Optimizes RmQR performance

### DIFF
--- a/.github/docs/plans/skiasharp-qrcode-microqr-rmqr-implementation-plan.md
+++ b/.github/docs/plans/skiasharp-qrcode-microqr-rmqr-implementation-plan.md
@@ -226,7 +226,7 @@ Exit: decoder MVT image-level rows satisfied; degradation matrix green for rMQR.
   fast path `MicroQRModulePlacer.PlaceSymbol` (new partial file
   `MicroQRModulePlacer.PlaceSymbol.cs`); the per-module stage methods remain as
   the readable reference. `MicroQRCodeGenerator.WriteCoreModules` now makes one
-  placer call. Kernel-level result (private micro-benchmark loop, 14 variants,
+  placer call. Kernel-level result (kernel benchmark loop, 14 variants,
   4 rounds): 3.1-4.0x over the per-module pipeline, zero allocations.
 - Design: <= 192-bit stream prepacked into 3 ulongs; closed-form column-pair
   segments (no per-module function predicate, no remaining-bits guard, stream
@@ -276,7 +276,7 @@ only).
 
 **Done**
 
-- Reopened the micro-benchmark loop with SIMD/CPU-instruction variants (rounds
+- Reopened the kernel benchmark loop with SIMD/CPU-instruction variants (rounds
   5-7, 25 variants total; the scalar-only constraint applied to the initial
   Micro QR implementation, not to optimization). Kernel result vs the
   per-module baseline: 3.6-5.8x (M4-M 680 -> 118 ns), vs the scalar fast path
@@ -357,7 +357,7 @@ Allocations unchanged (Span paths 0 B). StandardQr control stable across runs.
 - BDN DisassemblyDiagnoser flakes ~50% on this box; tiering off +
   `DOTNET_JitDisasm` is the reliable fallback for reading codegen.
 
-**Benchmark delta**, kernel (private micro-benchmark loop, MicroQRBinaryEncode):
+**Benchmark delta**, kernel (kernel benchmark loop, MicroQRBinaryEncode):
 1.8-2.5x (15-31 ns → 6.7-17 ns across M1-M4 payloads); E2E MicroQREncode −4 to
 −14% (placement dominates after the earlier follow-ups). Branch-final E2E state
 (net10.0 Release, two launches averaged, 2026-07-17):
@@ -373,8 +373,8 @@ Allocations unchanged (Span paths 0 B). StandardQr control stable across runs.
 
 **Done**
 
-- Reopened the placement micro-benchmark loop (rounds 8-11, variants V26-V37 in
-  the private findings log). The round-7 audit's "the placement recurrence is
+- Reopened the placement kernel benchmark loop (rounds 8-11, variants V26-V37 in
+  the kernel findings log). The round-7 audit's "the placement recurrence is
   genuinely serial" was wrong one level up: the zigzag is a FIXED bit
   permutation per size, so each row's data bits are 3x (PEXT gather + PDEP
   scatter) from static per-(size, row) masks, branch-free, no cross-row

--- a/.github/docs/plans/skiasharp-qrcode-rmqr-implementation-plan.md
+++ b/.github/docs/plans/skiasharp-qrcode-rmqr-implementation-plan.md
@@ -560,3 +560,34 @@ The first of the post-Phase-7 kernel rounds (kernel benchmark loop: 19 variants 
 | StandardQr_Numeric_V1_Encode (Span) (untouched control) | 1.891 µs | 2.072 µs | |
 
 Kernel: 1.3x (12 digits) to 7.5x (150 Latin-1 bytes), 2.6x on the largest numeric (361 digits: 199 → 80 ns), 5.6x on the largest alphanumeric (219 chars: 268 → 48 ns), 0 B everywhere. E2E: the encoder is 1-2 % of the encode pipeline (placement dominates: R17x139 spends ~14 µs painting 2,363 modules), so the E2E rows move by 1-7 %, at or below the run-to-run band (the untouched control drifted +9.6 %). The next lever for the encode E2E is the placer fast path listed under Follow-ups, not the bit stream.
+
+### Follow-up: placer fast path (`RmQRModulePlacer`), completed 2026-08-16
+
+Second post-Phase-7 kernel round (kernel benchmark loop: 13 variants over 3 rounds, byte-identical gate of 3,840 placements per variant against the verbatim reference — all 32 versions × 2 ECC × all-zero / all-one / random / over-long messages on a poisoned core — disassembly-read, converged when round 3 fell inside 3 %).
+
+**Done**
+
+- `src`: `RmQRModulePlacer.PlaceSymbol` is now the fast path; the per-module painters (`PlaceFunctionModules`, `PlaceFormat`, `PlaceData`) stay as `PlaceSymbolReference`, the source of truth that builds the tables and that the matrix decoder's `IsFunctionModule` / `GetMaskBit` still share. Per-version `Layout` built once (lazily, `Volatile` publish): a function template plus a per-ECC template with both format copies painted (memcpy replaces ~500 pattern stores + 36 format stores + two BCH words per call), the zigzag walk as `ushort` core indices with a mask byte per position, and the column-pair segmentation (a pair is "clean" when both columns are pure data on rows 1..h-2). Placement = template copy → one vector pass expanding the message bits to bytes fused with the mask XOR (AVX2 32 modules / SSSE3 16 per step under `NET8_0_OR_GREATER`, scalar 8-per-byte otherwise; remainder positions get the mask only) → store pass: clean pairs as one byte-swapped 16-bit store per row from the bit array, the finder / format / alignment / sub-finder-neighbour pairs as an index scatter. Scratch is the repo's fixed-budget policy: 512-byte stackalloc (every version ≤ 63 codewords) with an `ArrayPool` rental above it. Zero allocations after the one-time tables (≤ 8.5 KB per version, both ECC templates included; ~120 KB if every version and ECC were ever used).
+- Tests (+40 on each TFM; full suite net10.0 5,073 / net8.0 5,061, 0 failed): `RmQRModulePlacerParityTest` (fast vs reference for all 32 × 2 ECC × six message shapes incl. the generator's buffer size and an over-long message, oversized core untouched beyond w×h, undersized-buffer contracts of both paths, ECC alternation on a shared cache). The existing structural / format read-back / extraction / module-exact oracle tests (every committed external symbol) now run through the fast path.
+- Refuted along the way (kept in the kernel findings log): band stores of up to 4 pairs as one 8-byte store per row (4x fewer stores, neutral — the strided destination, not the store count, bounds the pass), and the pure index scatter once fixed costs were gone (loses 12-17 % to the pair stores on medium/large versions).
+
+**Lessons learned**
+
+- Rung 1 (hoist everything version-derived) was 6-7x on its own before any instruction-level work: the per-module `IsFunctionModule` predicate + `col / 3` were the placer. Every later rung (bit expansion, pair stores, fused XOR) added 1.2-1.7x each; the fixed-cost trims mattered only once the loop was cheap (a ~1.9 KB stack zeroing was 25 % of the smallest version).
+- Strided byte scatter runs at ~1 store per cycle and neither wider stores per row nor AVX-512 scatter change that; the win is in touching fewer bytes per module (bit-per-byte expansion, no per-module shifts), not in wider stores.
+- Keep the reference painter: it builds the tables (correct by construction), stays the decoder's predicate, and is the parity oracle — the fast path never re-derives geometry.
+
+**Benchmark delta (`RmQREncodeEndToEnd`, net10.0 Release, --launchCount 3 --warmupCount 3 --iterationCount 15, before = HEAD 9b4a095, after = this change; kernel numbers from the kernel benchmark loop)**
+
+| Benchmark | Before | After | Delta |
+|---|---|---|---|
+| RmQR_Numeric_R7x43_Encode | 1.191 µs / 112 B | 329 ns / 112 B | -72 % |
+| RmQR_Alphanumeric_R11x59_Encode | 3.173 µs / 160 B | 614 ns / 160 B | -81 % |
+| RmQR_Byte_R17x139_Encode | 14.67 µs / 368 B | 2.379 µs / 368 B | -84 % |
+| RmQR_Numeric_R7x43_Encode (Span) | 1.061 µs | 179 ns | -83 % |
+| RmQR_Alphanumeric_R11x59_Encode (Span) | 2.699 µs | 318 ns | -88 % |
+| RmQR_Byte_R17x139_Encode (Span) | 13.65 µs | 1.054 µs | -92 % |
+| RmQR_Numeric_AutoFit_Encode (Span) | 1.115 µs | 358 ns | -68 % |
+| StandardQr_Numeric_V1_Encode (Span) (untouched control) | 2.116 µs | 2.182 µs | +3 % (drift) |
+
+Kernel: 864 → 49 ns (R7x43), 2,304 → 123 ns (R11x59), 5,730 → 252 ns (R13x99-H), 12,721 → 473 ns (R17x139), 0 B; E2E 6-13x on the span paths because the placer was 80-90 % of the encode. Remaining encode-side levers, in order: automatic version selection (AutoFit 358 vs fixed 179 ns — the fit scan is now half of a small encode), the `RmQRCodeData` result object and its packing on the class API, and the quiet-zone copy of the span path.

--- a/.github/docs/plans/skiasharp-qrcode-rmqr-implementation-plan.md
+++ b/.github/docs/plans/skiasharp-qrcode-rmqr-implementation-plan.md
@@ -74,7 +74,7 @@ Rejected: encoding the strategy inside `RmQRVersion` (mixes exact sizes with pol
 
 ### Performance posture
 
-Correct-and-clear first, then measured optimization, exactly the Micro QR sequence: reference per-module placer + naive bit-string references first, parity tests, then a fused fast path in a follow-up with kernel benchmarks in the private MicroBenchmarks repo and E2E in `SkiaSharp.QrCode.Benchmark`. Note for that follow-up: rows up to 139 modules no longer fit one ulong (Micro QR's packed-row and PEXT/PDEP tricks assumed ≤ 17), and there is no mask scoring at all, so the profile will differ; do not port Micro QR kernels blindly. Zero allocation on the span paths is a Phase 5 requirement, not a follow-up.
+Correct-and-clear first, then measured optimization, exactly the Micro QR sequence: reference per-module placer + naive bit-string references first, parity tests, then a fused fast path in a follow-up with kernel benchmarks and E2E in `SkiaSharp.QrCode.Benchmark`. Note for that follow-up: rows up to 139 modules no longer fit one ulong (Micro QR's packed-row and PEXT/PDEP tricks assumed ≤ 17), and there is no mask scoring at all, so the profile will differ; do not port Micro QR kernels blindly. Zero allocation on the span paths is a Phase 5 requirement, not a follow-up.
 
 ### Decoder architecture
 
@@ -192,7 +192,7 @@ Exit (Phase 7): decoder MVT image rows and the representative degradation subset
 
 ### Follow-ups (after Phase 7, optional, benchmark-driven)
 
-- Placer / bit-stream fast paths (private MicroBenchmarks kernel loop, disassembly-read, SIMD rounds in scope), ported back with parity tests exactly as the Micro QR follow-ups.
+- Placer / bit-stream fast paths (kernel benchmark loop, disassembly-read, SIMD rounds in scope), ported back with parity tests exactly as the Micro QR follow-ups.
 - ECI emission in the encoder; Kanji mode across symbologies (single decision, three symbologies).
 
 ## Dependency graph
@@ -531,3 +531,32 @@ Three review rounds (independent reviewer agents per lens: correctness, performa
 | R17x139_ImageDecode_Span | 127 µs | 129 µs | |
 
 Allocations identical on every row (span paths 0 B). The encode / decode "after" run landed on a noisier machine state (StdErr 5-30 % vs 1-3 % before): the untouched Standard QR reference rows moved by the same +6 % (decode) / +19 % (encode) as the rMQR rows, and the fixed-version encode rows execute byte-identical code before and after (the encode-path changes are the version-selector failure scan, bypassed by a requested version and strictly less work on auto fit, and the UTF-8 branch of WriteByte, which the ASCII benchmark payloads never take), so the rMQR deltas are run-to-run noise, not the review changes; the decoder change decodes the same two format copies as before. The PNG rows are a real improvement (the width-only default is now an opaque RGB surface). Image decode is flat.
+
+### Follow-up: bit-stream fast path (`RmQRBinaryEncoder`), completed 2026-08-16
+
+The first of the post-Phase-7 kernel rounds (kernel benchmark loop: 19 variants over 3 rounds, byte-identical gate of 35,851 encodes per variant against the verbatim baseline, disassembly-read, converged when round 3 fell inside the canary band).
+
+**Done**
+
+- `src`: `RmQRBinaryEncoder` rewritten around a raw-local writer (64-bit MSB-first accumulator, pending-bit count, byte position, `ref byte` destination threaded through inlined `Append` / `AppendWide` / `Append64`; no per-flush slice checks because every stored bit is real data inside the capacity that version selection guarantees). Numeric: 64-bit SWAR 3-digit groups, 9 digits per 30-bit append, x64 SSSE3/SSE4.1 tier 12 digits per `pmaddwd` / `phaddd` / `packusdw` / `pmaddwd` → 40-bit append. Alphanumeric: unchecked value table with 2 pairs per 22-bit append, x64 tier 8 chars per `pshufb`-classified values + `pmaddubsw`(45,1) + `pmaddwd`(2048,1) → 44-bit append. Byte: SSE2 narrow 8 chars per 64-bit append; UTF-8 in a separate `NoInlining` cold function with its own writer (Micro QR's address-exposure lesson), still `Encoding.UTF8` into the 160-byte stack budget. Terminator + alignment are bit-count arithmetic; pads are 8-byte 0xEC11 stores; the mode switch computes its own header. Vector tiers are `NET8_0_OR_GREATER` + capability gated; netstandard / non-x86 take the SWAR / table paths. Allocation contract unchanged (netstandard2.0 UTF-8 remains the documented exception).
+- Tests (+40 on each TFM; full suite net10.0 5,007 / net8.0 4,995, 0 failed): `RmQRBinaryEncoderKernelParityTest` drives each internal segment writer with `vectorized` = true / false from the same pre-seeded writer state (13 header phases × every length up to R17x139-M capacity × min / max / cyclic / random contents; every alphanumeric symbol through every vector lane) and compares the logical bit stream (stored bytes + pending bits, because `AppendWide` may leave exactly 32 bits pending where `Append` flushes). The existing `RmQRBinaryEncoderParityTest` (naive reference, all 64 × 3 modes × every length) and the corpus-oracle unit tests pin the end-to-end stream unchanged.
+- Refuted along the way (kept in the kernel findings log): `Encoding.Latin1` bulk narrowing (loses to a direct SSE2 pack once the input is known Latin-1), the hand-rolled UTF-8 encoder (loses to `Encoding.UTF8` at 150 bytes; Micro QR's ≤ 15-byte finding does not transfer), a 16-char byte block with hoisted shift (neutral), and single-switch / zero-skip fixed-cost trims (neutral, shipped only as the simpler shape).
+
+**Lessons learned**
+
+- The shared `BitWriter` ref struct IS fully promoted by the JIT; what it pays for is the `Span.Slice` range check on every 32-bit flush (~6 instructions). A `ref byte` writer with a proven capacity contract halves the writer cost at rMQR sizes — worth revisiting for the Standard QR encoder, whose acc64 round stopped at the struct.
+- `pmaddwd` pairs are fixed at lanes (0,1),(2,3),…: a 3-digit group cannot straddle a pair, so "two groups per 8-char load" silently reverses every second group. The gate caught it before any measurement; the shipped shape is one group per load from four overlapping loads.
+- Layout noise dominates at 10-50 ns when every variant is a different compilation of one large method (mode switch inside): the canary moved up to ±32 % in one round, and variants that changed only the numeric path moved the byte scenario by +47 %. Read the column of the mode a variant changed; treat cross-mode swings as noise; never accept a < 3 % delta from one run.
+- Inlining hot writers is only a win once the writer body is lean: forcing the checked `GetAlphanumericValue` (two throw branches per char) inline regressed alnum 1.6-1.8x until the unchecked table replaced it.
+
+**Benchmark delta (`RmQREncodeEndToEnd`, net10.0 Release, --launchCount 3 --warmupCount 3 --iterationCount 15, before = HEAD 62c0268, after = this change; kernel numbers from the kernel benchmark loop)**
+
+| Benchmark | Before | After | Kernel before → after |
+|---|---|---|---|
+| RmQR_Numeric_R7x43_Encode (Span) | 1.125 µs | 1.047 µs | 16 → 12 ns |
+| RmQR_Alphanumeric_R11x59_Encode (Span) | 2.843 µs | 2.821 µs | 55 → 16 ns |
+| RmQR_Byte_R17x139_Encode (Span) | 14.52 µs | 14.05 µs | 177 → 23 ns |
+| RmQR_Numeric_AutoFit_Encode (Span) | 1.157 µs | 1.119 µs | |
+| StandardQr_Numeric_V1_Encode (Span) (untouched control) | 1.891 µs | 2.072 µs | |
+
+Kernel: 1.3x (12 digits) to 7.5x (150 Latin-1 bytes), 2.6x on the largest numeric (361 digits: 199 → 80 ns), 5.6x on the largest alphanumeric (219 chars: 268 → 48 ns), 0 B everywhere. E2E: the encoder is 1-2 % of the encode pipeline (placement dominates: R17x139 spends ~14 µs painting 2,363 modules), so the E2E rows move by 1-7 %, at or below the run-to-run band (the untouched control drifted +9.6 %). The next lever for the encode E2E is the placer fast path listed under Follow-ups, not the bit stream.

--- a/.github/docs/specs/rmqr-encoder.md
+++ b/.github/docs/specs/rmqr-encoder.md
@@ -222,7 +222,7 @@ Blocks per the table (smaller data blocks first, sizes differ by at most one), E
 
 ### 7. Place function patterns and data
 
-Finder (7×7 with separators), sub-finder (5×5), four edge timing patterns, the two corner patterns, vertical timing columns with 3×3 alignment patterns at both ends, and both format regions are function modules; data fills the rest in zigzag order. Coordinates live in code comments in Phase 5.5.
+Finder (7×7 with separators), sub-finder (5×5), four edge timing patterns, the two corner patterns, vertical timing columns with 3×3 alignment patterns at both ends, and both format regions are function modules; data fills the rest in zigzag order. Coordinates live in code comments in Phase 5.5. The fast placer reproduces the reference module for module from cached per-version tables (see Decisions).
 
 ### 8. Fixed mask, 9. format information
 
@@ -255,7 +255,7 @@ The single mask is applied to data modules while placing. Both format copies com
 | ECI on encode | Not emitted | Interop demand; decoder parses ECI regardless |
 | Kanji | Deferred (tables keep the column) | Cross-symbology decision |
 | Interleaver | Lifted `BinaryInterleaver` to `Internals.BinaryEncoders` (Phase 5.4): it never used the version, only the `ECCInfo` block structure; the remainder-bit count became a parameter | - |
-| Placer performance | Reference per-module placer first; fused/SIMD fast path as a benchmark-driven follow-up | After Phase 7 |
+| Placer performance | Reference per-module placer first (Phase 5.5), then the benchmark-driven fast path (follow-up, 2026-08-16): per-version tables built once by the reference painters (painted template per version × ECC, zigzag order as core indices, mask per position, column-pair segmentation), vector bit expansion fused with the mask, 16-bit pair stores + index scatter; the reference stays the source of truth (tables, decoder predicate) and the parity test pins both | - |
 | Bit-stream performance | Reference shape first (Phase 5.3), then the benchmark-driven fast path (follow-up, 2026-08-16): raw-local writer, SWAR / SSE numeric and alphanumeric value kernels, SSE2 byte narrowing, capability-gated with scalar fallbacks; kernel-level parity tests pin vector vs scalar, the naive-reference parity pins the stream | - |
 
 ## Verification record

--- a/.github/docs/specs/rmqr-encoder.md
+++ b/.github/docs/specs/rmqr-encoder.md
@@ -214,7 +214,7 @@ Required bits = 3 (mode) + count indicator (per version, table above) + payload 
 
 ### 4. Build the data codewords
 
-3-bit mode indicator, count indicator, payload bits, terminator `000` (shortened at capacity), zero bits to a byte boundary, alternating 0xEC / 0x11 pads to the data-codeword count.
+3-bit mode indicator, count indicator, payload bits, terminator `000` (shortened at capacity), zero bits to a byte boundary, alternating 0xEC / 0x11 pads to the data-codeword count. The stream is written straight into the caller's buffer (no intermediate copy); vectorized value kernels exist per mode on x64 (see Decisions), all producing the identical stream.
 
 ### 5. Reed-Solomon per block, 6. interleave
 
@@ -256,6 +256,7 @@ The single mask is applied to data modules while placing. Both format copies com
 | Kanji | Deferred (tables keep the column) | Cross-symbology decision |
 | Interleaver | Lifted `BinaryInterleaver` to `Internals.BinaryEncoders` (Phase 5.4): it never used the version, only the `ECCInfo` block structure; the remainder-bit count became a parameter | - |
 | Placer performance | Reference per-module placer first; fused/SIMD fast path as a benchmark-driven follow-up | After Phase 7 |
+| Bit-stream performance | Reference shape first (Phase 5.3), then the benchmark-driven fast path (follow-up, 2026-08-16): raw-local writer, SWAR / SSE numeric and alphanumeric value kernels, SSE2 byte narrowing, capability-gated with scalar fallbacks; kernel-level parity tests pin vector vs scalar, the naive-reference parity pins the stream | - |
 
 ## Verification record
 
@@ -283,6 +284,8 @@ Pre-implementation (from the verification itself):
 - On multi-block versions the leading data bytes in placement order are interleaved; any "read the first bits" check must deinterleave first or it silently reads block-2 codewords.
 
 Implementation lessons: appended per phase (Phase 5 progress log in the [implementation plan](../plans/skiasharp-qrcode-rmqr-implementation-plan.md), then consolidated here).
+
+- Bit-stream fast path (follow-up, 2026-08-16): a memory-backed writer's cost is the per-flush range check, not the struct; a fixed-lane horizontal instruction (`pmaddwd`) cannot express a 3-digit group that straddles its lane pairs, so the group must own the load; at 10-50 ns per encode, code-layout noise (±30 % on identical code) is the measurement floor, and only same-run, same-mode deltas above it count. Details in the plan's progress log.
 
 ## Validation
 

--- a/.github/docs/specs/rmqr-spec-map.md
+++ b/.github/docs/specs/rmqr-spec-map.md
@@ -4,7 +4,7 @@ An index of where each part of the rMQR Code symbology specification (ISO/IEC 23
 
 This document is intentionally a **map, not a spec copy**. The normative details, bit layouts, formulas, edge-case constraints, and the reasoning behind implementation choices, live in code comments next to the implementation, where they stay in sync with the code.
 
-Status: **encoder, rendering, matrix decoder and image detection implemented (Phases 5-7)**. Follow-ups (fused placer fast path, kernel tuning) are listed in the [rMQR implementation plan](../plans/skiasharp-qrcode-rmqr-implementation-plan.md). Rows whose parameters were already verified against external oracles before implementation say so; the verification record is in the design record.
+Status: **encoder, rendering, matrix decoder and image detection implemented (Phases 5-7)**. Follow-ups (remaining kernel tuning; the bit-stream and placer fast paths shipped 2026-08-16) are listed in the [rMQR implementation plan](../plans/skiasharp-qrcode-rmqr-implementation-plan.md). Rows whose parameters were already verified against external oracles before implementation say so; the verification record is in the design record.
 
 ## Encoding Pipeline Overview
 

--- a/src/SkiaSharp.QrCode/Internals/MicroQR/MicroQRModulePlacer.PlaceSymbol.cs
+++ b/src/SkiaSharp.QrCode/Internals/MicroQR/MicroQRModulePlacer.PlaceSymbol.cs
@@ -391,7 +391,7 @@ internal static partial class MicroQRModulePlacer
     /// guarantees SSSE3 or AdvSimd.Arm64; IsSupported is a JIT constant so the
     /// untaken branch is eliminated.
     /// x86: PSHUFB + PAND + PCMPEQB, beat the GFNI bit-expand in the
-    /// micro-benchmark loop (GFNI's matrix-operand preparation outweighs its
+    /// kernel benchmark loop (GFNI's matrix-operand preparation outweighs its
     /// single-instruction expand).
     /// ARM64: TBL + CMTST, CMTST (compare-test: 0xFF iff (a &amp; b) != 0)
     /// fuses the AND+CMEQ pair; x86 has no per-lane bit-test compare.
@@ -423,7 +423,7 @@ internal static partial class MicroQRModulePlacer
     /// no cross-row dependency), the stream word count is dispatched per size
     /// (M1 fits one word, M2 two), and the unpack expands 32 modules per AVX2
     /// step. Measured over the SSSE3 pipeline: M4 -29%, M3 -22%, M2 -10%,
-    /// M1 -5% (micro-benchmark rounds 8-11).
+    /// M1 -5% (kernel benchmark rounds 8-11).
     /// </summary>
     private static int PlaceCoreBmi2(Span<byte> matrix, int size, ReadOnlySpan<ulong> stream, MicroQRVersion version, MicroQREccLevel eccLevel)
     {

--- a/src/SkiaSharp.QrCode/Internals/RmQr/RmQRBinaryEncoder.cs
+++ b/src/SkiaSharp.QrCode/Internals/RmQr/RmQRBinaryEncoder.cs
@@ -1,7 +1,13 @@
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
-using SkiaSharp.QrCode.Internals.BinaryEncoders;
+#if NET8_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
 
 namespace SkiaSharp.QrCode.Internals.RmQr;
 
@@ -11,14 +17,36 @@ namespace SkiaSharp.QrCode.Internals.RmQr;
 /// capacity), zero bits to the byte boundary, then alternating 0xEC / 0x11 pad
 /// codewords up to the data codeword count. Single segment; ECI headers are not
 /// emitted (non-Latin-1 text is carried as UTF-8 bytes in Byte mode, the Micro QR
-/// precedent). Allocation-free: the shared <see cref="BitWriter"/> writes straight
-/// into the caller's destination and byte-mode transcoding uses a fixed
-/// stack budget with a pool fallback.
+/// precedent). Allocation-free: bits are written straight into the caller's
+/// destination and byte-mode transcoding uses a fixed stack budget with a pool
+/// fallback.
 /// </summary>
 /// <remarks>
-/// This is the readable reference-shaped implementation; a register-accumulator
-/// fast path (as Micro QR's) is a benchmark-driven follow-up and must stay parity
-/// tested against <c>RmQRNaiveReference.NaiveDataCodewords</c>.
+/// Performance design (benchmark-driven, parity-pinned by
+/// <c>RmQRBinaryEncoderParityTest</c> / <c>RmQRBinaryEncoderKernelParityTest</c>):
+/// <list type="bullet">
+/// <item>Writer state is three raw locals (64-bit MSB-first accumulator, pending bit
+/// count, byte position) plus a <c>ref byte</c> into the destination, threaded by
+/// ref through inlined helpers. Every flushed word is real data inside the
+/// capacity that version selection guarantees, so stores need no per-flush slice
+/// bounds checks (measured ~2x over the shared <c>BitWriter</c> at this size).</item>
+/// <item>Numeric: 3-digit group values by 64-bit SWAR (one load + one multiply),
+/// 9 digits per 30-bit append; on x64 with SSSE3/SSE4.1, 12 digits per iteration
+/// via <c>pmaddwd</c> (one group per 8-char load), <c>phaddd</c>, <c>packusdw</c>,
+/// <c>pmaddwd</c> into one 40-bit append.</item>
+/// <item>Alphanumeric: unchecked 128-entry value table, 2 pairs per 22-bit append;
+/// on x64 with SSSE3/SSE4.1, 8 chars per iteration: <c>pshufb</c> offset classes
+/// (row 0x2_ specials, row 0x3_ digits + ':', letters) then
+/// <c>pmaddubsw</c>(45,1) and <c>pmaddwd</c>(2048,1) into one 44-bit append.</item>
+/// <item>Byte (Latin-1): SSE2 narrows 8 chars per 64-bit append; UTF-8 runs as a
+/// separate cold function with its own writer (sharing the accumulator by ref with
+/// a non-inlined callee would address-expose it, Micro QR lesson).</item>
+/// <item>Terminator / alignment are bit-count arithmetic; the pad run is written as
+/// 8-byte 0xEC11 pattern stores.</item>
+/// </list>
+/// The mode switch computes the header for its own segment (one dispatch instead of
+/// three chained switches). Vector paths are <c>NET8_0_OR_GREATER</c> + capability
+/// gated; netstandard and non-x86 runtimes take the scalar SWAR / table paths.
 /// </remarks>
 internal static class RmQRBinaryEncoder
 {
@@ -48,98 +76,247 @@ internal static class RmQRBinaryEncoder
             throw new ArgumentException($"Destination too small: {codewordCount} data codewords required, got {destination.Length} bytes.", nameof(destination));
         Debug.Assert(RmQRVersionSelector.GetRequiredBits(version, mode, analysis.DataLength) <= capacityBits, "content must fit (version selection guarantees this)");
 
-        var writer = new BitWriter(destination.Slice(0, codewordCount));
-        writer.Write(RmQRConstants.GetModeIndicatorValue(mode), RmQRConstants.ModeIndicatorLength);
-        writer.Write(analysis.DataLength, RmQRConstants.GetCountIndicatorLength(version, mode));
+        // Writer state: 64-bit MSB-first accumulator, pending bit count (0..32
+        // between appends), byte position; every store below lands inside
+        // [0, codewordCount) because all stored bits are real data bits within the
+        // capacity asserted above.
+        ref var dest = ref MemoryMarshal.GetReference(destination);
+        ulong acc = 0;
+        var accBits = 0;
+        var bytePos = 0;
 
         switch (mode)
         {
             case EncodingMode.Numeric:
-                WriteNumeric(ref writer, text);
-                break;
+                {
+                    var countBits = RmQRConstants.GetCountIndicatorLength(version, EncodingMode.Numeric);
+                    Append(ref dest, ref acc, ref accBits, ref bytePos, (0b001 << countBits) | analysis.DataLength, RmQRConstants.ModeIndicatorLength + countBits);
+                    WriteNumeric(ref dest, ref acc, ref accBits, ref bytePos, text, vectorized: true);
+                    break;
+                }
             case EncodingMode.Alphanumeric:
-                WriteAlphanumeric(ref writer, text);
-                break;
+                {
+                    var countBits = RmQRConstants.GetCountIndicatorLength(version, EncodingMode.Alphanumeric);
+                    Append(ref dest, ref acc, ref accBits, ref bytePos, (0b010 << countBits) | analysis.DataLength, RmQRConstants.ModeIndicatorLength + countBits);
+                    WriteAlphanumeric(ref dest, ref acc, ref accBits, ref bytePos, text, vectorized: true);
+                    break;
+                }
             case EncodingMode.Byte:
-                WriteByte(ref writer, text, analysis.EciMode, analysis.DataLength);
-                break;
+                {
+                    var countBits = RmQRConstants.GetCountIndicatorLength(version, EncodingMode.Byte);
+                    var headerValue = (0b011 << countBits) | analysis.DataLength;
+                    var headerBits = RmQRConstants.ModeIndicatorLength + countBits;
+                    if (analysis.EciMode is EciMode.Default or EciMode.Iso8859_1)
+                    {
+                        Append(ref dest, ref acc, ref accBits, ref bytePos, headerValue, headerBits);
+                        WriteLatin1(ref dest, ref acc, ref accBits, ref bytePos, text, vectorized: true);
+                        break;
+                    }
+                    if (analysis.EciMode != EciMode.Utf8)
+                        throw new ArgumentOutOfRangeException(nameof(analysis), $"Unsupported charset {analysis.EciMode} for rMQR Byte mode.");
+                    return EncodeUtf8Codewords(text, codewordCount, capacityBits, headerValue, headerBits, analysis.DataLength, destination);
+                }
             default:
                 throw new ArgumentOutOfRangeException(nameof(analysis), $"Encoding mode {mode} is not supported by rMQR.");
         }
 
-        // Terminator: 000, shortened to whatever capacity remains (possibly zero bits).
-        var terminator = Math.Min(RmQRConstants.TerminatorLength, capacityBits - writer.BitPosition);
-        if (terminator > 0)
-            writer.Write(0, terminator);
-
-        // Zero bits to the byte boundary (capacity is a whole number of bytes, so
-        // this never overruns), then alternating pad codewords.
-        var misalignment = writer.BitPosition & 7;
-        if (misalignment != 0)
-            writer.Write(0, 8 - misalignment);
-        writer.WritePadBytes(codewordCount - writer.BitPosition / 8);
-
-        Debug.Assert(writer.BitPosition == capacityBits);
+        Finish(ref dest, acc, accBits, bytePos, codewordCount, capacityBits);
         return codewordCount;
     }
 
-    /// <summary>Digits in groups of three (10 bits), a two-digit tail (7 bits) or one-digit tail (4 bits).</summary>
-    private static void WriteNumeric(ref BitWriter writer, ReadOnlySpan<char> digits)
+    // ---------------------------------------------------------------
+    // Segment writers. Internal + AggressiveInlining: the production call sites
+    // above inline them (so the writer locals stay enregistered), while the kernel
+    // parity tests call them directly with vectorized = true / false.
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// Numeric segment: 10/7/4 bits per 3/2/1 digits. Contract: digits are '0'-'9'
+    /// (validated by the analyzer); the SWAR / SIMD group math produces a wrong but
+    /// memory-safe stream otherwise.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void WriteNumeric(ref byte dest, ref ulong acc, ref int accBits, ref int bytePos, ReadOnlySpan<char> digits, bool vectorized)
     {
+        Debug.Assert(AllNumeric(digits), "caller must validate the numeric alphabet");
+
+        ref var c = ref MemoryMarshal.GetReference(digits);
+        var length = digits.Length;
         var i = 0;
-        for (; i + 3 <= digits.Length; i += 3)
-        {
-            var value = (digits[i] - '0') * 100 + (digits[i + 1] - '0') * 10 + (digits[i + 2] - '0');
-            writer.Write(value, 10);
-        }
 
-        switch (digits.Length - i)
+#if NET8_0_OR_GREATER
+        if (vectorized && Sse41.IsSupported && Ssse3.IsSupported)
         {
-            case 2:
-                writer.Write((digits[i] - '0') * 10 + (digits[i + 1] - '0'), 7);
-                break;
-            case 1:
-                writer.Write(digits[i] - '0', 4);
-                break;
+            // pmaddwd pairs are fixed at lanes (0,1),(2,3),... so a 3-digit group cannot
+            // straddle a pair: one group per 8-char load (weights 100,10 | 1,0 | 0,0 | 0,0)
+            // from four loads at i, i+3, i+6, i+9. The last load reads chars i+9..i+16,
+            // hence the i+17 <= length guard; the SWAR loops below take the tail.
+            //   phaddd x3      -> [G0, G1, G2, G3] (each group + '0' bias 5328)
+            //   packusdw       -> 16-bit lanes
+            //   pmaddwd(1024,1)-> [G0*1024+G1, G2*1024+G3] = two 20-bit halves + 5328*1025 each
+            ref var t = ref Unsafe.As<char, short>(ref c);
+            var w = Vector128.Create((short)100, 10, 1, 0, 0, 0, 0, 0);
+            var pw = Vector128.Create((short)1024, 1, 1024, 1, 1024, 1, 1024, 1);
+            for (; i + 17 <= length; i += 12)
+            {
+                var a = Sse2.MultiplyAddAdjacent(Vector128.LoadUnsafe(ref t, (nuint)i), w);
+                var b = Sse2.MultiplyAddAdjacent(Vector128.LoadUnsafe(ref t, (nuint)(i + 3)), w);
+                var c2 = Sse2.MultiplyAddAdjacent(Vector128.LoadUnsafe(ref t, (nuint)(i + 6)), w);
+                var d = Sse2.MultiplyAddAdjacent(Vector128.LoadUnsafe(ref t, (nuint)(i + 9)), w);
+                var s = Ssse3.HorizontalAdd(Ssse3.HorizontalAdd(a, b), Ssse3.HorizontalAdd(c2, d));
+                var p = Sse41.PackUnsignedSaturate(s, s);
+                var q = Sse2.MultiplyAddAdjacent(p.AsInt16(), pw).AsUInt64().ToScalar() - SimdNumericBiasPair;
+                AppendWide(ref dest, ref acc, ref accBits, ref bytePos, ((q & 0xFFFFF) << 20) | (q >> 32), 40);
+            }
         }
-    }
+#endif
 
-    /// <summary>Character pairs as 45·a + b (11 bits), a single tail character as 6 bits.</summary>
-    private static void WriteAlphanumeric(ref BitWriter writer, ReadOnlySpan<char> chars)
-    {
-        var i = 0;
-        for (; i + 2 <= chars.Length; i += 2)
+        // 9 digits -> one 30-bit append; the SWAR load at i+6 reads chars i+6..i+9,
+        // so a 10th char must exist: i + 9 < length
+        for (; i + 9 < length; i += 9)
         {
-            writer.Write(CharacterSets.GetAlphanumericValue(chars[i]) * 45 + CharacterSets.GetAlphanumericValue(chars[i + 1]), 11);
+            var g = (SwarGroup(ref c, i) << 20) | (SwarGroup(ref c, i + 3) << 10) | SwarGroup(ref c, i + 6);
+            Append(ref dest, ref acc, ref accBits, ref bytePos, g, 30);
         }
-
-        if (i < chars.Length)
-            writer.Write(CharacterSets.GetAlphanumericValue(chars[i]), 6);
+        // 3 digits per append while a 4th readable char exists
+        for (; i + 3 < length; i += 3)
+        {
+            Append(ref dest, ref acc, ref accBits, ref bytePos, SwarGroup(ref c, i), 10);
+        }
+        // scalar tail: 0-3 digits left, no headroom for an 8-byte load; the per-digit
+        // '0' offsets fold into one subtract (5328 = '0' * 111, 528 = '0' * 11)
+        if (i + 2 < length)
+        {
+            Append(ref dest, ref acc, ref accBits, ref bytePos, digits[i] * 100 + digits[i + 1] * 10 + digits[i + 2] - 5328, 10);
+            i += 3;
+        }
+        if (i + 1 < length)
+        {
+            Append(ref dest, ref acc, ref accBits, ref bytePos, digits[i] * 10 + digits[i + 1] - 528, 7);
+        }
+        else if (i < length)
+        {
+            Append(ref dest, ref acc, ref accBits, ref bytePos, digits[i] - '0', 4);
+        }
     }
 
     /// <summary>
-    /// Byte mode: chars ≤ 0xFF narrow directly (Default / ISO-8859-1, validated by
-    /// the analyzer); otherwise the text is transcoded to UTF-8 (no ECI header).
-    /// <paramref name="byteCount"/> is the analyzer's exact encoded length, which
-    /// picks the stack budget for every payload that passed version selection.
+    /// Alphanumeric segment: 11 bits per pair (45·a + b), 6 bits for a trailing
+    /// character. Contract: the alphabet is validated by the analyzer; the
+    /// <c>&amp; 0x7F</c> table index is memory-safe for any input but does not
+    /// sanitize.
     /// </summary>
-    private static void WriteByte(ref BitWriter writer, ReadOnlySpan<char> text, EciMode eciMode, int byteCount)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void WriteAlphanumeric(ref byte dest, ref ulong acc, ref int accBits, ref int bytePos, ReadOnlySpan<char> chars, bool vectorized)
     {
-        if (eciMode is EciMode.Default or EciMode.Iso8859_1)
-        {
-            for (var i = 0; i < text.Length; i++)
-                writer.Write((byte)text[i], 8);
-            return;
-        }
+        Debug.Assert(AllAlphanumeric(chars), "caller must validate the alphanumeric alphabet");
 
-        if (eciMode != EciMode.Utf8)
-            throw new ArgumentOutOfRangeException(nameof(eciMode), $"Unsupported charset {eciMode} for rMQR Byte mode.");
+        var i = 0;
+
+#if NET8_0_OR_GREATER
+        if (vectorized && Sse41.IsSupported && Ssse3.IsSupported)
+        {
+            // value = char + offset, offset chosen by the char's row (high nibble):
+            //   0x2_: ' '=36 (+4), '$'=37 '%'=38 (+1), '*'=39 '+'=40 (-3), '-'=41 '.'=42 '/'=43 (-4)
+            //   0x3_: '0'..'9' -> 0..9 (-48), ':' -> 44 (-14)
+            //   0x4_/0x5_: 'A'..'Z' -> 10..35 (-55)
+            // Two pshufb tables indexed by the low nibble cover rows 0x2_/0x3_, one
+            // constant covers letters; then pmaddubsw(45,1) forms the 4 pair values and
+            // pmaddwd(2048,1) two 22-bit quads -> one 44-bit append per 8 chars.
+            ref var t = ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(chars));
+            var row2 = Vector128.Create((sbyte)4, 0, 0, 0, 1, 1, 0, 0, 0, 0, -3, -3, 0, -4, -4, -4);
+            var row3 = Vector128.Create((sbyte)-48, -48, -48, -48, -48, -48, -48, -48, -48, -48, -14, 0, 0, 0, 0, 0);
+            var pairW = Vector128.Create((sbyte)45, 1, 45, 1, 45, 1, 45, 1, 45, 1, 45, 1, 45, 1, 45, 1);
+            var quadW = Vector128.Create((short)2048, 1, 2048, 1, 2048, 1, 2048, 1);
+            var three = Vector128.Create((byte)3);
+            var lowNibble = Vector128.Create((byte)0x0F);
+            var minus55 = Vector128.Create((sbyte)-55);
+            for (; i + 8 <= chars.Length; i += 8)
+            {
+                var v = Vector128.LoadUnsafe(ref t, (nuint)i);
+                var b = Sse2.PackUnsignedSaturate(v.AsInt16(), v.AsInt16());   // 8 chars -> 8 bytes (duplicated)
+                var lo = b & lowNibble;
+                var hi = (b.AsUInt16() >> 4).AsByte() & lowNibble;
+                var off = Ssse3.Shuffle(row2, lo.AsSByte());
+                var off3 = Ssse3.Shuffle(row3, lo.AsSByte());
+                off = Sse41.BlendVariable(off, off3, Sse2.CompareEqual(hi, three).AsSByte());
+                off = Sse41.BlendVariable(off, minus55, Sse2.CompareGreaterThan(hi.AsSByte(), three.AsSByte()));
+                var values = (b.AsSByte() + off).AsByte();                                    // 0..44
+                var pairs = Ssse3.MultiplyAddAdjacent(values, pairW);                        // 4 x (v0*45 + v1), 16-bit
+                var quads = Sse2.MultiplyAddAdjacent(pairs, quadW).AsUInt64().ToScalar();    // [p0*2048+p1 | (p2*2048+p3) << 32]
+                AppendWide(ref dest, ref acc, ref accBits, ref bytePos, ((quads & 0x3FFFFF) << 22) | (quads >> 32), 44);
+            }
+        }
+#endif
+
+        // 4 chars = 2 pairs -> one 22-bit append
+        for (; i + 3 < chars.Length; i += 4)
+        {
+            var p0 = AlnumValues[chars[i] & 0x7F] * 45 + AlnumValues[chars[i + 1] & 0x7F];
+            var p1 = AlnumValues[chars[i + 2] & 0x7F] * 45 + AlnumValues[chars[i + 3] & 0x7F];
+            Append(ref dest, ref acc, ref accBits, ref bytePos, (p0 << 11) | p1, 22);
+        }
+        if (i + 1 < chars.Length)
+        {
+            Append(ref dest, ref acc, ref accBits, ref bytePos, AlnumValues[chars[i] & 0x7F] * 45 + AlnumValues[chars[i + 1] & 0x7F], 11);
+            i += 2;
+        }
+        if (i < chars.Length)
+        {
+            Append(ref dest, ref acc, ref accBits, ref bytePos, AlnumValues[chars[i] & 0x7F], 6);
+        }
+    }
+
+    /// <summary>
+    /// Byte segment for Default / ISO-8859-1 text (every char ≤ 0xFF, validated by
+    /// the analyzer): 8 chars narrow to one 64-bit append on SSE2, scalar otherwise.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void WriteLatin1(ref byte dest, ref ulong acc, ref int accBits, ref int bytePos, ReadOnlySpan<char> text, bool vectorized)
+    {
+        var i = 0;
+#if NET8_0_OR_GREATER
+        if (vectorized && Sse2.IsSupported)
+        {
+            // PackUnsignedSaturate narrows 16-bit lanes to bytes (the same vector twice
+            // duplicates the result; ToScalar takes the low 8 bytes). Saturation cannot
+            // corrupt data because every lane is <= 0xFF. The pack puts the FIRST char in
+            // the LOWEST byte while the stream wants it first, so byte-swap.
+            ref var t = ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(text));
+            for (; i + 8 <= text.Length; i += 8)
+            {
+                var v = Vector128.LoadUnsafe(ref t, (nuint)i);
+                var packed = Sse2.PackUnsignedSaturate(v.AsInt16(), v.AsInt16()).AsUInt64().ToScalar();
+                Append64(ref dest, ref acc, ref accBits, ref bytePos, BinaryPrimitives.ReverseEndianness(packed));
+            }
+        }
+#endif
+        for (; i < text.Length; i++)
+        {
+            Append(ref dest, ref acc, ref accBits, ref bytePos, (byte)text[i], 8);
+        }
+    }
+
+    /// <summary>
+    /// Byte segment for non-Latin-1 text: UTF-8 transcode (no ECI header) on a
+    /// private writer. <paramref name="byteCount"/> is the analyzer's exact encoded
+    /// length, which picks the stack budget for every payload that passed version
+    /// selection. Not inlined by design (see the class remarks).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int EncodeUtf8Codewords(ReadOnlySpan<char> text, int codewordCount, int capacityBits, int headerValue, int headerBits, int byteCount, Span<byte> destination)
+    {
+        ref var dest = ref MemoryMarshal.GetReference(destination);
+        ulong acc = 0;
+        var accBits = 0;
+        var bytePos = 0;
+        Append(ref dest, ref acc, ref accBits, ref bytePos, headerValue, headerBits);
 
         if (byteCount <= StackByteBudget)
         {
             Span<byte> utf8 = stackalloc byte[StackByteBudget];
             var length = GetUtf8Bytes(text, utf8);
-            WriteBytes(ref writer, utf8.Slice(0, length));
+            WriteBytes(ref dest, ref acc, ref accBits, ref bytePos, utf8.Slice(0, length));
         }
         else
         {
@@ -148,19 +325,30 @@ internal static class RmQRBinaryEncoder
             try
             {
                 var length = GetUtf8Bytes(text, rented);
-                WriteBytes(ref writer, rented.AsSpan(0, length));
+                WriteBytes(ref dest, ref acc, ref accBits, ref bytePos, rented.AsSpan(0, length));
             }
             finally
             {
                 ArrayPool<byte>.Shared.Return(rented);
             }
         }
+
+        Finish(ref dest, acc, accBits, bytePos, codewordCount, capacityBits);
+        return codewordCount;
     }
 
-    private static void WriteBytes(ref BitWriter writer, scoped ReadOnlySpan<byte> bytes)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteBytes(ref byte dest, ref ulong acc, ref int accBits, ref int bytePos, ReadOnlySpan<byte> bytes)
     {
-        for (var i = 0; i < bytes.Length; i++)
-            writer.Write(bytes[i], 8);
+        var i = 0;
+        for (; i + 8 <= bytes.Length; i += 8)
+        {
+            Append64(ref dest, ref acc, ref accBits, ref bytePos, BinaryPrimitives.ReadUInt64BigEndian(bytes.Slice(i)));
+        }
+        for (; i < bytes.Length; i++)
+        {
+            Append(ref dest, ref acc, ref accBits, ref bytePos, bytes[i], 8);
+        }
     }
 
     private static int GetUtf8Bytes(ReadOnlySpan<char> text, Span<byte> destination)
@@ -174,5 +362,200 @@ internal static class RmQRBinaryEncoder
         bytes.CopyTo(destination);
         return bytes.Length;
 #endif
+    }
+
+    // ---------------------------------------------------------------
+    // Group / value helpers
+    // ---------------------------------------------------------------
+
+    // SWAR (SIMD Within A Register): one ulong holds four 16-bit UTF-16 lanes,
+    // turning a 3-digit group into its numeric value with a single 64-bit
+    // multiply instead of per-digit subtracts and multiplies.
+    //
+    //   chunk = 4 chars, unaligned 8-byte read; "1234" lays out little-endian as
+    //           lanes  '1' | '2' | '3' | '4'
+    //   chunk - SwarDigitBias   subtracts '0' from every lane:
+    //           lanes   1  |  2  |  3  |  4
+    //   * SwarGroupMagic (100<<32 | 10<<16 | 1): the partial products
+    //           d0*100<<32, d1*10<<32, d2*1<<32
+    //   all land in bit window [32..47], so that window holds d0*100 + d1*10 + d2.
+    //   The group value is <= 999 < 2^10 (mask 0x3FF); lower lanes cannot carry
+    //   into the window, and every product of the 4th lane lands at bit 48+ or
+    //   overflows out of the 64-bit register, so its value never matters.
+    //
+    // Only 3 digits contribute, but the 8-byte load spans 4 chars, callers must
+    // guarantee one readable char beyond each group (see the loop guards above).
+    private const ulong SwarDigitBias = 0x0030_0030_0030_0030UL;
+    private const ulong SwarGroupMagic = (100UL << 32) | (10UL << 16) | 1UL;
+
+#if NET8_0_OR_GREATER
+    // pmaddwd(1024,1) over the biased 16-bit groups leaves 5328 * 1025 in each 32-bit half.
+    private const ulong SimdNumericBiasPair = (5328UL * 1025UL) | ((5328UL * 1025UL) << 32);
+#endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int SwarGroup(ref char c, int i)
+    {
+        if (BitConverter.IsLittleEndian)
+        {
+            var chunk = Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref c, i)));
+            return (int)(((chunk - SwarDigitBias) * SwarGroupMagic) >> 32) & 0x3FF;
+        }
+
+        // Big-endian runtimes: the little-endian lane layout above does not hold and a
+        // whole-ulong byte reversal would also swap the bytes INSIDE each 16-bit char
+        // lane, so fall back to scalar group math. IsLittleEndian is a JIT-time
+        // constant; this branch vanishes from little-endian codegen.
+        return Unsafe.Add(ref c, i) * 100 + Unsafe.Add(ref c, i + 1) * 10 + Unsafe.Add(ref c, i + 2) - 5328; // folded bias: 5328 = '0' * 111
+    }
+
+    // Direct value table replacing the per-char CharacterSets.GetAlphanumericValue
+    // call (and its two compare+throw branches). QR alphanumeric values are 0-44,
+    // so byte entries suffice; invalid slots hold 0 and are never read because the
+    // caller validates the alphabet. Lookups index as AlnumValues[c & 0x7F]: the
+    // 7-bit mask keeps ANY UTF-16 char inside 0-127, so the access is memory-safe
+    // without a bounds check even for out-of-alphabet input.
+    private static ReadOnlySpan<byte> AlnumValues =>
+    [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        36, 0, 0, 0, 37, 38, 0, 0, 0, 0, 39, 40, 0, 41, 42, 43,
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 44, 0, 0, 0, 0, 0,
+        0, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+
+    // Debug-only contract checks (evaluated solely inside Debug.Assert).
+    private static bool AllNumeric(ReadOnlySpan<char> chars)
+    {
+        foreach (var c in chars)
+        {
+            if (!CharacterSets.IsNumeric(c)) return false;
+        }
+        return true;
+    }
+
+    private static bool AllAlphanumeric(ReadOnlySpan<char> chars)
+    {
+        foreach (var c in chars)
+        {
+            if (!CharacterSets.IsAlphanumeric(c)) return false;
+        }
+        return true;
+    }
+
+    // ---------------------------------------------------------------
+    // Writer: 64-bit MSB-first accumulator; a 32-bit big-endian word is stored once
+    // 32+ bits are pending, so 0..32 bits stay pending between appends. Stores use
+    // ref arithmetic without per-store range checks: every stored bit is real data
+    // (or terminator/alignment/pad) inside the capacity, so bytePos + width never
+    // exceeds the codeword count.
+    // ---------------------------------------------------------------
+
+    /// <summary>Appends the low <paramref name="bitCount"/> bits (1-32) of <paramref name="value"/>.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Append(ref byte dest, ref ulong acc, ref int accBits, ref int bytePos, int value, int bitCount)
+    {
+        Debug.Assert(bitCount >= 1 && bitCount <= 32, "bitCount must be between 1 and 32");
+        Debug.Assert(accBits <= 32, "at most 32 bits may be pending between appends");
+
+        var v = (ulong)(uint)value & ((1UL << bitCount) - 1);
+        acc |= v << (64 - accBits - bitCount);
+        accBits += bitCount;
+        if (accBits >= 32)
+        {
+            StoreBigEndian(ref dest, bytePos, (uint)(acc >> 32));
+            bytePos += 4;
+            acc <<= 32;
+            accBits -= 32;
+        }
+    }
+
+    /// <summary>
+    /// Appends 1-56 pre-masked bits (the SIMD numeric / alphanumeric quads); unlike
+    /// <see cref="Append"/> the pending bits plus the value may exceed 64 bits, in
+    /// which case a full 8-byte word is stored and the remainder stays pending.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AppendWide(ref byte dest, ref ulong acc, ref int accBits, ref int bytePos, ulong value, int bitCount)
+    {
+        Debug.Assert(bitCount >= 1 && bitCount <= 56, "bitCount must be between 1 and 56");
+        Debug.Assert(value >> bitCount == 0, "value must be pre-masked to bitCount bits");
+
+        var end = accBits + bitCount;
+        if (end <= 64)
+        {
+            acc |= value << (64 - end);
+            accBits = end;
+            if (accBits >= 32)
+            {
+                StoreBigEndian(ref dest, bytePos, (uint)(acc >> 32));
+                bytePos += 4;
+                acc <<= 32;
+                accBits -= 32;
+            }
+        }
+        else
+        {
+            StoreBigEndian(ref dest, bytePos, acc | (value >> (end - 64)));
+            bytePos += 8;
+            accBits = end - 64;
+            acc = value << (128 - end);
+        }
+    }
+
+    /// <summary>Appends 64 bits (MSB first): pending bits + the head of the value are stored as one 8-byte word, the displaced tail stays pending.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Append64(ref byte dest, ref ulong acc, ref int accBits, ref int bytePos, ulong value)
+    {
+        StoreBigEndian(ref dest, bytePos, acc | (value >> accBits));
+        bytePos += 8;
+        acc = accBits == 0 ? 0UL : value << (64 - accBits);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void StoreBigEndian(ref byte dest, int bytePos, uint value)
+        => Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, bytePos), BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void StoreBigEndian(ref byte dest, int bytePos, ulong value)
+        => Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, bytePos), BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
+
+    /// <summary>
+    /// Terminator (000, shortened at capacity) + zero bits to the byte boundary as
+    /// bit-count arithmetic (the accumulator's unused low bits are already zero),
+    /// drain of the pending whole bytes, then alternating 0xEC / 0x11 pads written
+    /// as 8-byte pattern stores (pads always start with 0xEC).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Finish(ref byte dest, ulong acc, int accBits, int bytePos, int codewordCount, int capacityBits)
+    {
+        var bitPos = bytePos * 8 + accBits;
+        var terminator = Math.Min(RmQRConstants.TerminatorLength, capacityBits - bitPos);
+        bitPos += terminator;
+        accBits += terminator + ((8 - (bitPos & 7)) & 7);   // <= 32 + 3 + 7 pending, drained below
+        Debug.Assert((accBits & 7) == 0, "pending bits must be byte aligned after the terminator");
+
+        while (accBits >= 8)
+        {
+            Unsafe.Add(ref dest, bytePos++) = (byte)(acc >> 56);
+            acc <<= 8;
+            accBits -= 8;
+        }
+
+        var pads = codewordCount - bytePos;
+        Debug.Assert(pads >= 0, "the stream must not exceed the data codeword count");
+        var k = 0;
+        for (; k + 8 <= pads; k += 8)
+        {
+            // little-endian ulong 0x11EC11EC11EC11EC lays out as bytes EC 11 EC 11 ...
+            Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, bytePos + k), BitConverter.IsLittleEndian ? 0x11EC11EC11EC11ECUL : 0xEC11EC11EC11EC11UL);
+        }
+        for (; k < pads; k++)
+        {
+            Unsafe.Add(ref dest, bytePos + k) = (k & 1) == 0 ? (byte)0xEC : (byte)0x11;
+        }
     }
 }

--- a/src/SkiaSharp.QrCode/Internals/RmQr/RmQRModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/RmQr/RmQRModulePlacer.cs
@@ -1,4 +1,11 @@
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+#if NET8_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
 
 namespace SkiaSharp.QrCode.Internals.RmQr;
 
@@ -9,13 +16,27 @@ namespace SkiaSharp.QrCode.Internals.RmQr;
 /// row-major over the symbol width, quiet zone excluded).
 /// </summary>
 /// <remarks>
-/// This is the readable reference implementation, deliberately per-module: it
-/// writes every module (function and data) so the caller need not zero the buffer,
-/// and it allocates nothing. The function-module predicate
+/// Two implementations live here and are held to byte parity by
+/// <c>RmQRModulePlacerParityTest</c>:
+/// <list type="bullet">
+/// <item><see cref="PlaceSymbolReference"/> — the readable per-module reference
+/// (<see cref="PlaceFunctionModules"/>, <see cref="PlaceFormat"/>,
+/// <see cref="PlaceData"/>). The function-module predicate
 /// (<see cref="IsFunctionModule"/>) and the mask (<see cref="GetMaskBit"/>) are the
-/// single source of truth the matrix decoder reuses, so both sides always agree. A
-/// fused fast path (as Micro QR's <c>PlaceSymbol</c> tiers) is a benchmark-driven
-/// follow-up and must stay parity-tested against this implementation.
+/// single source of truth the matrix decoder reuses, so both sides always agree.</item>
+/// <item><see cref="PlaceSymbol"/> — the fast path (benchmark-driven, 16-27x over the
+/// reference). Everything derived from the version alone is built once per version
+/// by the reference code and cached (<see cref="Layout"/>): a painted template per
+/// (version, ECC) with every function and format module, the zigzag order as core
+/// indices, the mask value per data position, and the column-pair segmentation.
+/// Placement is then a template copy, one vector pass that expands the message bits
+/// to bytes and XORs the masks (AVX2 / SSSE3, scalar otherwise), and a store pass:
+/// "clean" column pairs (both columns pure data on rows 1..h-2) are written as one
+/// byte-swapped 16-bit store per row straight from the masked bit array, the
+/// remaining pairs (finder / format / alignment / sub-finder neighbours) as a table
+/// scatter. Bit array scratch is a fixed 512-byte stack budget with a pool fallback
+/// (versions above 63 codewords). Zero allocations after the one-time tables.</item>
+/// </list>
 ///
 /// Geometry (0-based, h = height, w = width):
 /// finder 7×7 at (0,0) with light separators col 7 (rows 0-7) and row 7 (cols 0-7);
@@ -87,6 +108,7 @@ internal static class RmQRModulePlacer
     /// Writes the complete symbol: function patterns, both format copies, and the
     /// masked final message (data + ECC + remainder) into <paramref name="core"/>
     /// (byte per module, row-major over the version's width; every module is written).
+    /// Fast path; see the class remarks.
     /// </summary>
     /// <param name="core">At least width × height bytes.</param>
     /// <param name="version">Symbol version.</param>
@@ -102,11 +124,298 @@ internal static class RmQRModulePlacer
         if (finalMessage.Length < totalCodewords)
             throw new ArgumentException($"Final message too short: required {totalCodewords} codewords, got {finalMessage.Length}.", nameof(finalMessage));
 
+        var layout = GetLayout(version);
+        var count = layout.DataModuleCount;
+
+        // Bit array scratch: one byte per data module (message bits, then the light
+        // remainder bits), mask already applied. Fixed stack budget, pool fallback.
+        if (count <= StackBitBudget)
+        {
+            Span<byte> bits = stackalloc byte[StackBitBudget];
+            PlaceCore(core.Slice(0, width * height), layout, layout.GetTemplate(version, eccLevel), height, width, finalMessage.Slice(0, totalCodewords), bits);
+        }
+        else
+        {
+            var rented = ArrayPool<byte>.Shared.Rent(count + VectorSlack);
+            try
+            {
+                PlaceCore(core.Slice(0, width * height), layout, layout.GetTemplate(version, eccLevel), height, width, finalMessage.Slice(0, totalCodewords), rented);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+
+    // 512 B covers every version with <= 63 total codewords (504 data modules + slack);
+    // larger symbols rent. The AVX2 expand step writes 32 bytes per 4 message bytes, so
+    // the scratch carries 32 bytes of slack past the module count.
+    private const int StackBitBudget = 512;
+    private const int VectorSlack = 32;
+
+    /// <summary>
+    /// Reference composition (per-module painters), the oracle the fast path is
+    /// parity-tested against; also builds the cached tables.
+    /// </summary>
+    internal static void PlaceSymbolReference(Span<byte> core, RmQRVersion version, RmQREccLevel eccLevel, ReadOnlySpan<byte> finalMessage)
+    {
+        var height = RmQRConstants.GetHeight(version);
+        var width = RmQRConstants.GetWidth(version);
+        var totalCodewords = RmQRConstants.GetTotalCodewordCount(version);
+        if (core.Length < width * height)
+            throw new ArgumentException($"Core buffer too small: required {width * height} bytes ({width}x{height}), got {core.Length}.", nameof(core));
+        if (finalMessage.Length < totalCodewords)
+            throw new ArgumentException($"Final message too short: required {totalCodewords} codewords, got {finalMessage.Length}.", nameof(finalMessage));
+
         core = core.Slice(0, width * height);
         PlaceFunctionModules(core, version, height, width);
         PlaceFormat(core, version, eccLevel, height, width);
         PlaceData(core, version, height, width, finalMessage.Slice(0, totalCodewords));
     }
+
+    // ---------------------------------------------------------------
+    // Fast path
+    // ---------------------------------------------------------------
+
+    private static void PlaceCore(Span<byte> core, Layout layout, byte[] template, int height, int width, ReadOnlySpan<byte> finalMessage, Span<byte> bits)
+    {
+        template.AsSpan().CopyTo(core);
+        ExpandBitsMasked(finalMessage, layout.Masks, layout.DataModuleCount, bits);
+        ScatterPairs(ref MemoryMarshal.GetReference(core), ref MemoryMarshal.GetReference(bits), layout, height, width);
+    }
+
+    /// <summary>
+    /// bits[i] = message bit i (MSB first) XOR mask[i] for i &lt; 8 × message length;
+    /// remainder positions up to <paramref name="count"/> get the mask only (light).
+    /// One vector pass: pshufb replicates each message byte over 8 lanes, an AND with
+    /// the per-lane bit mask + compare-equal yields 0/1 bytes, XOR with the mask table.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ExpandBitsMasked(ReadOnlySpan<byte> message, byte[] masks, int count, Span<byte> bits)
+    {
+        var byteCount = message.Length;
+        ref var src = ref MemoryMarshal.GetReference(message);
+        ref var msk = ref MemoryMarshal.GetReference(masks.AsSpan());
+        ref var dst = ref MemoryMarshal.GetReference(bits);
+        var k = 0;
+#if NET8_0_OR_GREATER
+        if (Avx2.IsSupported)
+        {
+            // 4 message bytes -> 32 module bytes per step; the uint broadcast puts the
+            // same 4 bytes in both 128-bit lanes, and the in-lane shuffle picks byte 0..3
+            var sel = Vector256.Create((byte)0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3);
+            var bitm = Vector256.Create((byte)128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1);
+            var one = Vector256.Create((byte)1);
+            for (; k + 4 <= byteCount; k += 4)
+            {
+                var v = Vector256.Create(Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref src, k))).AsByte();
+                var m = Avx2.Shuffle(v, sel) & bitm;
+                ((Vector256.Equals(m, bitm) & one) ^ Vector256.LoadUnsafe(ref msk, (nuint)(k * 8))).StoreUnsafe(ref dst, (nuint)(k * 8));
+            }
+        }
+        if (Ssse3.IsSupported)
+        {
+            var sel = Vector128.Create((byte)0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1);
+            var bitm = Vector128.Create((byte)128, 64, 32, 16, 8, 4, 2, 1, 128, 64, 32, 16, 8, 4, 2, 1);
+            var one = Vector128.Create((byte)1);
+            for (; k + 2 <= byteCount; k += 2)
+            {
+                var v = Vector128.Create(Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref src, k))).AsByte();
+                var m = Ssse3.Shuffle(v, sel) & bitm;
+                ((Vector128.Equals(m, bitm) & one) ^ Vector128.LoadUnsafe(ref msk, (nuint)(k * 8))).StoreUnsafe(ref dst, (nuint)(k * 8));
+            }
+        }
+#endif
+        for (; k < byteCount; k++)
+        {
+            int b = Unsafe.Add(ref src, k);
+            ref var d = ref Unsafe.Add(ref dst, k * 8);
+            ref var m = ref Unsafe.Add(ref msk, k * 8);
+            d = (byte)(((b >> 7) & 1) ^ m);
+            Unsafe.Add(ref d, 1) = (byte)(((b >> 6) & 1) ^ Unsafe.Add(ref m, 1));
+            Unsafe.Add(ref d, 2) = (byte)(((b >> 5) & 1) ^ Unsafe.Add(ref m, 2));
+            Unsafe.Add(ref d, 3) = (byte)(((b >> 4) & 1) ^ Unsafe.Add(ref m, 3));
+            Unsafe.Add(ref d, 4) = (byte)(((b >> 3) & 1) ^ Unsafe.Add(ref m, 4));
+            Unsafe.Add(ref d, 5) = (byte)(((b >> 2) & 1) ^ Unsafe.Add(ref m, 5));
+            Unsafe.Add(ref d, 6) = (byte)(((b >> 1) & 1) ^ Unsafe.Add(ref m, 6));
+            Unsafe.Add(ref d, 7) = (byte)((b & 1) ^ Unsafe.Add(ref m, 7));
+        }
+        // remainder bits (0..7 per version): light before masking -> mask only
+        for (var i = byteCount * 8; i < count; i++)
+            Unsafe.Add(ref dst, i) = Unsafe.Add(ref msk, i);
+    }
+
+    /// <summary>
+    /// Store pass. Clean pairs: the walk visits (row, col) then (row, col-1), so the two
+    /// consecutive bit-array bytes land at core[row, col-1..col] byte-swapped, one
+    /// 16-bit store per row walking the rows in the pair's direction. Other pairs:
+    /// scatter through the index table.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ScatterPairs(ref byte dest, ref byte src, Layout layout, int height, int width)
+    {
+        ref var idx = ref MemoryMarshal.GetReference(layout.Index.AsSpan());
+        var pairs = layout.Pairs;
+        var rows = (nuint)(height - 2);
+        var stride = (nuint)width;
+        for (var p = 0; p < pairs.Length; p++)
+        {
+            var seg = pairs[p];
+            if (seg.Clean)
+            {
+                var k = (nuint)seg.Start;
+                if (seg.Upward)
+                {
+                    ref var d = ref Unsafe.Add(ref dest, (nuint)((height - 2) * width + seg.Col - 1));
+                    for (nuint r = 0; r < rows; r++)
+                    {
+                        Unsafe.WriteUnaligned(ref d, ReverseIfLittleEndian(Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref src, k))));
+                        k += 2;
+                        d = ref Unsafe.Subtract(ref d, stride);
+                    }
+                }
+                else
+                {
+                    ref var d = ref Unsafe.Add(ref dest, (nuint)(width + seg.Col - 1));
+                    for (nuint r = 0; r < rows; r++)
+                    {
+                        Unsafe.WriteUnaligned(ref d, ReverseIfLittleEndian(Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref src, k))));
+                        k += 2;
+                        d = ref Unsafe.Add(ref d, stride);
+                    }
+                }
+            }
+            else
+            {
+                var end = (nuint)(seg.Start + seg.Count);
+                for (var i = (nuint)seg.Start; i < end; i++)
+                {
+                    Unsafe.Add(ref dest, Unsafe.Add(ref idx, i)) = Unsafe.Add(ref src, i);
+                }
+            }
+        }
+    }
+
+    // The bit array holds (col module, col-1 module) in walk order; memory wants
+    // col-1 first: swap the two bytes on little-endian hosts (a big-endian ushort
+    // read/write already reverses them).
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ushort ReverseIfLittleEndian(ushort v) => BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(v) : v;
+
+    // ---------------------------------------------------------------
+    // Per-version tables (built once from the reference painters, so they are
+    // correct by construction; published with a volatile write — a benign race
+    // builds identical tables twice). Memory per version: w×h bytes per ECC template
+    // used + 3 bytes per data module (index + mask) + a few pair descriptors:
+    // <= 8.5 KB for R17x139, ~120 KB if every version and ECC were ever used.
+    // ---------------------------------------------------------------
+
+    /// <summary>A column pair (col, col-1) of the zigzag walk.</summary>
+    private readonly struct PairSegment
+    {
+        public readonly int Col;
+        public readonly int Start;   // first walk position of the pair
+        public readonly int Count;   // data modules in the pair
+        public readonly bool Upward;
+        public readonly bool Clean;  // rows 1..h-2 are data in both columns (Count == 2 * (h - 2))
+
+        public PairSegment(int col, int start, int count, bool upward, bool clean)
+        {
+            Col = col;
+            Start = start;
+            Count = count;
+            Upward = upward;
+            Clean = clean;
+        }
+    }
+
+    private sealed class Layout
+    {
+        public readonly ushort[] Index;      // core index per walk position
+        public readonly byte[] Masks;        // mask bit per walk position
+        public readonly int DataModuleCount; // 8 * total codewords + remainder bits
+        public readonly PairSegment[] Pairs;
+        private readonly byte[] _functionTemplate; // function modules painted, format modules 0
+        private byte[]? _templateM;
+        private byte[]? _templateH;
+
+        public Layout(byte[] functionTemplate, ushort[] index, byte[] masks, PairSegment[] pairs)
+        {
+            _functionTemplate = functionTemplate;
+            Index = index;
+            Masks = masks;
+            DataModuleCount = index.Length;
+            Pairs = pairs;
+        }
+
+        /// <summary>Function template with the ECC level's two format copies painted.</summary>
+        public byte[] GetTemplate(RmQRVersion version, RmQREccLevel eccLevel)
+        {
+            ref var slot = ref (eccLevel == RmQREccLevel.M ? ref _templateM : ref _templateH);
+            var t = Volatile.Read(ref slot);
+            if (t is not null) return t;
+            t = (byte[])_functionTemplate.Clone();
+            PlaceFormat(t, version, eccLevel, RmQRConstants.GetHeight(version), RmQRConstants.GetWidth(version));
+            Volatile.Write(ref slot, t);
+            return t;
+        }
+    }
+
+    private static readonly Layout?[] layouts = new Layout?[RmQRConstants.VersionCount + 1];
+
+    private static Layout GetLayout(RmQRVersion version)
+    {
+        ref var slot = ref layouts[(int)version];
+        var layout = Volatile.Read(ref slot);
+        if (layout is not null) return layout;
+        layout = BuildLayout(version);
+        Volatile.Write(ref slot, layout);
+        return layout;
+    }
+
+    private static Layout BuildLayout(RmQRVersion version)
+    {
+        var height = RmQRConstants.GetHeight(version);
+        var width = RmQRConstants.GetWidth(version);
+        var functionTemplate = new byte[width * height];
+        PlaceFunctionModules(functionTemplate, version, height, width);
+
+        // The same walk as PlaceData, recording core index + mask per data position and
+        // the per-pair shape.
+        var index = new List<ushort>();
+        var masks = new List<byte>();
+        var pairs = new List<PairSegment>();
+        var upward = true;
+        for (var col = width - 2; col >= 1; col -= 2)
+        {
+            var start = index.Count;
+            var clean = true;
+            for (var step = 0; step < height; step++)
+            {
+                var row = upward ? height - 1 - step : step;
+                for (var c = col; c >= col - 1; c--)
+                {
+                    var isFunction = IsFunctionModule(version, row, c);
+                    if (isFunction)
+                    {
+                        if (row >= 1 && row <= height - 2) clean = false;
+                        continue;
+                    }
+                    index.Add((ushort)(row * width + c));
+                    masks.Add((byte)(GetMaskBit(row, c) ? 1 : 0));
+                }
+            }
+            pairs.Add(new PairSegment(col, start, index.Count - start, upward, clean));
+            upward = !upward;
+        }
+
+        return new Layout(functionTemplate, index.ToArray(), masks.ToArray(), pairs.ToArray());
+    }
+
+    // ---------------------------------------------------------------
+    // Reference painters (per module)
+    // ---------------------------------------------------------------
 
     /// <summary>Paints every function module (dark or light) for the version.</summary>
     internal static void PlaceFunctionModules(Span<byte> core, RmQRVersion version, int height, int width)
@@ -182,7 +491,6 @@ internal static class RmQRModulePlacer
                 core[(height - 5 + row) * width + width - 5 + col] = (byte)(ring == 1 ? 0 : 1);
             }
         }
-
     }
 
     /// <summary>Writes both 18-bit format-information copies.</summary>

--- a/src/SkiaSharp.QrCode/Internals/RmQr/RmQRModulePlacer.cs
+++ b/src/SkiaSharp.QrCode/Internals/RmQr/RmQRModulePlacer.cs
@@ -270,7 +270,7 @@ internal static class RmQRModulePlacer
                     ref var d = ref Unsafe.Add(ref dest, (nuint)((height - 2) * width + seg.Col - 1));
                     for (nuint r = 0; r < rows; r++)
                     {
-                        Unsafe.WriteUnaligned(ref d, ReverseIfLittleEndian(Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref src, k))));
+                        Unsafe.WriteUnaligned(ref d, SwapPair(Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref src, k))));
                         k += 2;
                         d = ref Unsafe.Subtract(ref d, stride);
                     }
@@ -280,7 +280,7 @@ internal static class RmQRModulePlacer
                     ref var d = ref Unsafe.Add(ref dest, (nuint)(width + seg.Col - 1));
                     for (nuint r = 0; r < rows; r++)
                     {
-                        Unsafe.WriteUnaligned(ref d, ReverseIfLittleEndian(Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref src, k))));
+                        Unsafe.WriteUnaligned(ref d, SwapPair(Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref src, k))));
                         k += 2;
                         d = ref Unsafe.Add(ref d, stride);
                     }
@@ -298,10 +298,11 @@ internal static class RmQRModulePlacer
     }
 
     // The bit array holds (col module, col-1 module) in walk order; memory wants
-    // col-1 first: swap the two bytes on little-endian hosts (a big-endian ushort
-    // read/write already reverses them).
+    // col-1 first. Read and write go through the same host endianness, so a
+    // ReverseEndianness in between always swaps the two BYTES in memory order,
+    // whatever the host is — the swap is unconditional by design.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static ushort ReverseIfLittleEndian(ushort v) => BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(v) : v;
+    private static ushort SwapPair(ushort v) => BinaryPrimitives.ReverseEndianness(v);
 
     // ---------------------------------------------------------------
     // Per-version tables (built once from the reference painters, so they are

--- a/src/SkiaSharp.QrCode/QRCodeData.cs
+++ b/src/SkiaSharp.QrCode/QRCodeData.cs
@@ -120,7 +120,7 @@ public class QRCodeData
     //   - _size == _baseSize, no coordinate translation
     //   - bitIndex = row × _size + col directly
     //
-    // Why this layout (measured, see the MatrixStorage micro-benchmark log):
+    // Why this layout (measured in the MatrixStorage kernel benchmark):
     // - 8.7x smaller per-instance allocation (34,225 -> 3,944 bytes at v40/qz4),
     //   which was essentially 100% of CreateQrCode's allocation.
     // - _bits IS the serialization payload, so GetRawData collapses to

--- a/tests/SkiaSharp.QrCode.Tests/RmQr/RmQRBinaryEncoderKernelParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/RmQr/RmQRBinaryEncoderKernelParityTest.cs
@@ -1,0 +1,139 @@
+using System.Runtime.InteropServices;
+using SkiaSharp.QrCode.Internals.RmQr;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// Vectorized segment writers of <see cref="RmQRBinaryEncoder"/> (x64 SSSE3/SSE4.1
+/// numeric + alphanumeric, SSE2 Latin-1) versus their scalar SWAR / table fallbacks,
+/// called directly with <c>vectorized</c> = true / false on the same writer state.
+/// Covers every length up to the largest rMQR capacity, every pending-bit phase the
+/// header can leave (0..12 bits), min / max / cyclic / pseudo-random contents.
+/// On hardware without the vector ISA both calls take the scalar path and the test
+/// degenerates to a self-check; <see cref="RmQRBinaryEncoderParityTest"/> pins the
+/// end-to-end stream against the naive reference either way.
+/// </summary>
+public class RmQRBinaryEncoderKernelParityTest
+{
+    private const string AlphanumericAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+    private const int MaxNumeric = 361;      // R17x139-M
+    private const int MaxAlphanumeric = 219; // R17x139-M
+    private const int MaxByte = 150;         // R17x139-M
+
+    private delegate void Writer(ref byte dest, ref ulong acc, ref int accBits, ref int bytePos, ReadOnlySpan<char> text, bool vectorized);
+
+    private static string PseudoRandom(string alphabet, int length, int seed)
+    {
+        var chars = new char[length];
+        var state = (uint)seed * 2654435761u + 7u;
+        for (var i = 0; i < length; i++)
+        {
+            state = state * 1664525u + 1013904223u;
+            chars[i] = alphabet[(int)(state >> 8) % alphabet.Length];
+        }
+        return new string(chars);
+    }
+
+    private static string Cyclic(string alphabet, int length, int offset)
+    {
+        var chars = new char[length];
+        for (var i = 0; i < length; i++)
+            chars[i] = alphabet[(i + offset) % alphabet.Length];
+        return new string(chars);
+    }
+
+    /// <summary>Runs the writer twice (scalar / vectorized) from the same pre-seeded state and compares bytes + pending state.</summary>
+    private static async Task AssertKernelParity(Writer writer, string text, int headerBits, string label)
+    {
+        // seed: headerBits pending bits (all ones keeps the merge with the first append visible)
+        var seedAcc = headerBits == 0 ? 0UL : ulong.MaxValue << (64 - headerBits);
+
+        var scalar = new byte[256];
+        var vector = new byte[256];
+        ulong accS = seedAcc, accV = seedAcc;
+        int bitsS = headerBits, bitsV = headerBits;
+        int posS = 0, posV = 0;
+
+        writer(ref MemoryMarshal.GetArrayDataReference(scalar), ref accS, ref bitsS, ref posS, text.AsSpan(), vectorized: false);
+        writer(ref MemoryMarshal.GetArrayDataReference(vector), ref accV, ref bitsV, ref posV, text.AsSpan(), vectorized: true);
+
+        // The two paths may split the same bit stream differently between stored bytes
+        // and pending bits (AppendWide can leave exactly 32 bits pending where Append
+        // would have flushed them), so compare the logical stream: stored bytes followed
+        // by the pending bits, MSB first.
+        var streamS = Logical(scalar, posS, accS, bitsS);
+        var streamV = Logical(vector, posV, accV, bitsV);
+        if (streamS != streamV)
+        {
+            Assert.Fail($"{label} len {text.Length} header {headerBits}: scalar pos {posS} bits {bitsS} / vector pos {posV} bits {bitsV}\n scalar {streamS}\n vector {streamV}");
+        }
+        await Task.CompletedTask;
+    }
+
+    private static string Logical(byte[] stored, int bytePos, ulong acc, int accBits)
+    {
+        var bits = new System.Text.StringBuilder(bytePos * 8 + accBits);
+        for (var i = 0; i < bytePos; i++)
+            bits.Append(Convert.ToString(stored[i], 2).PadLeft(8, '0'));
+        for (var i = 0; i < accBits; i++)
+            bits.Append((acc >> (63 - i)) & 1);
+        return bits.ToString();
+    }
+
+    public static IEnumerable<int> HeaderPhases() => Enumerable.Range(0, 13); // 3-bit mode + 0..9-bit count = 3..12 pending, plus 0
+
+    [Test]
+    [MethodDataSource(nameof(HeaderPhases))]
+    public async Task Numeric_VectorizedMatchesScalar_EveryLengthAndPhase(int headerBits)
+    {
+        for (var length = 0; length <= MaxNumeric; length++)
+        {
+            await AssertKernelParity(RmQRBinaryEncoder.WriteNumeric, new string('0', length), headerBits, "Numeric zeros");
+            await AssertKernelParity(RmQRBinaryEncoder.WriteNumeric, new string('9', length), headerBits, "Numeric nines");
+            await AssertKernelParity(RmQRBinaryEncoder.WriteNumeric, PseudoRandom("0123456789", length, length * 3 + headerBits), headerBits, "Numeric random");
+        }
+    }
+
+    [Test]
+    [MethodDataSource(nameof(HeaderPhases))]
+    public async Task Alphanumeric_VectorizedMatchesScalar_EveryLengthAndPhase(int headerBits)
+    {
+        for (var length = 0; length <= MaxAlphanumeric; length++)
+        {
+            await AssertKernelParity(RmQRBinaryEncoder.WriteAlphanumeric, new string('0', length), headerBits, "Alnum zeros");
+            await AssertKernelParity(RmQRBinaryEncoder.WriteAlphanumeric, new string(':', length), headerBits, "Alnum colons");
+            await AssertKernelParity(RmQRBinaryEncoder.WriteAlphanumeric, Cyclic(AlphanumericAlphabet, length, length), headerBits, "Alnum cyclic");
+            await AssertKernelParity(RmQRBinaryEncoder.WriteAlphanumeric, PseudoRandom(AlphanumericAlphabet, length, 31 * length + headerBits), headerBits, "Alnum random");
+        }
+    }
+
+    [Test]
+    public async Task Alphanumeric_EverySymbolInEveryLane()
+    {
+        // each of the 45 symbols through every one of the 8 vector lanes (offset classes:
+        // row 0x2_ specials, row 0x3_ digits + ':', letters)
+        foreach (var symbol in AlphanumericAlphabet)
+        {
+            for (var lane = 0; lane < 8; lane++)
+            {
+                var chars = new string('A', 16).ToCharArray();
+                chars[lane] = symbol;
+                chars[8 + (7 - lane)] = symbol;
+                await AssertKernelParity(RmQRBinaryEncoder.WriteAlphanumeric, new string(chars), 8, $"Alnum symbol '{symbol}' lane {lane}");
+            }
+        }
+    }
+
+    [Test]
+    [MethodDataSource(nameof(HeaderPhases))]
+    public async Task Latin1_VectorizedMatchesScalar_EveryLengthAndPhase(int headerBits)
+    {
+        var latin1 = new string(Enumerable.Range(0, 256).Select(c => (char)c).ToArray());
+        for (var length = 0; length <= MaxByte; length++)
+        {
+            await AssertKernelParity(RmQRBinaryEncoder.WriteLatin1, new string('\0', length), headerBits, "Latin1 zeros");
+            await AssertKernelParity(RmQRBinaryEncoder.WriteLatin1, new string('ÿ', length), headerBits, "Latin1 0xFF");
+            await AssertKernelParity(RmQRBinaryEncoder.WriteLatin1, Cyclic(latin1, length, length * 7), headerBits, "Latin1 cyclic");
+        }
+    }
+}

--- a/tests/SkiaSharp.QrCode.Tests/RmQr/RmQRModulePlacerParityTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/RmQr/RmQRModulePlacerParityTest.cs
@@ -1,0 +1,99 @@
+using SkiaSharp.QrCode.Internals.RmQr;
+
+namespace SkiaSharp.QrCode.Tests;
+
+/// <summary>
+/// <see cref="RmQRModulePlacer.PlaceSymbol"/> (fast path: cached per-version tables,
+/// vector bit expansion, pair stores + scatter) versus
+/// <see cref="RmQRModulePlacer.PlaceSymbolReference"/> (per-module painters), byte for
+/// byte, for every version × ECC level over all-zero, all-one, pseudo-random and
+/// over-long messages, on a dirty core (every module must be written), plus the
+/// undersized-buffer contracts of the fast path.
+/// </summary>
+public class RmQRModulePlacerParityTest
+{
+    public static IEnumerable<(RmQRVersion version, RmQREccLevel ecc)> AllVersionEcc()
+    {
+        foreach (var v in Enum.GetValues<RmQRVersion>())
+        {
+            yield return (v, RmQREccLevel.M);
+            yield return (v, RmQREccLevel.H);
+        }
+    }
+
+    private static byte[] PseudoRandom(int length, int seed)
+    {
+        var bytes = new byte[length];
+        var state = (uint)seed * 2654435761u + 7u;
+        for (var i = 0; i < length; i++)
+        {
+            state = state * 1664525u + 1013904223u;
+            bytes[i] = (byte)(state >> 16);
+        }
+        return bytes;
+    }
+
+    [Test]
+    [MethodDataSource(nameof(AllVersionEcc))]
+    public async Task FastPath_MatchesReference_EveryMessageShape(RmQRVersion version, RmQREccLevel ecc)
+    {
+        var total = RmQRConstants.GetTotalCodewordCount(version);
+        var size = RmQRConstants.GetWidth(version) * RmQRConstants.GetHeight(version);
+        var messages = new[]
+        {
+            new byte[total],
+            Enumerable.Repeat((byte)0xFF, total).ToArray(),
+            PseudoRandom(total, (int)version * 31 + (int)ecc),
+            PseudoRandom(total, (int)version * 17 + (int)ecc + 5),
+            PseudoRandom(total + 3, (int)version + (int)ecc), // over-long: only the first `total` codewords count
+            PseudoRandom(RmQRCodewordEncoder.GetFinalMessageSize(version), 99 + (int)version), // the generator's buffer size
+        };
+        foreach (var message in messages)
+        {
+            var expected = new byte[size];
+            expected.AsSpan().Fill(0xA5);
+            RmQRModulePlacer.PlaceSymbolReference(expected, version, ecc, message);
+
+            var actual = new byte[size + 3]; // oversized core: only the first w×h bytes are written
+            actual.AsSpan().Fill(0xA5);
+            RmQRModulePlacer.PlaceSymbol(actual, version, ecc, message);
+
+            if (!actual.AsSpan(0, size).SequenceEqual(expected))
+            {
+                var first = 0;
+                while (first < size && actual[first] == expected[first]) first++;
+                var width = RmQRConstants.GetWidth(version);
+                Assert.Fail($"{version}-{ecc} msg[0]={message[0]:X2}: first mismatch at {first} (row {first / width}, col {first % width}): expected {expected[first]}, actual {actual[first]}");
+            }
+            await Assert.That(actual.AsSpan(size).ToArray()).IsEquivalentTo(new byte[] { 0xA5, 0xA5, 0xA5 });
+        }
+    }
+
+    [Test]
+    public async Task FastPath_RejectsUndersizedBuffers_LikeReference()
+    {
+        var message = new byte[RmQRCodewordEncoder.GetFinalMessageSize(RmQRVersion.R17x139)];
+        await Assert.That(() => RmQRModulePlacer.PlaceSymbol(new byte[17 * 139 - 1], RmQRVersion.R17x139, RmQREccLevel.M, message)).Throws<ArgumentException>();
+        await Assert.That(() => RmQRModulePlacer.PlaceSymbol(new byte[17 * 139], RmQRVersion.R17x139, RmQREccLevel.M, message.AsSpan(0, RmQRConstants.GetTotalCodewordCount(RmQRVersion.R17x139) - 1).ToArray())).Throws<ArgumentException>();
+        await Assert.That(() => RmQRModulePlacer.PlaceSymbolReference(new byte[17 * 139 - 1], RmQRVersion.R17x139, RmQREccLevel.M, message)).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task FastPath_IsRepeatable_AcrossEccAndVersionsSharingTables()
+    {
+        // the per-version cache serves both ECC levels and repeated calls; alternate them
+        var v = RmQRVersion.R11x59;
+        var total = RmQRConstants.GetTotalCodewordCount(v);
+        var size = RmQRConstants.GetWidth(v) * RmQRConstants.GetHeight(v);
+        for (var i = 0; i < 6; i++)
+        {
+            var ecc = (i & 1) == 0 ? RmQREccLevel.M : RmQREccLevel.H;
+            var message = PseudoRandom(total, i);
+            var expected = new byte[size];
+            RmQRModulePlacer.PlaceSymbolReference(expected, v, ecc, message);
+            var actual = new byte[size];
+            RmQRModulePlacer.PlaceSymbol(actual, v, ecc, message);
+            await Assert.That(actual.AsSpan().SequenceEqual(expected)).IsTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two benchmark-driven fast paths for the rMQR encode pipeline, both held to byte parity against the readable reference implementations:

- **`RmQRBinaryEncoder`** — data-codeword stream rewritten around a raw-local writer (64-bit accumulator + `ref byte`, no per-flush slice checks). Numeric: 64-bit SWAR 3-digit groups, plus an SSSE3/SSE4.1 `pmaddwd` tier (12 digits per 40-bit append). Alphanumeric: unchecked value table, plus a `pshufb`-classified tier with `pmaddubsw`/`pmaddwd` (8 chars per 44-bit append). Byte: SSE2 narrow (8 chars per 64-bit append); UTF-8 stays on `Encoding.UTF8` in a separate cold path. Terminator/alignment as bit-count arithmetic, 8-byte pad stores.
- **`RmQRModulePlacer`** — `PlaceSymbol` is now table-driven: per-version tables built once by the reference painters (painted template per version × ECC, zigzag order as core indices, mask per position, column-pair segmentation), then template copy → one vector pass expanding message bits to bytes fused with the mask XOR (AVX2 / SSSE3, scalar fallback) → 16-bit pair stores for "clean" column pairs, index scatter for the rest. Fixed 512 B stack scratch with a pool fallback. The per-module reference is kept as `PlaceSymbolReference` (table source, decoder predicate, parity oracle).

Vector tiers are `NET8_0_OR_GREATER` + `IsSupported` gated; netstandard / non-x86 take the scalar paths. Allocation contract unchanged (span paths 0 B).

## Why

After the rMQR feature landed, placement was 80-90 % of the encode E2E (R17x139: ~12 µs of 14 µs) and the bit stream was the reference shape by design. This is the planned follow-up: keep the reference implementations as the source of truth, and add measured fast paths on top.

## Tests

- `RmQRBinaryEncoderKernelParityTest` (+40): each segment writer with `vectorized` true/false from the same writer state, 13 header phases × every length up to capacity × min/max/cyclic/random, every alphanumeric symbol through every vector lane.
- `RmQRModulePlacerParityTest` (+40): fast path vs reference for all 32 versions × 2 ECC × six message shapes on a dirty core, oversized/undersized buffer contracts, ECC alternation on a shared cache.
- Existing naive-reference, structural and external-oracle tests (module-exact against every committed symbol) run through the new paths unchanged. Full suite: net10.0 5,073 / net8.0 5,061, 0 failed.

## Benchmarks

`RmQREncodeEndToEnd`, net10.0 Release, `--launchCount 3 --warmupCount 3 --iterationCount 15`, before = `62c0268` (rMQR merge), after = this PR.

| Benchmark | Before | After | Delta |
|---|---|---|---|
| RmQR_Numeric_R7x43_Encode | 1.240 µs / 112 B | 329 ns / 112 B | -73 % |
| RmQR_Alphanumeric_R11x59_Encode | 3.288 µs / 160 B | 614 ns / 160 B | -81 % |
| RmQR_Byte_R17x139_Encode | 15.07 µs / 368 B | 2.379 µs / 368 B | -84 % |
| RmQR_Numeric_R7x43_Encode (Span) | 1.125 µs / 0 B | 179 ns / 0 B | -84 % |
| RmQR_Alphanumeric_R11x59_Encode (Span) | 2.843 µs / 0 B | 318 ns / 0 B | -89 % |
| RmQR_Byte_R17x139_Encode (Span) | 14.52 µs / 0 B | 1.054 µs / 0 B | -93 % |
| RmQR_Numeric_AutoFit_Encode (Span) | 1.157 µs / 0 B | 358 ns / 0 B | -69 % |
| StandardQr_Numeric_V1_Encode (Span) (untouched control) | 1.891 µs | 2.182 µs | drift |

Kernel-level (same-run, vs the reference copies): bit stream 1.3x (12 digits) .. 7.5x (150 Latin-1 bytes); placer 15x (R11x27) .. 27x (R17x139), both 0 B.