### PR TITLE
feat: Improve rMQR Auto fit to table scan

### DIFF
--- a/.github/docs/plans/skiasharp-qrcode-rmqr-implementation-plan.md
+++ b/.github/docs/plans/skiasharp-qrcode-rmqr-implementation-plan.md
@@ -617,3 +617,29 @@ The two encode-side levers left by the placer round, done test-first (parity + g
 | StandardQr_Numeric_V1_Encode (Span) (untouched control) | 943 ns | 961 ns | +2 % (drift) |
 
 Allocations unchanged (the class results are the returned objects; span paths 0 B). The class-API pack was the whole gap between class and span paths (rMQR class results now cost less than the quiet-zoned span call; the Micro QR class API overtook its span path). The strided quiet-zone placement is time-neutral (the row/col-coded scatter for irregular pairs costs about what the removed pool rental and row copies did) and is kept for the contract: the generator's span destination path no longer rents an intermediate core buffer (the placer's own bit-scratch rental above 63 codewords, documented in the placer entry, is unchanged). Decode is flat (unpack was never its bottleneck).
+
+### Follow-up: table-driven automatic version fit (`RmQRVersionSelector`), completed 2026-08-17
+
+Third post-Phase-7 kernel round, one round only (kernel benchmark loop: 4 variants, gate of 93,492 selections per variant against the definitional scan for every mode × ECC × strategy × height filter × length).
+
+**Done**
+
+- `src`: the auto-fit path of `RmQRVersionSelector.Select` no longer evaluates `Fits` + `IsBetter` for all 32 versions per call. Three static tables (~1.3 KB, built at type init from `IsBetter` and `GetMaxDataLength`, so they cannot drift from the definitions): the versions in best-first order per strategy, each version's capacity per (mode, ECC) at that rank, and a per-strategy height bitmask; the fit is the first rank whose capacity holds the length and whose height is allowed. Kernel 27-108 ns → 1.3-8.3 ns (a constant-time SIMD compare/movemask variant measured ~1.8 ns but was not shipped: ≤ 6.5 ns on a ≥ 300 ns encode, and the scalar scan needs no intrinsics). Requested-version and failure-message paths unchanged.
+- Tests (+3; full suite net10.0 5,496 / net8.0 5,484, 0 failed): `RmQRVersionSelectorUnitTest.Select_AutoFit_MatchesDefinitionalScan_EveryLengthStrategyHeight` — every mode × ECC × strategy × height filter × length 0..max+3 against the definitional "best fitting version" scan (Fits + IsBetter), including the nothing-fits exception; the existing hand-derived fit tables, tie-break and interop-default tests keep passing.
+
+**Lessons learned**
+
+- A benchmark harness that copies internals also copies its own enums: the harness numbered the modes 0/1/2 while the library's `EncodingMode` is 1/2/4, and the first port indexed the capacity table with the raw enum value — every table-driven port needs a definitional test in the library, because the harness gate cannot see a mapping bug that only exists in the port.
+- With the placer at ~50-500 ns, second-order fixed costs (a 32-candidate fit scan, ~110 ns for numeric) become the largest remaining item; keep re-reading the E2E table after each round rather than the original profile.
+
+**Benchmark delta (`RmQREncodeEndToEnd`, net10.0 Release, --launchCount 3 --warmupCount 3 --iterationCount 15, before = HEAD f6a3816, after = this change)**
+
+| Benchmark | Before | After | Delta |
+|---|---|---|---|
+| RmQR_Numeric_AutoFit_Encode (Span) | 318.3 ns | 211.7 ns | -33 % |
+| RmQR_Numeric_R7x43_Encode (Span) (fixed version, code-identical) | 148.8 ns | 169.7 ns | +14 % (noise) |
+| RmQR_Alphanumeric_R11x59_Encode (Span) (fixed) | 289.4 ns | 328.2 ns | +13 % (noise) |
+| RmQR_Byte_R17x139_Encode (Span) (fixed) | 927.8 ns | 1,044 ns | +13 % (noise) |
+| StandardQr_Numeric_V1_Encode (Span) (untouched control) | 850.3 ns | 955.6 ns | +12 % (drift) |
+
+The after run landed on a noisier machine state (StdDev 5-7 % vs < 1 % before): every fixed-version row and the untouched control moved by the same +12-14 %, so the true auto-fit gain is ~-40 % (the fit scan was ~110 ns of 318). Auto fit of 12 digits selects R11x27 (297 modules), so it is not directly comparable with the fixed R7x43 row.

--- a/.github/docs/specs/rmqr-encoder.md
+++ b/.github/docs/specs/rmqr-encoder.md
@@ -203,7 +203,7 @@ Shared `TextAnalyzer` (Numeric / Alphanumeric / Byte, single segment). Non-Latin
 
 ### 3. Fit the version
 
-Required bits = 3 (mode) + count indicator (per version, table above) + payload bits. The terminator may shrink to the remaining capacity, including zero bits.
+Required bits = 3 (mode) + count indicator (per version, table above) + payload bits. The terminator may shrink to the remaining capacity, including zero bits. Automatic fit is a table scan (versions pre-ordered best-first per strategy with their capacity per mode × ECC, height as a bitmask); it selects exactly what the definitional "best fitting version" scan selects, and a test pins the two for every input.
 
 - `requestedVersion` given: use it or fail with an actionable capacity error (actual length, applicable maximum in mode units, remedy: shorten, lower ECC, choose a larger version, or use Standard QR).
 - Otherwise the candidate set is all 32 versions, or the versions of the constrained `height`; keep those whose data-codeword capacity holds the required bits; choose by `fitStrategy`:

--- a/src/SkiaSharp.QrCode/Internals/RmQr/RmQRConstants.cs
+++ b/src/SkiaSharp.QrCode/Internals/RmQr/RmQRConstants.cs
@@ -257,6 +257,23 @@ internal static class RmQRConstants
         _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Encoding mode {mode} is not supported by rMQR."),
     };
 
+    /// <summary>
+    /// Dense index of the encodable modes (Numeric 0, Alphanumeric 1, Byte 2) for
+    /// per-mode tables; <see cref="EncodingMode"/> values themselves are the Standard QR
+    /// mode-indicator bits (1, 2, 4) and are not contiguous.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetModeIndex(EncodingMode mode) => mode switch
+    {
+        EncodingMode.Numeric => 0,
+        EncodingMode.Alphanumeric => 1,
+        EncodingMode.Byte => 2,
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Encoding mode {mode} is not supported by rMQR."),
+    };
+
+    /// <summary>Number of dense-indexed encodable modes (the range of <see cref="GetModeIndex"/>: Numeric, Alphanumeric, Byte); ECI / Kanji are not part of it.</summary>
+    public const int ModeCount = 3;
+
     /// <summary>Character count indicator width in bits (ISO/IEC 23941 Table 3).</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetCountIndicatorLength(RmQRVersion version, EncodingMode mode) => mode switch

--- a/src/SkiaSharp.QrCode/Internals/RmQr/RmQRConstants.cs
+++ b/src/SkiaSharp.QrCode/Internals/RmQr/RmQRConstants.cs
@@ -276,13 +276,12 @@ internal static class RmQRConstants
 
     /// <summary>Character count indicator width in bits (ISO/IEC 23941 Table 3).</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int GetCountIndicatorLength(RmQRVersion version, EncodingMode mode) => mode switch
+    public static int GetCountIndicatorLength(RmQRVersion version, EncodingMode mode) => GetModeIndex(mode) switch
     {
-        EncodingMode.Numeric => numericCountBits[Index(version)],
-        EncodingMode.Alphanumeric => alphanumericCountBits[Index(version)],
-        EncodingMode.Byte => byteCountBits[Index(version)],
-        _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Encoding mode {mode} has no count indicator in rMQR."),
-    };
+        0 => numericCountBits[Index(version)],
+        1 => alphanumericCountBits[Index(version)],
+        _ => byteCountBits[Index(version)],
+    }; // unsupported modes throw from GetModeIndex, the single "not supported by rMQR" message on every path
 
     /// <summary>Kanji count indicator width; spec-transcribed, unverified (Kanji mode is not implemented).</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/SkiaSharp.QrCode/Internals/RmQr/RmQRVersionSelector.cs
+++ b/src/SkiaSharp.QrCode/Internals/RmQr/RmQRVersionSelector.cs
@@ -132,18 +132,11 @@ internal static class RmQRVersionSelector
         // fit is the first rank whose capacity holds the length and whose height is
         // allowed — the same result as scanning all 32 versions with Fits + IsBetter
         // (pinned by RmQRVersionSelectorUnitTest), at a fraction of the cost: the
-        // scan was half of a small auto-fit encode.
-        var modeIndex = mode switch
-        {
-            EncodingMode.Numeric => 0,
-            EncodingMode.Alphanumeric => 1,
-            EncodingMode.Byte => 2,
-            _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Encoding mode {mode} is not supported by rMQR."),
-        };
-        var capacities = FitCapacities[(modeIndex * 2 + (int)eccLevel) * 3 + (int)fitStrategy];
+        // scan was about a third of a small auto-fit encode.
+        var capacities = FitCapacities[(RmQRConstants.GetModeIndex(mode) * 2 + (int)eccLevel) * 3 + (int)fitStrategy];
         var order = FitOrders[(int)fitStrategy];
         var heightMask = height is { } fitHeight ? FitHeightMasks[(int)fitStrategy][((int)fitHeight - 7) / 2] : uint.MaxValue;
-        for (var j = 0; j < RmQRConstants.VersionCount; j++)
+        for (var j = 0; j < capacities.Length; j++)
         {
             if (capacities[j] >= dataLength && (heightMask & (1u << j)) != 0)
                 return (RmQRVersion)order[j];
@@ -181,7 +174,8 @@ internal static class RmQRVersionSelector
     //   FitOrders[strategy][rank]                       = version (1..32), best first
     //   FitCapacities[(mode*2+ecc)*3+strategy][rank]    = that version's max data length
     //   FitHeightMasks[strategy][(height-7)/2]          = bit `rank` set when the version has that height
-    // 3 × 32 B + 18 × 64 B + 3 × 24 B ≈ 1.3 KB.
+    // 3 × 32 B + 18 × 64 B + 3 × 24 B ≈ 1.3 KB of table data. Declaration order matters:
+    // static field initializers run textually, and the two lower tables index FitOrders.
     // ---------------------------------------------------------------
     private static readonly byte[][] FitOrders = BuildFitOrders();
     private static readonly ushort[][] FitCapacities = BuildFitCapacities();
@@ -208,16 +202,15 @@ internal static class RmQRVersionSelector
 
     private static ushort[][] BuildFitCapacities()
     {
-        var tables = new ushort[3 * 2 * 3][];
-        var modes = new[] { EncodingMode.Numeric, EncodingMode.Alphanumeric, EncodingMode.Byte };
-        for (var m = 0; m < modes.Length; m++)
+        var tables = new ushort[RmQRConstants.ModeCount * 2 * 3][];
+        foreach (var mode in new[] { EncodingMode.Numeric, EncodingMode.Alphanumeric, EncodingMode.Byte })
             for (var e = 0; e < 2; e++)
                 for (var s = 0; s < 3; s++)
                 {
                     var t = new ushort[RmQRConstants.VersionCount];
                     for (var rank = 0; rank < RmQRConstants.VersionCount; rank++)
-                        t[rank] = (ushort)GetMaxDataLength((RmQRVersion)FitOrders[s][rank], (RmQREccLevel)e, modes[m]);
-                    tables[(m * 2 + e) * 3 + s] = t;
+                        t[rank] = (ushort)GetMaxDataLength((RmQRVersion)FitOrders[s][rank], (RmQREccLevel)e, mode);
+                    tables[(RmQRConstants.GetModeIndex(mode) * 2 + e) * 3 + s] = t; // same index function as Select
                 }
         return tables;
     }

--- a/src/SkiaSharp.QrCode/Internals/RmQr/RmQRVersionSelector.cs
+++ b/src/SkiaSharp.QrCode/Internals/RmQr/RmQRVersionSelector.cs
@@ -125,21 +125,29 @@ internal static class RmQRVersionSelector
             return version;
         }
 
-        // Candidate set: all versions, or those of the requested height. Track the
-        // best fitting version by strategy.
-        var best = (RmQRVersion)0;
-        for (var i = 1; i <= RmQRConstants.VersionCount; i++)
+        // Candidate set: all versions, or those of the requested height; the best
+        // fitting version by strategy. The versions are laid out best-first per
+        // strategy with each version's capacity for the (mode, ECC) precomputed
+        // (static tables built from GetMaxDataLength / IsBetter at type init), so the
+        // fit is the first rank whose capacity holds the length and whose height is
+        // allowed — the same result as scanning all 32 versions with Fits + IsBetter
+        // (pinned by RmQRVersionSelectorUnitTest), at a fraction of the cost: the
+        // scan was half of a small auto-fit encode.
+        var modeIndex = mode switch
         {
-            var candidate = (RmQRVersion)i;
-            if (height is { } wanted && RmQRConstants.GetHeight(candidate) != (int)wanted)
-                continue;
-
-            if (Fits(candidate, eccLevel, mode, dataLength) && (best == 0 || IsBetter(candidate, best, fitStrategy)))
-                best = candidate;
+            EncodingMode.Numeric => 0,
+            EncodingMode.Alphanumeric => 1,
+            EncodingMode.Byte => 2,
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Encoding mode {mode} is not supported by rMQR."),
+        };
+        var capacities = FitCapacities[(modeIndex * 2 + (int)eccLevel) * 3 + (int)fitStrategy];
+        var order = FitOrders[(int)fitStrategy];
+        var heightMask = height is { } fitHeight ? FitHeightMasks[(int)fitStrategy][((int)fitHeight - 7) / 2] : uint.MaxValue;
+        for (var j = 0; j < RmQRConstants.VersionCount; j++)
+        {
+            if (capacities[j] >= dataLength && (heightMask & (1u << j)) != 0)
+                return (RmQRVersion)order[j];
         }
-
-        if (best != 0)
-            return best;
 
         // Nothing fits: find the most capacious candidate for the error message
         // (failure path only, the success path never pays for it).
@@ -166,6 +174,64 @@ internal static class RmQRVersionSelector
             (height is null
                 ? "Shorten the content, lower the ECC level, or use Standard QR (QRCodeGenerator) for longer content."
                 : "Shorten the content, lower the ECC level, allow a taller symbol, or use Standard QR (QRCodeGenerator) for longer content."));
+    }
+
+    // ---------------------------------------------------------------
+    // Auto-fit tables (built once at type init from IsBetter / GetMaxDataLength):
+    //   FitOrders[strategy][rank]                       = version (1..32), best first
+    //   FitCapacities[(mode*2+ecc)*3+strategy][rank]    = that version's max data length
+    //   FitHeightMasks[strategy][(height-7)/2]          = bit `rank` set when the version has that height
+    // 3 × 32 B + 18 × 64 B + 3 × 24 B ≈ 1.3 KB.
+    // ---------------------------------------------------------------
+    private static readonly byte[][] FitOrders = BuildFitOrders();
+    private static readonly ushort[][] FitCapacities = BuildFitCapacities();
+    private static readonly uint[][] FitHeightMasks = BuildFitHeightMasks();
+
+    private static byte[][] BuildFitOrders()
+    {
+        var orders = new byte[3][];
+        for (var s = 0; s < 3; s++)
+        {
+            // insertion sort under the strict IsBetter comparator: it is a total order
+            // (equal area and height means the same version), so the ranking is unique
+            var sorted = new List<byte>(RmQRConstants.VersionCount);
+            for (var v = 1; v <= RmQRConstants.VersionCount; v++)
+            {
+                var pos = 0;
+                while (pos < sorted.Count && !IsBetter((RmQRVersion)v, (RmQRVersion)sorted[pos], (RmQRFitStrategy)s)) pos++;
+                sorted.Insert(pos, (byte)v);
+            }
+            orders[s] = sorted.ToArray();
+        }
+        return orders;
+    }
+
+    private static ushort[][] BuildFitCapacities()
+    {
+        var tables = new ushort[3 * 2 * 3][];
+        var modes = new[] { EncodingMode.Numeric, EncodingMode.Alphanumeric, EncodingMode.Byte };
+        for (var m = 0; m < modes.Length; m++)
+            for (var e = 0; e < 2; e++)
+                for (var s = 0; s < 3; s++)
+                {
+                    var t = new ushort[RmQRConstants.VersionCount];
+                    for (var rank = 0; rank < RmQRConstants.VersionCount; rank++)
+                        t[rank] = (ushort)GetMaxDataLength((RmQRVersion)FitOrders[s][rank], (RmQREccLevel)e, modes[m]);
+                    tables[(m * 2 + e) * 3 + s] = t;
+                }
+        return tables;
+    }
+
+    private static uint[][] BuildFitHeightMasks()
+    {
+        var masks = new uint[3][];
+        for (var s = 0; s < 3; s++)
+        {
+            masks[s] = new uint[6];
+            for (var rank = 0; rank < RmQRConstants.VersionCount; rank++)
+                masks[s][(RmQRConstants.GetHeight((RmQRVersion)FitOrders[s][rank]) - 7) / 2] |= 1u << rank;
+        }
+        return masks;
     }
 
     /// <summary>Human unit per mode: Numeric counts digits, Alphanumeric characters, Byte encoded bytes.</summary>

--- a/tests/SkiaSharp.QrCode.Tests/RmQr/RmQRVersionSelectorUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/RmQr/RmQRVersionSelectorUnitTest.cs
@@ -211,4 +211,20 @@ public class RmQRVersionSelectorUnitTest
                     }
         await Assert.That(checks).IsGreaterThan(1000);
     }
+    /// <summary>
+    /// An unsupported mode (ECI / Kanji never come out of the analyzer, but the internal
+    /// contract is one exception on every path): the auto-fit path (table index) and
+    /// the requested-version path (count-indicator lookup) must throw the same type,
+    /// parameter name and message.
+    /// </summary>
+    [Test]
+    public async Task Select_UnsupportedMode_ThrowsTheSameOnAutoFitAndRequestedVersion()
+    {
+        var auto = Assert.Throws<ArgumentOutOfRangeException>(() => RmQRVersionSelector.Select(EncodingMode.ECI, 5, RmQREccLevel.M, null, RmQRFitStrategy.MinimizeArea, null));
+        var requested = Assert.Throws<ArgumentOutOfRangeException>(() => RmQRVersionSelector.Select(EncodingMode.ECI, 5, RmQREccLevel.M, RmQRVersion.R7x43, RmQRFitStrategy.MinimizeArea, null));
+        await Assert.That(auto.ParamName).IsEqualTo("mode");
+        await Assert.That(requested.ParamName).IsEqualTo("mode");
+        await Assert.That(auto.Message).IsEqualTo(requested.Message);
+        await Assert.That(auto.Message).Contains("not supported by rMQR");
+    }
 }

--- a/tests/SkiaSharp.QrCode.Tests/RmQr/RmQRVersionSelectorUnitTest.cs
+++ b/tests/SkiaSharp.QrCode.Tests/RmQr/RmQRVersionSelectorUnitTest.cs
@@ -166,4 +166,49 @@ public class RmQRVersionSelectorUnitTest
         await Assert.That(RmQRVersionSelector.IsBetter(candidate, incumbent, strategy)).IsEqualTo(expected);
         await Assert.That(RmQRVersionSelector.IsBetter(candidate, candidate, strategy)).IsFalse();
     }
+    /// <summary>
+    /// The table-driven auto fit (best-first version order per strategy, precomputed
+    /// capacities, height bitmask) must pick exactly what the definitional scan picks:
+    /// among all versions of the allowed height that <see cref="RmQRVersionSelector.Fits"/>,
+    /// the one no other candidate <see cref="RmQRVersionSelector.IsBetter"/> than — for
+    /// every mode × ECC × strategy × height filter × data length up to the largest
+    /// capacity plus a margin (where nothing fits, both must fail).
+    /// </summary>
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    public async Task Select_AutoFit_MatchesDefinitionalScan_EveryLengthStrategyHeight(int modeIndex)
+    {
+        var mode = new[] { EncodingMode.Numeric, EncodingMode.Alphanumeric, EncodingMode.Byte }[modeIndex];
+        var maxAll = Enum.GetValues<RmQRVersion>().Max(v => RmQRVersionSelector.GetMaxDataLength(v, RmQREccLevel.M, mode));
+        var heights = new RmQRHeight?[] { null, RmQRHeight.H7, RmQRHeight.H9, RmQRHeight.H11, RmQRHeight.H13, RmQRHeight.H15, RmQRHeight.H17 };
+        var checks = 0;
+        foreach (var ecc in new[] { RmQREccLevel.M, RmQREccLevel.H })
+            foreach (var strategy in Enum.GetValues<RmQRFitStrategy>())
+                foreach (var height in heights)
+                    for (var length = 0; length <= maxAll + 3; length++)
+                    {
+                        RmQRVersion expected = 0;
+                        foreach (var candidate in Enum.GetValues<RmQRVersion>())
+                        {
+                            if (height is { } h && RmQRConstants.GetHeight(candidate) != (int)h) continue;
+                            if (RmQRVersionSelector.Fits(candidate, ecc, mode, length) && (expected == 0 || RmQRVersionSelector.IsBetter(candidate, expected, strategy)))
+                                expected = candidate;
+                        }
+
+                        if (expected == 0)
+                        {
+                            await Assert.That(() => RmQRVersionSelector.Select(mode, length, ecc, null, strategy, height)).Throws<ArgumentException>();
+                        }
+                        else
+                        {
+                            var actual = RmQRVersionSelector.Select(mode, length, ecc, null, strategy, height);
+                            if (actual != expected)
+                                Assert.Fail($"{mode} len {length} {ecc} {strategy} height {height}: expected {expected}, got {actual}");
+                        }
+                        checks++;
+                    }
+        await Assert.That(checks).IsGreaterThan(1000);
+    }
 }


### PR DESCRIPTION
## Summary

rMQR automatic version fit (`RmQRVersionSelector.Select` without a requested version) no longer evaluates `Fits` + `IsBetter` for all 32 versions on every call. Three small static tables (~1.3 KB of table data, built once at type init from `IsBetter` / `GetMaxDataLength`) hold the versions in best-first order per fit strategy, each version's capacity per mode × ECC, and a per-strategy height bitmask; the fit is the first rank whose capacity holds the length and whose height is allowed. Adds `RmQRConstants.GetModeIndex` / `ModeCount` (dense 0/1/2 index for per-mode tables; `EncodingMode` values are 1/2/4) and uses the same index function on both the build and lookup side.

## Why

After the placer fast path, the fit scan was the largest remaining fixed cost of a small rMQR encode (~110 ns of 318 ns for 12 digits with auto fit). The result is unchanged by construction: the tables are derived from the same definitions, and a new exhaustive test pins the table scan against the definitional scan.

## Behavior / compatibility

- No API or behavior change; requested-version and failure-message paths are untouched. Unsupported modes still throw the same `ArgumentOutOfRangeException("mode", …)`.
- Zero per-call allocations (unchanged); the only new allocation is the one-time static tables.
- Test: `RmQRVersionSelectorUnitTest.Select_AutoFit_MatchesDefinitionalScan_EveryLengthStrategyHeight` — every mode × ECC × strategy × height filter × length 0..max+3 against the `Fits` + `IsBetter` definition, including the nothing-fits exception. Full suite: net10.0 5,496 / net8.0 5,484, 0 failed.

## Benchmarks

Kernel (auto-fit selection only, same run): 27-108 ns → 1.3-8.3 ns (numeric 12 digits, MinimizeArea: 108.5 → 1.3 ns; byte 150, last rank fits: 55.7 → 8.3 ns).

`RmQREncodeEndToEnd`, net10.0 Release, `--launchCount 3 --warmupCount 3 --iterationCount 15`, before = f6a3816:

| Benchmark | Before | After | Delta |
|---|---|---|---|
| RmQR_Numeric_AutoFit_Encode (Span) | 318.3 ns | 211.7 ns | -33 % |
| RmQR_Numeric_R7x43_Encode (Span) (fixed version, code-identical) | 148.8 ns | 169.7 ns | +14 % (noise) |
| RmQR_Byte_R17x139_Encode (Span) (fixed) | 927.8 ns | 1,044 ns | +13 % (noise) |
| StandardQr_Numeric_V1_Encode (Span) (untouched control) | 850.3 ns | 955.6 ns | +12 % (drift) |

The after run was noisier (StdDev 5-7 % vs < 1 %); every code-identical row and the control moved by the same +12-14 %, so the true auto-fit gain is ~-40 %. Allocations identical on every row.